### PR TITLE
Refactor/maintenance character affiliation

### DIFF
--- a/src/EveapiServiceProvider.php
+++ b/src/EveapiServiceProvider.php
@@ -54,6 +54,7 @@ use Seatplus\Eveapi\Models\Universe\Type;
 use Seatplus\Eveapi\Observers\CharacterInfoObserver;
 use Seatplus\Eveapi\Observers\GroupObserver;
 use Seatplus\Eveapi\Observers\TypeObserver;
+use Seatplus\Eveapi\Services\Character\RefreshCharacterAffiliationsService;
 use Seatplus\Eveapi\Services\Esi\EsiClientSetup;
 
 class EveapiServiceProvider extends ServiceProvider
@@ -236,7 +237,8 @@ class EveapiServiceProvider extends ServiceProvider
             });
 
             // Run Character Affiliation Job every five minutes to updated outdated affiliations.
-            $schedule->job(new CharacterAffiliationJob)->everyFiveMinutes();
+            //$schedule->job(new CharacterAffiliationJob)->everyFiveMinutes();
+            $schedule->call(new RefreshCharacterAffiliationsService)->everyFiveMinutes();
 
             // Cleanup Batches Table
             $schedule->command('queue:prune-batches')->daily();

--- a/src/Jobs/Character/CharacterAffiliationJob.php
+++ b/src/Jobs/Character/CharacterAffiliationJob.php
@@ -43,6 +43,7 @@ class CharacterAffiliationJob extends EsiBase implements HasRequestBodyInterface
     use HasRequestBody;
 
     private array $manual_ids = [];
+
     private Collection $character_affiliations;
 
     /**
@@ -94,7 +95,7 @@ class CharacterAffiliationJob extends EsiBase implements HasRequestBodyInterface
     public function processResponse(EsiResponse $response, Carbon $timestamp): void
     {
         collect($response)
-            ->each(fn(object $result) => $this->character_affiliations->push(
+            ->each(fn (object $result) => $this->character_affiliations->push(
                 [
                     'character_id' => $result->character_id,
                     'corporation_id' => $result->corporation_id,
@@ -164,6 +165,7 @@ class CharacterAffiliationJob extends EsiBase implements HasRequestBodyInterface
         // if the request fails and the character ids are less than 2, we can assume that the character id is invalid
         if (count($character_ids) === 1) {
             $this->handleSingleIdException($character_ids[0]);
+
             return;
         }
 

--- a/src/Jobs/Character/CharacterAffiliationJob.php
+++ b/src/Jobs/Character/CharacterAffiliationJob.php
@@ -26,16 +26,16 @@
 
 namespace Seatplus\Eveapi\Jobs\Character;
 
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\Redis;
+use Seatplus\EsiClient\DataTransferObjects\EsiResponse;
 use Seatplus\EsiClient\Exceptions\RequestFailedException;
 use Seatplus\Eveapi\Esi\HasRequestBodyInterface;
 use Seatplus\Eveapi\Jobs\Alliances\AllianceInfoJob;
 use Seatplus\Eveapi\Jobs\Corporation\CorporationInfoJob;
 use Seatplus\Eveapi\Jobs\EsiBase;
 use Seatplus\Eveapi\Models\Character\CharacterAffiliation;
-use Seatplus\Eveapi\Services\Jobs\CharacterAffiliationService;
 use Seatplus\Eveapi\Traits\HasRequestBody;
 
 class CharacterAffiliationJob extends EsiBase implements HasRequestBodyInterface
@@ -43,8 +43,12 @@ class CharacterAffiliationJob extends EsiBase implements HasRequestBodyInterface
     use HasRequestBody;
 
     private array $manual_ids = [];
+    private Collection $character_affiliations;
 
-    public function __construct(int|array|null $character_ids = null)
+    /**
+     * @throws \Throwable
+     */
+    public function __construct(int|array $character_ids)
     {
         parent::__construct(
             method: 'post',
@@ -53,6 +57,11 @@ class CharacterAffiliationJob extends EsiBase implements HasRequestBodyInterface
         );
 
         $this->setManualIds($character_ids);
+
+        // throw error if manual_ids is not larger than 1000
+        throw_unless(count($this->manual_ids) <= 1000, new \Exception('Character ids must not exceed 1000'));
+
+        $this->character_affiliations = collect();
     }
 
     public function tags(): array
@@ -64,106 +73,17 @@ class CharacterAffiliationJob extends EsiBase implements HasRequestBodyInterface
     }
 
     /**
-     * Get the middleware the job should pass through.
-     */
-    public function middleware(): array
-    {
-        return [
-            ...parent::middleware(),
-        ];
-    }
-
-    /**
      * Execute the job.
      *
      * @throws \Exception
      */
     public function executeJob(): void
     {
-        if ($this->manual_ids) {
-            $this->updateOrCreateCharacterAffiliations($this->manual_ids);
-        }
 
-        if (! $this->manual_ids) {
-            Redis::throttle('character_affiliations')
-                // allow one job to process every 5 minutes
-                ->block(0)->allow(1)->every(5 * 60)
-                ->then(function () {
-                    collect()
-                        ->merge($this->getIdsToUpdateFromCache())
-                        ->merge($this->getIdsToUpdateFromDatabase())
-                        ->chunk(1000)
-                        ->each(fn (Collection $chunk) => $this->updateOrCreateCharacterAffiliations($chunk->toArray()));
-                }, fn () => $this->delete());
-        }
-    }
+        $this->updateOrCreateCharacterAffiliations($this->getManualIds());
 
-    private function getIdsToUpdateFromCache(): Collection
-    {
-        return CharacterAffiliationService::make()->retrieve()->unique();
-    }
-
-    private function getIdsToUpdateFromDatabase(): Collection
-    {
-        return CharacterAffiliation::query()
-            // only those who were not pulled within the last hour
-            ->where('last_pulled', '<=', now()->subHour()->toDateTimeString())
-            // and don't try doomheimed characters
-            ->where('corporation_id', '<>', 1_000_001)
-            ->pluck('character_id');
-    }
-
-    private function updateOrCreateCharacterAffiliations(array $character_ids): void
-    {
-        $this->setRequestBody($character_ids);
-
-        $timestamp = now();
-
-        $character_affiliations = collect();
-
-        // try to get the character affiliations from the esi endpoint
-        try {
-            $response = $this->retrieve();
-
-            collect($response)
-                ->each(fn (object $result) => $character_affiliations->push(
-                    [
-                        'character_id' => $result->character_id,
-                        'corporation_id' => $result->corporation_id,
-                        'alliance_id' => data_get($result, 'alliance_id'),
-                        'faction_id' => data_get($result, 'faction_id'),
-                        'last_pulled' => $timestamp,
-                    ]
-                ));
-        } catch (RequestFailedException $exception) {
-            // if the request fails, we perform a binary search to find the character ids that are not valid
-            // if the request fails and the character ids are less than 2, we can assume that the character id is invalid
-            if (count($character_ids) === 1) {
-                // dispatch a new character_info job to update the character info if it is member of doomheim
-                CharacterInfoJob::dispatch($character_ids[0])->onQueue('low');
-
-                // cache the invalid character id for 1 day
-                // first get the cached invalid character ids
-                $invalid_character_ids = Cache::get('invalid_character_ids', []);
-                // add the invalid character id to the array
-                $invalid_character_ids[] = $character_ids[0];
-                // cache the array
-                Cache::put('invalid_character_ids', $invalid_character_ids, 60 * 24);
-
-                return;
-            }
-
-            // if the request fails and the character ids are more than 2, we perform a binary search to find the invalid character ids
-            $half = (int) ceil(count($character_ids) / 2);
-            $first_half = array_slice($character_ids, 0, $half);
-            $second_half = array_slice($character_ids, $half);
-
-            $this->updateOrCreateCharacterAffiliations($first_half);
-            $this->updateOrCreateCharacterAffiliations($second_half);
-        }
-
-        CharacterAffiliation::upsert(
-            $character_affiliations->toArray(),
+        CharacterAffiliation::query()->upsert(
+            $this->character_affiliations->toArray(),
             ['character_id'],
             ['corporation_id', 'alliance_id', 'faction_id', 'last_pulled']
         );
@@ -171,17 +91,42 @@ class CharacterAffiliationJob extends EsiBase implements HasRequestBodyInterface
         $this->followUp();
     }
 
+    public function processResponse(EsiResponse $response, Carbon $timestamp): void
+    {
+        collect($response)
+            ->each(fn(object $result) => $this->character_affiliations->push(
+                [
+                    'character_id' => $result->character_id,
+                    'corporation_id' => $result->corporation_id,
+                    'alliance_id' => data_get($result, 'alliance_id'),
+                    'faction_id' => data_get($result, 'faction_id'),
+                    'last_pulled' => $timestamp,
+                ]
+            ));
+    }
+
+    private function updateOrCreateCharacterAffiliations(array $character_ids): void
+    {
+        $this->setRequestBody($character_ids);
+        $timestamp = now();
+
+        // try to get the character affiliations from the esi endpoint
+        try {
+            $response = $this->retrieve();
+
+            $this->processResponse($response, $timestamp);
+        } catch (RequestFailedException $exception) {
+            $this->handleFailedRequest($character_ids);
+        }
+    }
+
     public function getManualIds(): array
     {
         return $this->manual_ids;
     }
 
-    public function setManualIds(int|array|null $manual_ids): void
+    public function setManualIds(int|array $manual_ids): void
     {
-        if (is_null($manual_ids)) {
-            return;
-        }
-
         $manual_ids = is_array($manual_ids) ? $manual_ids : [$manual_ids];
 
         $this->manual_ids = $manual_ids;
@@ -212,5 +157,44 @@ class CharacterAffiliationJob extends EsiBase implements HasRequestBodyInterface
             ->pluck('alliance_id')
             ->unique()
             ->each(fn (int $alliance_id) => AllianceInfoJob::dispatch($alliance_id)->onQueue('high'));
+    }
+
+    private function handleFailedRequest(array $character_ids)
+    {
+        // if the request fails and the character ids are less than 2, we can assume that the character id is invalid
+        if (count($character_ids) === 1) {
+            $this->handleSingleIdException($character_ids[0]);
+            return;
+        }
+
+        // if the request fails, we perform a binary search to find the character ids that are not valid
+        $this->handleMultipleIdsException($character_ids);
+
+    }
+
+    private function handleSingleIdException(int $character_id): void
+    {
+
+        // dispatch a new character_info job to update the character info if it is member of doomheim
+        CharacterInfoJob::dispatch($character_id)->onQueue('low');
+
+        // cache the invalid character id for 1 day
+        // first get the cached invalid character ids
+        $invalid_character_ids = Cache::get('invalid_character_ids', []);
+        // add the invalid character id to the array
+        $invalid_character_ids[] = $character_id;
+        // cache the array
+        Cache::put('invalid_character_ids', $invalid_character_ids, 60 * 24);
+    }
+
+    private function handleMultipleIdsException(array $character_ids): void
+    {
+        // if the request fails and the character ids are more than 2, we perform a binary search to find the invalid character ids
+        $half = (int) ceil(count($character_ids) / 2);
+        $first_half = array_slice($character_ids, 0, $half);
+        $second_half = array_slice($character_ids, $half);
+
+        $this->updateOrCreateCharacterAffiliations($first_half);
+        $this->updateOrCreateCharacterAffiliations($second_half);
     }
 }

--- a/src/Jobs/Character/CharacterAffiliationJob.php
+++ b/src/Jobs/Character/CharacterAffiliationJob.php
@@ -160,7 +160,7 @@ class CharacterAffiliationJob extends EsiBase implements HasRequestBodyInterface
             ->each(fn (int $alliance_id) => AllianceInfoJob::dispatch($alliance_id)->onQueue('high'));
     }
 
-    private function handleFailedRequest(array $character_ids)
+    private function handleFailedRequest(array $character_ids): void
     {
         // if the request fails and the character ids are less than 2, we can assume that the character id is invalid
         if (count($character_ids) === 1) {

--- a/src/Jobs/Seatplus/UpdateCorporation.php
+++ b/src/Jobs/Seatplus/UpdateCorporation.php
@@ -70,9 +70,10 @@ class UpdateCorporation implements ShouldQueue
         if ($this->corporation_id) {
             $this->execute($this->corporation_id, 'high');
         } else {
-            RefreshToken::with('corporation', 'character.roles')
+            RefreshToken::with(['corporation', 'character.roles'])
                 ->cursor()
-                ->map(fn (RefreshToken $token) => $token->corporation->corporation_id)
+                ->map(fn (RefreshToken $token) => $token->corporation?->corporation_id)
+                ->filter()
                 ->unique()
                 ->each(fn (int $corporation_id) => $this->execute($corporation_id));
         }

--- a/src/Services/Character/RefreshCharacterAffiliationsService.php
+++ b/src/Services/Character/RefreshCharacterAffiliationsService.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Seatplus\Eveapi\Services\Character;
+
+use Seatplus\Eveapi\Jobs\Character\CharacterAffiliationJob;
+use Seatplus\Eveapi\Models\Character\CharacterAffiliation;
+use Seatplus\Eveapi\Models\Character\CharacterInfo;
+use Seatplus\Eveapi\Services\Jobs\CacheCharacterAffiliationIdsService;
+
+class RefreshCharacterAffiliationsService
+{
+
+    public function __invoke(): void
+    {
+
+        $character_ids = [
+            ...$this->getIdsToUpdateFromDatabase(),
+            ...$this->getIdsToUpdateFromCache(),
+            ...$this->getMissingIdsFromCharacterInfo(),
+        ];
+
+        $this->processAffiliations($character_ids);
+    }
+
+    private function getMissingIdsFromCharacterInfo(): array
+    {
+        return CharacterInfo::query()
+            ->whereDoesntHave('character_affiliation')
+            ->pluck('character_id')
+            ->toArray();
+    }
+
+    private function processAffiliations(array $ids): void
+    {
+        $unique_ids = array_unique($ids);
+        $chunks = array_chunk($unique_ids, 1000);
+
+        foreach ($chunks as $chunk) {
+            CharacterAffiliationJob::dispatch($chunk)->onQueue('high');
+        }
+    }
+
+    private function getIdsToUpdateFromDatabase(): array
+    {
+        return CharacterAffiliation::query()
+            // only those who were not pulled within the last hour
+            ->where('last_pulled', '<=', now()->subHour()->toDateTimeString())
+            // and don't try doomheimed characters
+            ->where('corporation_id', '<>', 1_000_001)
+            ->pluck('character_id')
+            ->toArray();
+    }
+
+    private function getIdsToUpdateFromCache(): array
+    {
+        return CacheCharacterAffiliationIdsService::make()
+            ->retrieve()
+            ->unique()
+            ->toArray();
+    }
+}

--- a/src/Services/Character/RefreshCharacterAffiliationsService.php
+++ b/src/Services/Character/RefreshCharacterAffiliationsService.php
@@ -9,7 +9,6 @@ use Seatplus\Eveapi\Services\Jobs\CacheCharacterAffiliationIdsService;
 
 class RefreshCharacterAffiliationsService
 {
-
     public function __invoke(): void
     {
 

--- a/src/Services/Contacts/ProcessContactResponse.php
+++ b/src/Services/Contacts/ProcessContactResponse.php
@@ -29,7 +29,7 @@ namespace Seatplus\Eveapi\Services\Contacts;
 use Illuminate\Support\Collection;
 use Seatplus\EsiClient\DataTransferObjects\EsiResponse;
 use Seatplus\Eveapi\Models\Contacts\Contact;
-use Seatplus\Eveapi\Services\Jobs\CharacterAffiliationService;
+use Seatplus\Eveapi\Services\Jobs\CacheCharacterAffiliationIdsService;
 
 class ProcessContactResponse
 {
@@ -59,7 +59,7 @@ class ProcessContactResponse
                 $contact_model->labels()->createMany($labels_to_save->map(fn (int $label_id) => ['label_id' => $label_id]));
             }
         })->pipe(function (Collection $response) {
-            CharacterAffiliationService::make()
+            CacheCharacterAffiliationIdsService::make()
                 ->queue($response->filter(fn (object $contact) => $contact->contact_type === 'character')->pluck('contact_id')->toArray());
 
             return $response;

--- a/src/Services/Jobs/CacheCharacterAffiliationIdsService.php
+++ b/src/Services/Jobs/CacheCharacterAffiliationIdsService.php
@@ -5,7 +5,7 @@ namespace Seatplus\Eveapi\Services\Jobs;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 
-class CharacterAffiliationService
+class CacheCharacterAffiliationIdsService
 {
     public static function make(): self
     {

--- a/tests/Integration/CharacterAffiliationLifeCycleTest.php
+++ b/tests/Integration/CharacterAffiliationLifeCycleTest.php
@@ -2,7 +2,6 @@
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Queue;
-use Illuminate\Support\Facades\Redis;
 use Seatplus\EsiClient\DataTransferObjects\EsiResponse;
 use Seatplus\EsiClient\Exceptions\RequestFailedException;
 use Seatplus\Eveapi\Jobs\Alliances\AllianceInfoJob;
@@ -67,135 +66,12 @@ it('handles follow-up job', function (string $job_class, array $configuration = 
     ],
 ]);
 
-it('does not update affiliation younger then an hours', function () {
-    // expect the test_character entry to exist
-    expect(CharacterAffiliation::all())->toHaveCount(1);
-
-    // delete the entry
-    CharacterAffiliation::query()->delete();
-
-    $old_data = CharacterAffiliation::factory()->create([
-        'last_pulled' => now()->subMinutes(42),
-    ]);
-
-    expect(CharacterAffiliation::all())->toHaveCount(1);
-
-    $this->assertDatabaseHas('character_affiliations', [
-        'last_pulled' => $old_data->last_pulled,
-    ]);
-
-    noRetrieveEsiDataAction();
-
-    (new CharacterAffiliationJob())->handle();
-
-    $this->assertDatabaseHas('character_affiliations', [
-        'last_pulled' => $old_data->last_pulled,
-        'character_id' => $old_data->character_id,
-    ]);
-});
-
-it('updates affiliation older then an hours', function () {
-    // expect the test_character entry to exist
-    expect(CharacterAffiliation::all())->toHaveCount(1);
-
-    // delete the entry
-    CharacterAffiliation::query()->delete();
-
-    expect(CharacterAffiliation::all())->toHaveCount(0);
-
-    $old_data = CharacterAffiliation::factory()->create([
-        'last_pulled' => now()->subMinutes(61),
-    ]);
-
-    mockRetrieveEsiDataAction([
-        $old_data->toArray(),
-    ]);
-
-    $this->assertDatabaseHas('character_affiliations', [
-        'last_pulled' => $old_data->last_pulled,
-    ]);
-
-    Redis::flushall();
-    //$return_value = (new CharacterAffiliationAction)->execute();
-    (new CharacterAffiliationJob)->handle();
-
-    //$this->assertNull($return_value);
-
-    expect(CharacterAffiliation::first())
-        ->last_pulled->not()->toBe($old_data->last_pulled);
-
-    $this->assertDatabaseMissing('character_affiliations', [
-        'last_pulled' => $old_data->last_pulled,
-    ]);
-});
-
-it('updates affiliation by id', function () {
-    // expect the test_character entry to exist
-    expect(CharacterAffiliation::all())->toHaveCount(1);
-
-    // delete the entry
-    CharacterAffiliation::query()->delete();
-
-    expect(CharacterAffiliation::all())->toHaveCount(0);
-
-    $old_data = CharacterAffiliation::factory()->create();
-
-    mockRetrieveEsiDataAction([$old_data->toArray()]);
-
-    $this->assertDatabaseHas('character_affiliations', [
-        'last_pulled' => $old_data->last_pulled,
-    ]);
-
-    Redis::flushall();
-
-    (new CharacterAffiliationJob($old_data->character_id))->handle();
-
-    expect(CharacterAffiliation::first())
-        ->last_pulled->not()->toBe($old_data->last_pulled);
-
-    $this->assertDatabaseMissing('character_affiliations', [
-        'last_pulled' => $old_data->last_pulled,
-    ]);
-});
-
-it('updates cached ids', function () {
-    // expect the test_character entry to exist
-    expect(CharacterAffiliation::all())->toHaveCount(1);
-
-    // delete the entry
-    CharacterAffiliation::query()->delete();
-
-    expect(CharacterAffiliation::all())->toHaveCount(0);
-
-    $character_affiliation = CharacterAffiliation::factory()->make();
-
-    mockRetrieveEsiDataAction([$character_affiliation->toArray()]);
-
-    $this->assertDatabaseMissing('character_affiliations', [
-        'character_id' => $character_affiliation->character_id,
-    ]);
-
-    Redis::flushall();
-
-    \Seatplus\Eveapi\Services\Jobs\CharacterAffiliationService::make()
-        ->queue($character_affiliation->character_id);
-
-    (new CharacterAffiliationJob)->handle();
-
-    expect(CharacterAffiliation::all())->toHaveCount(1);
-
-    expect(CharacterAffiliation::first())->character_id
-        ->toBe($character_affiliation->character_id);
-});
 
 it('applies binary search and chaches it if one id is invalid', function () {
     Queue::fake();
 
     CharacterAffiliation::query()->delete();
     $mock_data = CharacterAffiliation::factory()->make();
-
-    // expect no invalid ids in cache
-    expect(cache('invalid_character_ids'))->toBeNull();
 
     // prepare the ids with a length of 2, the first id must be the invalid one
     $ids = [123456789, $mock_data->character_id];

--- a/tests/Integration/CharacterAffiliationLifeCycleTest.php
+++ b/tests/Integration/CharacterAffiliationLifeCycleTest.php
@@ -66,7 +66,6 @@ it('handles follow-up job', function (string $job_class, array $configuration = 
     ],
 ]);
 
-
 it('applies binary search and chaches it if one id is invalid', function () {
     Queue::fake();
 

--- a/tests/Integration/ContactLifecycleTest.php
+++ b/tests/Integration/ContactLifecycleTest.php
@@ -23,7 +23,7 @@ test('run character contact', function () {
 
     $job->handle();
 
-    $cached_ids = \Seatplus\Eveapi\Services\Jobs\CharacterAffiliationService::make()->retrieve();
+    $cached_ids = \Seatplus\Eveapi\Services\Jobs\CacheCharacterAffiliationIdsService::make()->retrieve();
 
     foreach ($mock_data as $data) {
         //Assert that character asset created
@@ -47,7 +47,7 @@ test('run corporation contact', function () {
 
     $job->handle();
 
-    $cached_ids = \Seatplus\Eveapi\Services\Jobs\CharacterAffiliationService::make()->retrieve();
+    $cached_ids = \Seatplus\Eveapi\Services\Jobs\CacheCharacterAffiliationIdsService::make()->retrieve();
 
     foreach ($mock_data as $data) {
         //Assert that character asset created

--- a/tests/Unit/Services/Character/RefreshCharacterAffiliationsServiceTest.php
+++ b/tests/Unit/Services/Character/RefreshCharacterAffiliationsServiceTest.php
@@ -1,0 +1,108 @@
+<?php
+
+use Illuminate\Support\Facades\Queue;
+use Seatplus\Eveapi\Jobs\Character\CharacterAffiliationJob;
+use Seatplus\Eveapi\Models\Character\CharacterAffiliation;
+use Seatplus\Eveapi\Services\Character\RefreshCharacterAffiliationsService;
+
+beforeEach(function() {
+    Queue::fake();
+
+    // check that only one CharacterAffiliation exists and that it is the test character
+    expect(CharacterAffiliation::count())->toBe(1)
+        ->and(CharacterAffiliation::first()->character_id)->toBe(testCharacter()->character_id);
+});
+
+describe('dispatches CharacterAffiliationJob for ', function () {
+
+    test('older than an hour', function () {
+
+        // arrange
+
+        // update the character affiliation to not be last pulled within the last hour
+        CharacterAffiliation::query()->update([
+            'last_pulled' => now()->subHours(2),
+        ]);
+
+        // act
+        $service = new RefreshCharacterAffiliationsService();
+        $service();
+
+        // assert
+        Queue::assertPushed(CharacterAffiliationJob::class);
+
+        // assert that the job was dispatched with the correct id
+        Queue::assertPushed(CharacterAffiliationJob::class, function (CharacterAffiliationJob $job) {
+            return $job->getManualIds() === [testCharacter()->character_id];
+        });
+
+    });
+
+    test('cached ids', function () {
+
+        // arrange
+
+        // clear the redis cache
+        \Illuminate\Support\Facades\Redis::flushall();
+
+        // cache the character id
+        \Seatplus\Eveapi\Services\Jobs\CacheCharacterAffiliationIdsService::make()
+            ->queue(testCharacter()->character_id);
+
+        // act
+        $service = new RefreshCharacterAffiliationsService();
+        $service();
+
+        // assert
+        Queue::assertPushed(CharacterAffiliationJob::class);
+
+        // assert that the job was dispatched with the correct id
+        Queue::assertPushed(CharacterAffiliationJob::class, function (CharacterAffiliationJob $job) {
+            return $job->getManualIds() === [testCharacter()->character_id];
+        });
+
+    });
+
+    test('missing ids from character info', function () {
+
+        // arrange
+
+        // delete the character affiliation
+        CharacterAffiliation::query()->delete();
+
+        // act
+        $service = new RefreshCharacterAffiliationsService();
+        $service();
+
+        // assert
+        Queue::assertPushed(CharacterAffiliationJob::class);
+
+        // assert that the job was dispatched with the correct id
+        Queue::assertPushed(CharacterAffiliationJob::class, function (CharacterAffiliationJob $job) {
+            return $job->getManualIds() === [testCharacter()->character_id];
+        });
+
+    });
+
+});
+
+describe('does not dispatches CharacterAffiliationJob ', function () {
+
+    test('for younger than an hour', function () {
+
+        // arrange
+
+        // update the character affiliation to be pulled within the last hour
+        CharacterAffiliation::query()->update([
+            'last_pulled' => now()->subMinutes(30),
+        ]);
+
+        // act
+        $service = new RefreshCharacterAffiliationsService();
+        $service();
+
+        // assert
+        Queue::assertNotPushed(CharacterAffiliationJob::class);
+    });
+
+});

--- a/tests/Unit/Services/Character/RefreshCharacterAffiliationsServiceTest.php
+++ b/tests/Unit/Services/Character/RefreshCharacterAffiliationsServiceTest.php
@@ -5,7 +5,7 @@ use Seatplus\Eveapi\Jobs\Character\CharacterAffiliationJob;
 use Seatplus\Eveapi\Models\Character\CharacterAffiliation;
 use Seatplus\Eveapi\Services\Character\RefreshCharacterAffiliationsService;
 
-beforeEach(function() {
+beforeEach(function () {
     Queue::fake();
 
     // check that only one CharacterAffiliation exists and that it is the test character


### PR DESCRIPTION
This addresses the second part of https://github.com/seatplus/eveapi/issues/650 

First of all, a new `RefreshCharacterAffiliationsService` has been created that replaces some logic that was previously within the `CharacterAffiliationJob`.

This sevices checks every 5 minutes if:
- there are any characters in seatplus without a character_affiliation
- if some ids are cached to be queued
- if some affiliations are older then an hours

if this is the case the ids are being dispatched.

`CharacterAffiliationJob` complexity has reduced. Its cleaner now and tests has been simplified by doing this. Resulting in better testability. Also the job now concentrates again in only one thing - getting the character_affiliations from ESI. 
Also refactoring lead to simplification and more explicit design, making it easier to maintain