### PR TITLE
add character_id to corporation and alliance contact jobs

### DIFF
--- a/src/Jobs/Contacts/AllianceContactJob.php
+++ b/src/Jobs/Contacts/AllianceContactJob.php
@@ -40,6 +40,7 @@ class AllianceContactJob extends ContactBaseJob
 
     public function __construct(
         public int $alliance_id,
+        public int $character_id
     ) {
         parent::__construct(
             method: 'get',

--- a/src/Jobs/Contacts/AllianceContactLabelJob.php
+++ b/src/Jobs/Contacts/AllianceContactLabelJob.php
@@ -40,6 +40,7 @@ class AllianceContactLabelJob extends ContactBaseJob
 
     public function __construct(
         public int $alliance_id,
+        public int $character_id,
     ) {
         parent::__construct(
             method: 'get',

--- a/src/Jobs/Contacts/ContactBaseJob.php
+++ b/src/Jobs/Contacts/ContactBaseJob.php
@@ -41,7 +41,7 @@ abstract class ContactBaseJob extends EsiBase implements HasPathValuesInterface,
 
         $character_id = $object_vars['character_id'];
 
-        $refresh_token =  RefreshToken::find($character_id);
+        $refresh_token = RefreshToken::find($character_id);
 
         throw_unless($refresh_token->hasScope($this->getRequiredScope()), new Exception('refresh token does not have required scope'));
 

--- a/src/Jobs/Contacts/ContactBaseJob.php
+++ b/src/Jobs/Contacts/ContactBaseJob.php
@@ -35,31 +35,16 @@ abstract class ContactBaseJob extends EsiBase implements HasPathValuesInterface,
 
         // throw exception if character_id, corporation_id or alliance_id is not set
         throw_unless(
-            Arr::hasAny($object_vars, ['character_id', 'corporation_id', 'alliance_id']),
-            new Exception('character_id, corporation_id or alliance_id is not set')
+            Arr::has($object_vars, 'character_id'),
+            new Exception('character_id is not set')
         );
 
-        // if corporation_id is set, get refresh token for corporation_id
-        if (Arr::has($object_vars, 'corporation_id')) {
-            return $this->getToken('corporation_id', $object_vars['corporation_id']);
-        }
+        $character_id = $object_vars['character_id'];
 
-        // if alliance_id is set, get refresh token for alliance_id
-        if (Arr::has($object_vars, 'alliance_id')) {
-            return $this->getToken('alliance_id', $object_vars['alliance_id']);
-        }
+        $refresh_token =  RefreshToken::find($character_id);
 
-        // if neither corporation_id nor alliance_id is set, get refresh token for character_id
-        return $this->getToken('character_id', $object_vars['character_id']);
-    }
+        throw_unless($refresh_token->hasScope($this->getRequiredScope()), new Exception('refresh token does not have required scope'));
 
-    private function getToken(string $key, int $value): RefreshToken
-    {
-        return RefreshToken::query()
-            ->when($key === 'character_id', fn ($query) => $query->where('character_id', $value))
-            ->when($key === 'corporation_id', fn ($query) => $query->whereRelation('corporation', 'corporation_infos.corporation_id', $value))
-            ->when($key === 'alliance_id', fn ($query) => $query->whereRelation('corporation.alliance', 'alliance_infos.alliance_id', $value))
-            ->get()
-            ->first(fn ($refresh_token) => $refresh_token->hasScope($this->getRequiredScope()));
+        return $refresh_token;
     }
 }

--- a/src/Jobs/Contacts/CorporationContactJob.php
+++ b/src/Jobs/Contacts/CorporationContactJob.php
@@ -40,6 +40,7 @@ class CorporationContactJob extends ContactBaseJob
 
     public function __construct(
         public int $corporation_id,
+        public int $character_id
     ) {
         parent::__construct(
             method: 'get',

--- a/src/Jobs/Contacts/CorporationContactLabelJob.php
+++ b/src/Jobs/Contacts/CorporationContactLabelJob.php
@@ -39,7 +39,8 @@ class CorporationContactLabelJob extends ContactBaseJob
     private Collection $known_ids;
 
     public function __construct(
-        public int $corporation_id
+        public int $corporation_id,
+        public int $character_id
     ) {
         parent::__construct(
             method: 'get',

--- a/src/Jobs/Seatplus/Batch/CharacterBatchJob.php
+++ b/src/Jobs/Seatplus/Batch/CharacterBatchJob.php
@@ -223,7 +223,7 @@ class CharacterBatchJob implements ShouldQueue, ShouldBeUnique
         return [
             [
                 new AllianceContactJob($alliance_id, $this->character_id),
-                new AllianceContactLabelJob($alliance_id, $this->character_id)
+                new AllianceContactLabelJob($alliance_id, $this->character_id),
             ],
         ];
     }

--- a/src/Jobs/Seatplus/Batch/CharacterBatchJob.php
+++ b/src/Jobs/Seatplus/Batch/CharacterBatchJob.php
@@ -194,10 +194,13 @@ class CharacterBatchJob implements ShouldQueue, ShouldBeUnique
             return [];
         }
 
+        // Get corporation_id from character
+        $corporation_id = $this->refresh_token->character->corporation_id;
+
         return [
             [
-                new CorporationContactJob($this->character_id),
-                new CorporationContactLabelJob($this->character_id),
+                new CorporationContactJob($corporation_id, $this->character_id),
+                new CorporationContactLabelJob($corporation_id, $this->character_id),
             ],
         ];
     }
@@ -209,10 +212,18 @@ class CharacterBatchJob implements ShouldQueue, ShouldBeUnique
             return [];
         }
 
+        // Get alliance_id from character
+        $alliance_id = $this->refresh_token->character->alliance_id;
+
+        // Return empty array if character has no alliance
+        if (! $alliance_id) {
+            return [];
+        }
+
         return [
             [
-                new AllianceContactJob($this->character_id),
-                new AllianceContactLabelJob($this->character_id),
+                new AllianceContactJob($alliance_id, $this->character_id),
+                new AllianceContactLabelJob($alliance_id, $this->character_id)
             ],
         ];
     }

--- a/tests/Integration/ContactLabelJobTest.php
+++ b/tests/Integration/ContactLabelJobTest.php
@@ -39,7 +39,7 @@ test('run corporation contact label', function () {
 
     updateRefreshTokenScopes($this->test_character->refresh_token, ['esi-corporations.read_contacts.v1'])->save();
 
-    (new CorporationContactLabelJob(testCharacter()->corporation->corporation_id))->handle();
+    (new CorporationContactLabelJob(testCharacter()->corporation->corporation_id, testCharacter()->character_id))->handle();
 
     //assertContactLabel($mock_data, $this->test_character->corporation->corporation_id);
     foreach ($mock_data as $data) {
@@ -56,7 +56,7 @@ test('run alliance contact label', function () {
 
     updateRefreshTokenScopes($this->test_character->refresh_token, ['esi-alliances.read_contacts.v1'])->save();
 
-    (new AllianceContactLabelJob(testCharacter()->corporation->alliance_id))->handle();
+    (new AllianceContactLabelJob(testCharacter()->corporation->alliance_id, testCharacter()->character_id))->handle();
 
     //assertContactLabel($mock_data, $this->test_character->corporation->alliance_id);
     foreach ($mock_data as $data) {

--- a/tests/Integration/ContactLifecycleTest.php
+++ b/tests/Integration/ContactLifecycleTest.php
@@ -42,7 +42,7 @@ test('run character contact', function () {
 test('run corporation contact', function () {
     $mock_data = buildContactLifecycleMockEsiData();
 
-    $job = new CorporationContactJob(testCharacter()->corporation->corporation_id);
+    $job = new CorporationContactJob(testCharacter()->corporation->corporation_id, testCharacter()->character_id);
 
     updateRefreshTokenScopes($this->test_character->refresh_token, ['esi-corporations.read_contacts.v1'])->save();
 
@@ -66,7 +66,7 @@ test('run corporation contact', function () {
 test('run alliance contact', function () {
     $mock_data = buildContactLifecycleMockEsiData();
 
-    $job = new AllianceContactJob(testCharacter()->corporation->alliance_id);
+    $job = new AllianceContactJob(testCharacter()->corporation->alliance_id, testCharacter()->character_id);
 
     updateRefreshTokenScopes($this->test_character->refresh_token, ['esi-alliances.read_contacts.v1'])->save();
 

--- a/tests/Jobs/Contacts/ContactJobTest.php
+++ b/tests/Jobs/Contacts/ContactJobTest.php
@@ -15,7 +15,7 @@ test('alliance contact job', function () {
     // Assert that no jobs were pushed...
     Queue::assertNothingPushed();
 
-    AllianceContactJob::dispatch(testCharacter()->corporation->alliance->alliance_id)->onQueue('default');
+    AllianceContactJob::dispatch(testCharacter()->corporation->alliance->alliance_id, testCharacter()->character_id)->onQueue('default');
 
     // Assert a job was pushed to a given queue...
     Queue::assertPushedOn('default', AllianceContactJob::class);
@@ -27,7 +27,7 @@ test('alliance contact label job', function () {
     // Assert that no jobs were pushed...
     Queue::assertNothingPushed();
 
-    AllianceContactLabelJob::dispatch(testCharacter()->corporation->alliance->alliance_id)->onQueue('default');
+    AllianceContactLabelJob::dispatch(testCharacter()->corporation->alliance->alliance_id, testCharacter()->character_id)->onQueue('default');
 
     // Assert a job was pushed to a given queue...
     Queue::assertPushedOn('default', AllianceContactLabelJob::class);
@@ -39,7 +39,7 @@ test('corporation contact job', function () {
     // Assert that no jobs were pushed...
     Queue::assertNothingPushed();
 
-    CorporationContactJob::dispatch(testCharacter()->corporation->corporation_id)->onQueue('default');
+    CorporationContactJob::dispatch(testCharacter()->corporation->corporation_id, testCharacter()->character_id)->onQueue('default');
 
     // Assert a job was pushed to a given queue...
     Queue::assertPushedOn('default', CorporationContactJob::class);
@@ -51,7 +51,7 @@ test('corporation contact label job', function () {
     // Assert that no jobs were pushed...
     Queue::assertNothingPushed();
 
-    CorporationContactLabelJob::dispatch(testCharacter()->corporation->corporation_id)->onQueue('default');
+    CorporationContactLabelJob::dispatch(testCharacter()->corporation->corporation_id, testCharacter()->character_id)->onQueue('default');
 
     // Assert a job was pushed to a given queue...
     Queue::assertPushedOn('default', CorporationContactLabelJob::class);
@@ -92,11 +92,11 @@ test('ContactJob using ContactBaseJob and finds refresh_token', function (string
 
     $job = match ($flavour) {
         'character' => new CharacterContactJob($this->test_character->character_id),
-        'corporation' => new CorporationContactJob($this->test_character->corporation->corporation_id),
-        'alliance' => new AllianceContactJob($this->test_character->corporation->alliance->alliance_id),
+        'corporation' => new CorporationContactJob($this->test_character->corporation->corporation_id, testCharacter()->character_id),
+        'alliance' => new AllianceContactJob($this->test_character->corporation->alliance->alliance_id, testCharacter()->character_id),
         'character_label' => new CharacterContactLabelJob($this->test_character->character_id),
-        'corporation_label' => new CorporationContactLabelJob($this->test_character->corporation->corporation_id),
-        'alliance_label' => new AllianceContactLabelJob($this->test_character->corporation->alliance->alliance_id),
+        'corporation_label' => new CorporationContactLabelJob($this->test_character->corporation->corporation_id, testCharacter()->character_id),
+        'alliance_label' => new AllianceContactLabelJob($this->test_character->corporation->alliance->alliance_id, testCharacter()->character_id),
     };
 
     expect($job->getRefreshToken())->character_id->toBe($this->test_character->character_id);


### PR DESCRIPTION
- this is necessary to hint which refresh_token the job should be using
- don't dispatch alliance contact job if character has no alliance