### PR TITLE
Fix/missing character info maintenance

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
         coverage: xdebug #optional
     - uses: getong/mariadb-action@v1.1
       with:
-        host port: 3308 # Optional, default value is 3306. The port of host
+        host port: 3306 # Optional, default value is 3306. The port of host
         #container port: 3307 # Optional, default value is 3306. The port of container
         #character set server: 'utf8' # Optional, default value is 'utf8mb4'. The '--character-set-server' option for mysqld
         #collation server: 'utf8_general_ci' # Optional, default value is 'utf8mb4_general_ci'. The '--collation-server' option for mysqld

--- a/database/factories/AssetFactory.php
+++ b/database/factories/AssetFactory.php
@@ -38,8 +38,8 @@ class AssetFactory extends Factory
     public function definition()
     {
         return [
-            'assetable_id' => $this->faker->numberBetween(), //factory(CharacterInfo::class),
-            'assetable_type' => CharacterInfo::class, //$this->faker->randomElement([CharacterInfo::class, CorporationInfo::class]),
+            'assetable_id' => $this->faker->numberBetween(), // factory(CharacterInfo::class),
+            'assetable_type' => CharacterInfo::class, // $this->faker->randomElement([CharacterInfo::class, CorporationInfo::class]),
             'item_id' => $this->faker->unique()->randomNumber(),
             'is_blueprint_copy' => false,
             'is_singleton' => $this->faker->boolean,

--- a/database/factories/CharacterInfoFactory.php
+++ b/database/factories/CharacterInfoFactory.php
@@ -57,7 +57,7 @@ class CharacterInfoFactory extends Factory
         return [
             'character_id' => $this->faker->unique()->numberBetween(9000000, 98000000),
             'name' => $this->faker->name,
-            //'corporation_id'  => $this->faker->numberBetween(98000000, 99000000),
+            // 'corporation_id'  => $this->faker->numberBetween(98000000, 99000000),
             'birthday' => $this->faker->iso8601('now'),
             'gender' => $this->faker->randomElement(['male', 'female']),
             'race_id' => $this->faker->randomDigitNotNull,

--- a/database/factories/ContractFactory.php
+++ b/database/factories/ContractFactory.php
@@ -50,7 +50,7 @@ class ContractFactory extends Factory
             'status' => $this->faker->randomElement(['outstanding', 'in_progress', 'finished_issuer', 'finished_contractor', 'finished', 'cancelled', 'rejected', 'failed', 'deleted', 'reversed']),
             'type' => $this->faker->randomElement(['unknown', 'item_exchange', 'auction', 'courier', 'loan']),
 
-            //optionals
+            // optionals
             'buyout' => $this->faker->randomFloat(),
             'collateral' => $this->faker->randomFloat(),
             'date_accepted' => carbon()->addHour(),

--- a/database/migrations/2019_09_18_185641_create_corporation_infosTable.php
+++ b/database/migrations/2019_09_18_185641_create_corporation_infosTable.php
@@ -38,13 +38,13 @@ return new class extends Migration
     public function up()
     {
         Schema::create('corporation_infos', function (Blueprint $table) {
-            $table->bigIncrements('corporation_id'); //req
-            $table->string('ticker'); //req
-            $table->string('name'); //req
-            $table->bigInteger('member_count'); //req
-            $table->bigInteger('ceo_id'); //req
-            $table->bigInteger('creator_id'); //req
-            $table->float('tax_rate', 10, 2); //req
+            $table->bigIncrements('corporation_id'); // req
+            $table->string('ticker'); // req
+            $table->string('name'); // req
+            $table->bigInteger('member_count'); // req
+            $table->bigInteger('ceo_id'); // req
+            $table->bigInteger('creator_id'); // req
+            $table->float('tax_rate', 10, 2); // req
 
             $table->bigInteger('alliance_id')->nullable();
             $table->dateTime('date_founded')->nullable();

--- a/database/migrations/2025_01_02_185356_fix_killmail_items_table.php
+++ b/database/migrations/2025_01_02_185356_fix_killmail_items_table.php
@@ -2,8 +2,8 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -17,7 +17,7 @@
     <env name="REDIS_PASSWORD" value="null"/>
     <env name="REDIS_PORT" value="6379"/>
     <env name="DB_HOST" value="127.0.0.1"/>
-    <env name="DB_PORT" value="3308"/>
+    <env name="DB_PORT" value="3306"/>
     <env name="DB_DATABASE" value="testbench"/>
     <env name="DB_USERNAME" value="default"/>
     <env name="DB_PASSWORD" value="secret"/>

--- a/src/Commands/CheckJobsCommand.php
+++ b/src/Commands/CheckJobsCommand.php
@@ -87,7 +87,7 @@ class CheckJobsCommand extends Command
             ->each(function (array $job) {
                 // check if any assertion failed
                 if ($job['status'] === 'error') {
-                    //$this->writeAssertionOutput(get_class($job), 'px-2', '<span class="px-2 bg-red text-gray-400 uppercase">error</span>');
+                    // $this->writeAssertionOutput(get_class($job), 'px-2', '<span class="px-2 bg-red text-gray-400 uppercase">error</span>');
                     $this->writeAssertionHeader($job['class'], 'px-2 bg-red text-gray-400 uppercase', 'error');
                 } elseif ($job['status'] === 'warning') {
                     $this->writeAssertionHeader($job['class'], 'px-2 bg-yellow text-gray-400 uppercase', 'warning');

--- a/src/EveapiServiceProvider.php
+++ b/src/EveapiServiceProvider.php
@@ -71,7 +71,7 @@ class EveapiServiceProvider extends ServiceProvider
 
     public function boot(): void
     {
-        //Add Migrations
+        // Add Migrations
         $this->loadMigrationsFrom(__DIR__.'/../database/migrations/');
 
         // Configure the queue dashboard
@@ -149,7 +149,7 @@ class EveapiServiceProvider extends ServiceProvider
                     'processes' => (int) env(self::QUEUE_BALANCING_WORKERS, 4),
                     'block_for' => 5,
                     'timeout' => 120, // 2 minutes
-                    'nice' => 10, //Allowed values are between 0 and 19
+                    'nice' => 10, // Allowed values are between 0 and 19
                     'maxTime' => 3600,
                     'maxJobs' => 1000,
                 ],
@@ -162,7 +162,7 @@ class EveapiServiceProvider extends ServiceProvider
                     'minProcesses' => 1,
                     'maxProcesses' => (int) env(self::QUEUE_BALANCING_WORKERS, 4),
                     'tries' => 1,
-                    'nice' => 10, //Allowed values are between 0 and 19
+                    'nice' => 10, // Allowed values are between 0 and 19
                     'timeout' => 900, // 15 minutes
                     'maxTime' => 3600,
                     'maxJobs' => 1000,
@@ -204,7 +204,7 @@ class EveapiServiceProvider extends ServiceProvider
         Type::observe(TypeObserver::class);
         Group::observe(GroupObserver::class);
 
-        //Character Observers
+        // Character Observers
         CharacterInfo::observe(CharacterInfoObserver::class);
     }
 
@@ -237,7 +237,7 @@ class EveapiServiceProvider extends ServiceProvider
             });
 
             // Run Character Affiliation Job every five minutes to updated outdated affiliations.
-            //$schedule->job(new CharacterAffiliationJob)->everyFiveMinutes();
+            // $schedule->job(new CharacterAffiliationJob)->everyFiveMinutes();
             $schedule->call(new RefreshCharacterAffiliationsService)->everyFiveMinutes();
 
             // Cleanup Batches Table

--- a/src/Jobs/Contracts/CharacterContractsJob.php
+++ b/src/Jobs/Contracts/CharacterContractsJob.php
@@ -105,7 +105,7 @@ class CharacterContractsJob extends EsiBase implements HasPathValuesInterface, H
                 'status' => $contract->status,
                 'type' => $contract->type,
 
-                //optionals
+                // optionals
                 'buyout' => optional($contract)->buyout,
                 'collateral' => optional($contract)->collateral,
                 'date_accepted' => optional($contract)->date_accepted ? carbon(optional($contract)->date_accepted) : null,

--- a/src/Jobs/Contracts/ContractItemsJob.php
+++ b/src/Jobs/Contracts/ContractItemsJob.php
@@ -77,7 +77,7 @@ abstract class ContractItemsJob extends EsiBase implements HasPathValuesInterfac
         $contract_items = collect($response)->map(fn (object $item) => [
             // primary
             'record_id' => $item->record_id,
-            //others
+            // others
             'contract_id' => $this->contract_id,
             'is_included' => $item->is_included,
             'is_singleton' => $item->is_singleton,

--- a/src/Jobs/Hydrate/Maintenance/GetMissingCharacterInfos.php
+++ b/src/Jobs/Hydrate/Maintenance/GetMissingCharacterInfos.php
@@ -7,7 +7,6 @@ use Seatplus\Eveapi\Models\RefreshToken;
 
 class GetMissingCharacterInfos extends HydrateMaintenanceBase
 {
-
     public function handle(): void
     {
         if ($this->batch()->cancelled()) {

--- a/src/Jobs/Hydrate/Maintenance/GetMissingCharacterInfos.php
+++ b/src/Jobs/Hydrate/Maintenance/GetMissingCharacterInfos.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Seatplus\Eveapi\Jobs\Hydrate\Maintenance;
+
+use Seatplus\Eveapi\Jobs\Character\CharacterInfoJob;
+use Seatplus\Eveapi\Models\RefreshToken;
+
+class GetMissingCharacterInfos extends HydrateMaintenanceBase
+{
+
+    public function handle(): void
+    {
+        if ($this->batch()->cancelled()) {
+            // Determine if the batch has been cancelled...
+
+            return;
+        }
+
+        $jobs = RefreshToken::query()
+            ->whereDoesntHave('character')
+            ->pluck('character_id')
+            ->unique()
+            ->values()
+            ->map(fn (int $character_id) => new CharacterInfoJob($character_id));
+
+        $this->batch()->add(
+            $jobs->toArray()
+        );
+    }
+}

--- a/src/Jobs/Hydrate/Maintenance/GetMissingTypesFromCharacterAssets.php
+++ b/src/Jobs/Hydrate/Maintenance/GetMissingTypesFromCharacterAssets.php
@@ -41,7 +41,7 @@ class GetMissingTypesFromCharacterAssets extends HydrateMaintenanceBase
 
         $type_ids = Asset::doesntHave('type')->pluck('type_id')->unique()->values();
 
-        //$type_ids->each(fn ($id) => ResolveUniverseTypeByIdJob::dispatch($id)->onQueue('low'));
+        // $type_ids->each(fn ($id) => ResolveUniverseTypeByIdJob::dispatch($id)->onQueue('low'));
         $jobs = $type_ids->map(fn (int $id) => new ResolveUniverseTypeByIdJob($id));
 
         $this->batch()->add(

--- a/src/Jobs/Hydrate/Maintenance/GetMissingTypesFromLocations.php
+++ b/src/Jobs/Hydrate/Maintenance/GetMissingTypesFromLocations.php
@@ -49,7 +49,11 @@ class GetMissingTypesFromLocations extends HydrateMaintenanceBase
                 $query->whereDoesntHave('type')->addSelect('type_id');
             }
         )->with('locatable')->get()->map(function (Location $location) {
-            return $location->locatable->type_id;
+
+            /** @var Structure|Station $locatable */
+            $locatable = $location->locatable;
+
+            return $locatable->type_id;
         })->unique()->values();
 
         $jobs = $type_ids->map(fn (int $id) => new ResolveUniverseTypeByIdJob($id));

--- a/src/Jobs/Hydrate/Maintenance/GetMissingTypesFromSkillQueue.php
+++ b/src/Jobs/Hydrate/Maintenance/GetMissingTypesFromSkillQueue.php
@@ -41,7 +41,7 @@ class GetMissingTypesFromSkillQueue extends HydrateMaintenanceBase
 
         $type_ids = SkillQueue::doesntHave('type')->pluck('skill_id')->unique()->values();
 
-        //$type_ids->each(fn ($id) => ResolveUniverseTypeByIdJob::dispatch($id)->onQueue('low'));
+        // $type_ids->each(fn ($id) => ResolveUniverseTypeByIdJob::dispatch($id)->onQueue('low'));
         $jobs = $type_ids->map(fn (int $id) => new ResolveUniverseTypeByIdJob($id));
 
         $this->batch()->add(

--- a/src/Jobs/Seatplus/MaintenanceJob.php
+++ b/src/Jobs/Seatplus/MaintenanceJob.php
@@ -37,6 +37,7 @@ use Illuminate\Support\Facades\Bus;
 use Seatplus\Eveapi\Jobs\Assets\EnrichAssetTypeGroupCategoryJob;
 use Seatplus\Eveapi\Jobs\Hydrate\Maintenance\GetMissingBodysFromMails;
 use Seatplus\Eveapi\Jobs\Hydrate\Maintenance\GetMissingCategorys;
+use Seatplus\Eveapi\Jobs\Hydrate\Maintenance\GetMissingCharacterInfos;
 use Seatplus\Eveapi\Jobs\Hydrate\Maintenance\GetMissingCharacterInfosFromCorporationMemberTracking;
 use Seatplus\Eveapi\Jobs\Hydrate\Maintenance\GetMissingConstellations;
 use Seatplus\Eveapi\Jobs\Hydrate\Maintenance\GetMissingGroups;
@@ -84,6 +85,7 @@ class MaintenanceJob implements ShouldQueue
     {
         return Bus::batch([
 
+            new GetMissingCharacterInfos,
             new GetMissingGroups,
             new GetMissingCategorys,
             new EnrichAssetTypeGroupCategoryJob,

--- a/src/Jobs/Seatplus/UpdateCorporation.php
+++ b/src/Jobs/Seatplus/UpdateCorporation.php
@@ -55,7 +55,7 @@ class UpdateCorporation implements ShouldQueue
     public function __construct(
         public ?int $corporation_id = null,
     ) {
-        $this->findCorporationRefreshToken = new FindCorporationRefreshToken();
+        $this->findCorporationRefreshToken = new FindCorporationRefreshToken;
     }
 
     public function middleware(): array

--- a/src/Models/Assets/Asset.php
+++ b/src/Models/Assets/Asset.php
@@ -86,7 +86,7 @@ class Asset extends Model implements TypeWatchListInterface
 
     public function location(): HasOne
     {
-        //Todo create morphTo relation
+        // Todo create morphTo relation
         return $this->hasOne(Location::class, 'location_id', 'location_id');
     }
 

--- a/src/Models/Contacts/ContactLabel.php
+++ b/src/Models/Contacts/ContactLabel.php
@@ -28,6 +28,9 @@ namespace Seatplus\Eveapi\Models\Contacts;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Seatplus\Eveapi\Models\Alliance\AllianceInfo;
+use Seatplus\Eveapi\Models\Character\CharacterInfo;
+use Seatplus\Eveapi\Models\Corporation\CorporationInfo;
 
 class ContactLabel extends Model
 {
@@ -44,9 +47,11 @@ class ContactLabel extends Model
 
     public function getLabelNameAttribute(): ?string
     {
-        return $this->contact
-            ->contactable
-            ->labels
+
+        /** @var CharacterInfo|CorporationInfo|AllianceInfo $contactable */
+        $contactable = $this->contact->contactable;
+
+        return $contactable->labels
             ->firstWhere('label_id', $this->label_id)
             ?->label_name;
     }

--- a/src/Services/Esi/UpdateRefreshTokenService.php
+++ b/src/Services/Esi/UpdateRefreshTokenService.php
@@ -12,7 +12,7 @@ class UpdateRefreshTokenService
 
     public static function make(): self
     {
-        return new self();
+        return new self;
     }
 
     public function update(RefreshToken $refreshToken): RefreshToken

--- a/src/Services/Jobs/CacheCharacterAffiliationIdsService.php
+++ b/src/Services/Jobs/CacheCharacterAffiliationIdsService.php
@@ -9,7 +9,7 @@ class CacheCharacterAffiliationIdsService
 {
     public static function make(): self
     {
-        return new self();
+        return new self;
     }
 
     final public function queue(int|array $character_ids): void

--- a/src/Services/Jobs/GetLocationFlagNameService.php
+++ b/src/Services/Jobs/GetLocationFlagNameService.php
@@ -32,7 +32,7 @@ class GetLocationFlagNameService
 
     public static function make(): self
     {
-        return new self();
+        return new self;
     }
 
     public function get(int $flag_id): string
@@ -47,7 +47,7 @@ class GetLocationFlagNameService
             'ship_hangar' => range(90, 90),
             'fighter_tubes' => range(159, 163),
             'dronebay' => [
-                ...range(158, 158), //FighterBay
+                ...range(158, 158), // FighterBay
                 ...range(87, 87), // DroneBay
             ],
             'specialized' => [

--- a/src/Services/ResolveLocation/Finders/ThroughCharacterAssetsFinder.php
+++ b/src/Services/ResolveLocation/Finders/ThroughCharacterAssetsFinder.php
@@ -21,7 +21,7 @@ class ThroughCharacterAssetsFinder implements FinderInterface
             ->where('assetable_type', CharacterInfo::class)
             ->inRandomOrder()
             ->get()
-            ->map(fn (Asset $asset) => $asset->assetable->refresh_token)
+            ->map(fn (Asset $asset) => data_get($asset, 'assetable.refresh_token'))
             ->unique()
             // filter refresh token that has scope esi-universe.read_structures.v1
             ->filter(fn (RefreshToken $refresh_token) => $refresh_token->hasScope('esi-universe.read_structures.v1'))

--- a/src/Services/ResolveLocation/Finders/ThroughWalletTransactionsFinder.php
+++ b/src/Services/ResolveLocation/Finders/ThroughWalletTransactionsFinder.php
@@ -27,7 +27,7 @@ class ThroughWalletTransactionsFinder implements FinderInterface
             ->where('wallet_transactionable_type', CharacterInfo::class)
             ->inRandomOrder()
             ->get()
-            ->map(fn (WalletTransaction $wallet_transaction) => $wallet_transaction->wallet_transactionable->refresh_token)
+            ->map(fn(WalletTransaction $wallet_transaction) => data_get($wallet_transaction, 'wallet_transactionable.refresh_token'))
             ->unique()
             // filter refresh token that has scope esi-universe.read_structures.v1
             ->filter(fn (RefreshToken $refresh_token) => $refresh_token->hasScope('esi-universe.read_structures.v1'))

--- a/src/Services/ResolveLocation/Finders/ThroughWalletTransactionsFinder.php
+++ b/src/Services/ResolveLocation/Finders/ThroughWalletTransactionsFinder.php
@@ -27,7 +27,7 @@ class ThroughWalletTransactionsFinder implements FinderInterface
             ->where('wallet_transactionable_type', CharacterInfo::class)
             ->inRandomOrder()
             ->get()
-            ->map(fn(WalletTransaction $wallet_transaction) => data_get($wallet_transaction, 'wallet_transactionable.refresh_token'))
+            ->map(fn (WalletTransaction $wallet_transaction) => data_get($wallet_transaction, 'wallet_transactionable.refresh_token'))
             ->unique()
             // filter refresh token that has scope esi-universe.read_structures.v1
             ->filter(fn (RefreshToken $refresh_token) => $refresh_token->hasScope('esi-universe.read_structures.v1'))

--- a/src/Services/ResolveLocation/Resolver/StructureResolver.php
+++ b/src/Services/ResolveLocation/Resolver/StructureResolver.php
@@ -51,7 +51,7 @@ class StructureResolver implements ResolverInterface
 
         // if args is RefreshToken or null, set it as refreshToken
         if ($args instanceof RefreshToken) {
-            //set it as refreshToken
+            // set it as refreshToken
             $this->refreshToken = $args;
         }
 

--- a/src/Traits/HasRequiredScopes.php
+++ b/src/Traits/HasRequiredScopes.php
@@ -68,7 +68,7 @@ trait HasRequiredScopes
 
         $refresh_token = $refresh_tokens->first();
 
-        //check if the refresh token has the required scope
+        // check if the refresh token has the required scope
         throw_unless($refresh_token->hasScope($this->getRequiredScope()), new Exception('refresh token does not have the required scope'));
 
         return $refresh_token;

--- a/tests/Integration/CharacterWalletJournalLifecycleTest.php
+++ b/tests/Integration/CharacterWalletJournalLifecycleTest.php
@@ -19,9 +19,9 @@ test('run wallet journal job', function () {
 
     $job->handle();
 
-    //assertWalletJournal($mock_data, $this->test_character->character_id);
+    // assertWalletJournal($mock_data, $this->test_character->character_id);
     foreach ($mock_data as $data) {
-        //Assert that character asset created
+        // Assert that character asset created
         $this->assertDatabaseHas('wallet_journals', [
             'wallet_journable_id' => $this->test_character->character_id,
             'id' => $data->id,

--- a/tests/Integration/ContactLabelJobTest.php
+++ b/tests/Integration/ContactLabelJobTest.php
@@ -23,9 +23,9 @@ test('run character contact label', function () {
 
     dispatch_sync($job);
 
-    //assertContactLabel($mock_data, $this->test_character->character_id);
+    // assertContactLabel($mock_data, $this->test_character->character_id);
     foreach ($mock_data as $data) {
-        //Assert that character asset created
+        // Assert that character asset created
         $this->assertDatabaseHas('labels', [
             'labelable_id' => (string) $this->test_character->character_id,
             'label_id' => $data->label_id,
@@ -40,9 +40,9 @@ test('run corporation contact label', function () {
 
     (new CorporationContactLabelJob(testCharacter()->corporation->corporation_id, testCharacter()->character_id))->handle();
 
-    //assertContactLabel($mock_data, $this->test_character->corporation->corporation_id);
+    // assertContactLabel($mock_data, $this->test_character->corporation->corporation_id);
     foreach ($mock_data as $data) {
-        //Assert that character asset created
+        // Assert that character asset created
         $this->assertDatabaseHas('labels', [
             'labelable_id' => (string) $this->test_character->corporation->corporation_id,
             'label_id' => $data->label_id,
@@ -57,9 +57,9 @@ test('run alliance contact label', function () {
 
     (new AllianceContactLabelJob(testCharacter()->corporation->alliance_id, testCharacter()->character_id))->handle();
 
-    //assertContactLabel($mock_data, $this->test_character->corporation->alliance_id);
+    // assertContactLabel($mock_data, $this->test_character->corporation->alliance_id);
     foreach ($mock_data as $data) {
-        //Assert that character asset created
+        // Assert that character asset created
         $this->assertDatabaseHas('labels', [
             'labelable_id' => (string) $this->test_character->corporation->alliance_id,
             'label_id' => $data->label_id,

--- a/tests/Integration/ContactLifecycleTest.php
+++ b/tests/Integration/ContactLifecycleTest.php
@@ -26,7 +26,7 @@ test('run character contact', function () {
     $cached_ids = \Seatplus\Eveapi\Services\Jobs\CacheCharacterAffiliationIdsService::make()->retrieve();
 
     foreach ($mock_data as $data) {
-        //Assert that character asset created
+        // Assert that character asset created
         $this->assertDatabaseHas('contacts', [
             'contactable_id' => $this->test_character->character_id,
             'contact_id' => $data->contact_id,
@@ -50,7 +50,7 @@ test('run corporation contact', function () {
     $cached_ids = \Seatplus\Eveapi\Services\Jobs\CacheCharacterAffiliationIdsService::make()->retrieve();
 
     foreach ($mock_data as $data) {
-        //Assert that character asset created
+        // Assert that character asset created
         $this->assertDatabaseHas('contacts', [
             'contactable_id' => $this->test_character->corporation->corporation_id,
             'contact_id' => $data->contact_id,
@@ -71,9 +71,9 @@ test('run alliance contact', function () {
 
     $job->handle();
 
-    //assertContact($mock_data, $this->test_character->corporation->alliance_id);
+    // assertContact($mock_data, $this->test_character->corporation->alliance_id);
     foreach ($mock_data as $data) {
-        //Assert that character asset created
+        // Assert that character asset created
         $this->assertDatabaseHas('contacts', [
             'contactable_id' => $this->test_character->corporation->alliance_id,
             'contact_id' => $data->contact_id,
@@ -95,7 +95,7 @@ it('has labels', function () {
     $job->handle();
 
     foreach (collect($mock_data) as $data) {
-        //Assert that character asset created
+        // Assert that character asset created
         $this->assertDatabaseHas('contacts', [
             'contactable_id' => $this->test_character->character_id,
             'contact_id' => $data->contact_id,

--- a/tests/Integration/CorporationMemberTrackingLifeCycleTest.php
+++ b/tests/Integration/CorporationMemberTrackingLifeCycleTest.php
@@ -1,7 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Queue;
-use Seatplus\Eveapi\Jobs\Character\CharacterInfoJob as CharacterInfoJob;
+use Seatplus\Eveapi\Jobs\Character\CharacterInfoJob;
 use Seatplus\Eveapi\Jobs\Corporation\CorporationMemberTrackingJob;
 use Seatplus\Eveapi\Jobs\Universe\ResolveLocationJob;
 use Seatplus\Eveapi\Jobs\Universe\ResolveUniverseTypeByIdJob;

--- a/tests/Integration/SkillQueueLifeCycleTest.php
+++ b/tests/Integration/SkillQueueLifeCycleTest.php
@@ -31,7 +31,7 @@ it('dispatch type job if skill_id is not yet in the type table', function () {
 
     Queue::assertNothingPushed();
 
-    //SkillQueue::factory(['skill_id' => 123])->make();
+    // SkillQueue::factory(['skill_id' => 123])->make();
 
     $mock_data = buildSkillQueueMockEsiData();
 

--- a/tests/Integration/UniverseRegionTest.php
+++ b/tests/Integration/UniverseRegionTest.php
@@ -52,21 +52,21 @@ it('resolves system', function () {
     $mock_data = System::factory()->make();
     mockRetrieveEsiDataAction($mock_data->toArray());
 
-    //$job = new ResolveUniverseSystemBySystemIdJob;
+    // $job = new ResolveUniverseSystemBySystemIdJob;
 
-    //Assert that no system is created
+    // Assert that no system is created
     $this->assertDatabaseMissing('universe_systems', [
         'system_id' => $mock_data->system_id,
     ]);
 
     Event::fake();
 
-    //$job->setSystemId($mock_data->system_id)->handle();
+    // $job->setSystemId($mock_data->system_id)->handle();
     (new ResolveUniverseSystemBySystemIdJob($mock_data->system_id))->handle();
 
     Event::assertDispatched(UniverseSystemCreated::class);
 
-    //Assert that system is created
+    // Assert that system is created
     $this->assertDatabaseHas('universe_systems', [
         'system_id' => $mock_data->system_id,
     ]);
@@ -105,14 +105,14 @@ it('resolves constellations', function () {
 
     mockRetrieveEsiDataAction($mock_data->toArray());
 
-    //Assert that no system is present
+    // Assert that no system is present
     $this->assertDatabaseMissing('universe_constellations', [
         'constellation_id' => $mock_data->constellation_id,
     ]);
 
     (new ResolveUniverseConstellationByConstellationIdJob($mock_data->constellation_id))->handle();
 
-    //Assert that system is created
+    // Assert that system is created
     $this->assertDatabaseHas('universe_constellations', [
         'constellation_id' => $mock_data->constellation_id,
     ]);
@@ -153,14 +153,14 @@ it('resolves regions', function () {
 
     mockRetrieveEsiDataAction($mock_data->toArray());
 
-    //Assert that no system is present
+    // Assert that no system is present
     $this->assertDatabaseMissing('universe_regions', [
         'region_id' => $mock_data->region_id,
     ]);
 
     (new ResolveUniverseRegionByRegionIdJob($mock_data->region_id))->handle();
 
-    //Assert that system is created
+    // Assert that system is created
     $this->assertDatabaseHas('universe_regions', [
         'region_id' => $mock_data->region_id,
     ]);

--- a/tests/Integration/WalletTransactionLifecycleTest.php
+++ b/tests/Integration/WalletTransactionLifecycleTest.php
@@ -33,9 +33,9 @@ test('run wallet transaction action', function (bool $is_corporation = false) {
 
     runWalletTransactionJobWithMockData($mock_data->toArray());
 
-    //assertWalletTransaction($mock_data, $this->test_character->character_id);
+    // assertWalletTransaction($mock_data, $this->test_character->character_id);
     foreach ($mock_data as $data) {
-        //Assert that character asset created
+        // Assert that character asset created
         $this->assertDatabaseHas('wallet_transactions', [
             'wallet_transactionable_id' => $wallet_transactionable_id,
             'transaction_id' => $data->transaction_id,

--- a/tests/Jobs/Alliance/AllianceInfoJobTest.php
+++ b/tests/Jobs/Alliance/AllianceInfoJobTest.php
@@ -30,7 +30,7 @@ test('retrieve test', function () {
     // Run InfoAction
     $job->handle();
 
-    //Assert that alliance_info is created
+    // Assert that alliance_info is created
     $this->assertDatabaseHas('alliance_infos', [
         'name' => $mock_data->name,
     ]);

--- a/tests/Jobs/Assets/CharacterAssetTest.php
+++ b/tests/Jobs/Assets/CharacterAssetTest.php
@@ -41,7 +41,7 @@ test('retrieve test', function () {
     (new CharacterAssetJob($this->test_character->character_id))->handle();
 
     foreach ($mock_data as $data) {
-        //Assert that character asset created
+        // Assert that character asset created
         $this->assertDatabaseHas('assets', [
             'assetable_id' => $this->test_character->character_id,
             'item_id' => $data->item_id,
@@ -59,7 +59,7 @@ it('cleans up assets', function () {
 
     // assert that old data is present before CharacterAssetsCleanUpAction
     foreach ($old_data as $data) {
-        //Assert that character asset created
+        // Assert that character asset created
         $this->assertDatabaseHas('assets', [
             'assetable_id' => $this->test_character->character_id,
             'item_id' => $data->item_id,
@@ -72,7 +72,7 @@ it('cleans up assets', function () {
     (new CharacterAssetJob($this->test_character->character_id))->handle();
 
     foreach ($mock_data as $data) {
-        //Assert that character asset created
+        // Assert that character asset created
         $this->assertDatabaseHas('assets', [
             'assetable_id' => $this->test_character->character_id,
             'item_id' => $data->item_id,
@@ -97,7 +97,7 @@ it('dispatches unknown location job', function () {
     (new CharacterAssetJob($this->test_character->character_id))->handle();
 
     foreach ($mock_data as $data) {
-        //Assert that character asset created
+        // Assert that character asset created
         $this->assertDatabaseHas('assets', [
             'assetable_id' => $this->test_character->character_id,
             'item_id' => $data->item_id,
@@ -115,7 +115,7 @@ it('dispatches unknown types job', function () {
     (new CharacterAssetJob($this->test_character->character_id))->handle();
 
     foreach ($mock_data as $data) {
-        //Assert that character asset created
+        // Assert that character asset created
         $this->assertDatabaseHas('assets', [
             'assetable_id' => $this->test_character->character_id,
             'item_id' => $data->item_id,

--- a/tests/Jobs/Assets/CharacterAssetsNameJobTest.php
+++ b/tests/Jobs/Assets/CharacterAssetsNameJobTest.php
@@ -18,7 +18,7 @@ beforeEach(function () {
     $refresh_token = updateRefreshTokenScopes($this->test_character->refresh_token, ['esi-assets.read_assets.v1']);
     $refresh_token->save();
 
-    //$this->job = new CharacterAssetsNameJob($job_container);
+    // $this->job = new CharacterAssetsNameJob($job_container);
     $this->name_to_create = 'TestName';
 });
 
@@ -55,7 +55,7 @@ it('updates a name', function () {
         'is_singleton' => true,
     ]);
 
-    //Assert that character asset created has no name
+    // Assert that character asset created has no name
     $this->assertDatabaseHas('assets', [
         'assetable_id' => $asset->assetable_id,
         'item_id' => $asset->item_id,
@@ -71,7 +71,7 @@ it('updates a name', function () {
 
     (new CharacterAssetsNameJob($this->test_character->character_id))->handle();
 
-    //Assert that character asset created has name
+    // Assert that character asset created has name
     $this->assertDatabaseHas('assets', [
         'assetable_id' => $asset->assetable_id,
         'item_id' => $asset->item_id,
@@ -97,7 +97,7 @@ it('does not update for wrong category', function () {
         'is_singleton' => true,
     ]);
 
-    //Assert that character asset created has no name
+    // Assert that character asset created has no name
     $this->assertDatabaseHas('assets', [
         'assetable_id' => $asset->assetable_id,
         'item_id' => $asset->item_id,
@@ -106,7 +106,7 @@ it('does not update for wrong category', function () {
 
     $this->assertRetrieveEsiDataIsNotCalled();
 
-    //Assert that character asset created has no name
+    // Assert that character asset created has no name
     $this->assertDatabaseMissing('assets', [
         'assetable_id' => $asset->assetable_id,
         'item_id' => $asset->item_id,
@@ -122,7 +122,7 @@ it('does not run if category id is out of scope', function () {
 
     $group = Event::fakeFor(fn () => Group::factory()->create([
         'group_id' => $type->group_id,
-        'category_id' => 5, //Only Celestials, Ships, Deployable, Starbases, Orbitals and Structures might be named
+        'category_id' => 5, // Only Celestials, Ships, Deployable, Starbases, Orbitals and Structures might be named
     ]));
 
     $asset = Asset::factory()->create([
@@ -131,7 +131,7 @@ it('does not run if category id is out of scope', function () {
         'is_singleton' => true,
     ]);
 
-    //Assert that character asset created has no name
+    // Assert that character asset created has no name
     $this->assertDatabaseHas('assets', [
         'assetable_id' => $asset->assetable_id,
         'item_id' => $asset->item_id,
@@ -140,7 +140,7 @@ it('does not run if category id is out of scope', function () {
 
     $this->assertRetrieveEsiDataIsNotCalled();
 
-    //Assert that character asset created has no name
+    // Assert that character asset created has no name
     $this->assertDatabaseMissing('assets', [
         'assetable_id' => $asset->assetable_id,
         'item_id' => $asset->item_id,
@@ -160,7 +160,7 @@ it('does not run if group is missing', function () {
         'is_singleton' => true,
     ]);
 
-    //Assert that character asset created has no name
+    // Assert that character asset created has no name
     $this->assertDatabaseHas('assets', [
         'assetable_id' => $asset->assetable_id,
         'item_id' => $asset->item_id,
@@ -171,7 +171,7 @@ it('does not run if group is missing', function () {
 
     $this->assertRetrieveEsiDataIsNotCalled();
 
-    //Assert that character asset created has no name
+    // Assert that character asset created has no name
     $this->assertDatabaseMissing('assets', [
         'assetable_id' => $asset->assetable_id,
         'item_id' => $asset->item_id,
@@ -196,7 +196,7 @@ it('runs the job', function () {
         'is_singleton' => true,
     ]));
 
-    //Assert that character asset created has no name
+    // Assert that character asset created has no name
     $this->assertDatabaseHas('assets', [
         'assetable_id' => $asset->assetable_id,
         'item_id' => $asset->item_id,
@@ -212,7 +212,7 @@ it('runs the job', function () {
 
     (new CharacterAssetsNameJob($asset->assetable_id))->handle();
 
-    //Assert that character asset created has name
+    // Assert that character asset created has name
     $this->assertCount(
         1,
         Asset::where('assetable_id', $asset->assetable_id)

--- a/tests/Jobs/Character/CharacterInfoTest.php
+++ b/tests/Jobs/Character/CharacterInfoTest.php
@@ -35,9 +35,9 @@ test('retrieve test', function () {
 
     $job->handle();
 
-    //(new CharacterInfoAction)->execute($mock_data['character_id']);
+    // (new CharacterInfoAction)->execute($mock_data['character_id']);
 
-    //Assert that test character is now created
+    // Assert that test character is now created
     $this->assertDatabaseHas('character_infos', [
         'name' => $mock_data['name'],
     ]);

--- a/tests/Jobs/Character/CharacterRoleTest.php
+++ b/tests/Jobs/Character/CharacterRoleTest.php
@@ -37,7 +37,7 @@ test('retrieve test', function () {
 
     (new CharacterRoleJob($this->test_character->character_id))->handle();
 
-    //Assert that test character is now created
+    // Assert that test character is now created
     $this->assertDatabaseHas('character_roles', [
         'character_id' => $mock_data->character_id,
     ]);

--- a/tests/Jobs/Corporation/CorporationDivisionsJobTest.php
+++ b/tests/Jobs/Corporation/CorporationDivisionsJobTest.php
@@ -21,7 +21,7 @@ it('runs the job', function () {
 
     expect(CorporationDivision::all())->toHaveCount(0);
 
-    //dd($this->test_character->refresh_token->scopes, 'esi-corporations.read_divisions.v1', $this->test_character->roles);
+    // dd($this->test_character->refresh_token->scopes, 'esi-corporations.read_divisions.v1', $this->test_character->roles);
 
     (new CorporationDivisionsJob(testCharacter()->corporation->corporation_id))->handle();
 

--- a/tests/Jobs/Corporation/CorporationInfoJobTest.php
+++ b/tests/Jobs/Corporation/CorporationInfoJobTest.php
@@ -23,7 +23,7 @@ test('retrieve test', function () {
     // Run InfoAction
     (new CorporationInfoJob($this->corporation_id))->handle();
 
-    //Assert that test character is now created
+    // Assert that test character is now created
     $this->assertDatabaseHas('corporation_infos', [
         'name' => $mock_data->name,
     ]);

--- a/tests/Jobs/Corporation/CorporationMemberTrackingJobTest.php
+++ b/tests/Jobs/Corporation/CorporationMemberTrackingJobTest.php
@@ -51,7 +51,7 @@ test('retrieve test', function () {
     // Run Action
     (new CorporationMemberTrackingJob(testCharacter()->corporation->corporation_id))->handle();
 
-    //Assert that test character is now created
+    // Assert that test character is now created
     $this->assertDatabaseHas('corporation_member_trackings', [
         'corporation_id' => $this->test_character->corporation->corporation_id,
     ]);

--- a/tests/Jobs/Seatplus/MaintenanceJobTest.php
+++ b/tests/Jobs/Seatplus/MaintenanceJobTest.php
@@ -49,7 +49,7 @@ use Seatplus\Eveapi\Models\Universe\Type;
 use Seatplus\Eveapi\Models\Wallet\WalletTransaction;
 
 beforeEach(function () {
-    //$this->job = new MaintenanceJob;
+    // $this->job = new MaintenanceJob;
 });
 
 it('MaintenanceJob dispatches job: ', function ($hydrate_job) {
@@ -460,7 +460,7 @@ it('dispatch get missing constellations and get missing regions as chained job',
     Bus::assertBatched(fn ($batch) => $batch->jobs->first(fn ($job) => [
         new GetMissingConstellations,
         new GetMissingRegions,
-    ])); //$batch->jobs->first(fn($job) => $job instanceof GetMissingConstellations));
+    ])); // $batch->jobs->first(fn($job) => $job instanceof GetMissingConstellations));
 });
 
 it('dispatches resolve universe constellation by constellation id job for missing constellations', function () {

--- a/tests/Jobs/Seatplus/MaintenanceJobTest.php
+++ b/tests/Jobs/Seatplus/MaintenanceJobTest.php
@@ -6,6 +6,7 @@ use Seatplus\Eveapi\Jobs\Assets\EnrichAssetTypeGroupCategoryJob;
 use Seatplus\Eveapi\Jobs\Character\CharacterInfoJob;
 use Seatplus\Eveapi\Jobs\Hydrate\Maintenance\GetMissingBodysFromMails;
 use Seatplus\Eveapi\Jobs\Hydrate\Maintenance\GetMissingCategorys;
+use Seatplus\Eveapi\Jobs\Hydrate\Maintenance\GetMissingCharacterInfos;
 use Seatplus\Eveapi\Jobs\Hydrate\Maintenance\GetMissingCharacterInfosFromCorporationMemberTracking;
 use Seatplus\Eveapi\Jobs\Hydrate\Maintenance\GetMissingConstellations;
 use Seatplus\Eveapi\Jobs\Hydrate\Maintenance\GetMissingGroups;
@@ -61,6 +62,7 @@ it('MaintenanceJob dispatches job: ', function ($hydrate_job) {
     });
 
 })->with([
+    GetMissingCharacterInfos::class,
     GetMissingGroups::class,
     GetMissingCategorys::class,
     EnrichAssetTypeGroupCategoryJob::class,
@@ -147,6 +149,23 @@ it('catches missing groups from type', function () {
         ->once()
         ->with([
             new ResolveUniverseGroupByIdJob($type->group_id),
+        ]);
+
+    $mock->handle();
+});
+
+it('catches missing character_infos from refresh_token', function () {
+    $refresh_token = Event::fakeFor(fn () => \Seatplus\Eveapi\Models\RefreshToken::factory()->create([
+        'character_id' => CharacterInfo::factory()->make(),
+    ]));
+
+    $mock = Mockery::mock(GetMissingCharacterInfos::class)->makePartial();
+
+    $mock->shouldReceive('batch->cancelled')->once()->andReturnFalse();
+    $mock->shouldReceive('batch->add')
+        ->once()
+        ->with([
+            new CharacterInfoJob($refresh_token->character_id),
         ]);
 
     $mock->handle();

--- a/tests/Jobs/Universe/ResolveLocationJobTest.php
+++ b/tests/Jobs/Universe/ResolveLocationJobTest.php
@@ -25,7 +25,7 @@ it('runs ResolveLocationService', function () {
     $job->handle();
 
     // Assert
-    //assert that mock was called
+    // assert that mock was called
     expect(\Seatplus\Eveapi\Models\Universe\Location::all())
         ->toHaveCount(0);
 });

--- a/tests/Jobs/Universe/ResolveUniverseStationByIdJobTest.php
+++ b/tests/Jobs/Universe/ResolveUniverseStationByIdJobTest.php
@@ -27,7 +27,7 @@ it('creates station', function () {
 
     (new ResolveUniverseStationByIdJob($mock_data->station_id))->handle();
 
-    //Assert that structure is created
+    // Assert that structure is created
     $this->assertDatabaseHas('universe_stations', [
         'station_id' => $mock_data->station_id,
     ]);
@@ -39,14 +39,14 @@ it('creates station', function () {
 it('creates location', function () {
     $mock_data = buildStationMockEsiData();
 
-    //Assert that no structure is created
+    // Assert that no structure is created
     $this->assertDatabaseMissing('universe_locations', [
         'location_id' => $mock_data->station_id,
     ]);
 
     (new ResolveUniverseStationByIdJob($mock_data->station_id))->handle();
 
-    //Assert that structure is created
+    // Assert that structure is created
     $this->assertDatabaseHas('universe_locations', [
         'location_id' => $mock_data->station_id,
     ]);
@@ -75,7 +75,7 @@ it('does not create structure if location id is not in range', function () {
 
     (new ResolveUniverseStationByIdJob($mock_data->station_id))->handle();
 
-    //Assert that no structure is created
+    // Assert that no structure is created
     $this->assertDatabaseMissing('universe_stations', [
         'station_id' => $mock_data->station_id,
     ]);

--- a/tests/Jobs/Universe/ResolveUniverseStructureByIdJobTest.php
+++ b/tests/Jobs/Universe/ResolveUniverseStructureByIdJobTest.php
@@ -26,14 +26,14 @@ beforeEach(function () {
 it('creates structure', function () {
     $mock_data = buildStructureMockEsiData();
 
-    //Assert that no structure is created
+    // Assert that no structure is created
     $this->assertDatabaseMissing('universe_structures', [
         'structure_id' => $mock_data->structure_id,
     ]);
 
     (new ResolveUniverseStructureByIdJob($this->refresh_token->character_id, $mock_data->structure_id))->handle();
 
-    //Assert that structure is created
+    // Assert that structure is created
     $this->assertDatabaseHas('universe_structures', [
         'structure_id' => $mock_data->structure_id,
     ]);
@@ -45,14 +45,14 @@ it('creates structure', function () {
 it('creates location', function () {
     $mock_data = buildStructureMockEsiData();
 
-    //Assert that no structure is created
+    // Assert that no structure is created
     $this->assertDatabaseMissing('universe_locations', [
         'location_id' => $mock_data->structure_id,
     ]);
 
     (new ResolveUniverseStructureByIdJob($this->refresh_token->character_id, $mock_data->structure_id))->handle();
 
-    //Assert that structure is created
+    // Assert that structure is created
     $this->assertDatabaseHas('universe_locations', [
         'location_id' => $mock_data->structure_id,
     ]);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -19,7 +19,7 @@ use Seatplus\EsiClient\DataTransferObjects\EsiResponse;
 use Seatplus\Eveapi\Services\Facade\RetrieveEsiData;
 
 uses(\Seatplus\Eveapi\Tests\TestCase::class)->in('Unit', 'Integration', 'Jobs');
-//uses(\Illuminate\Foundation\Testing\LazilyRefreshDatabase::class)->in('Unit', 'Integration', 'Jobs');
+// uses(\Illuminate\Foundation\Testing\LazilyRefreshDatabase::class)->in('Unit', 'Integration', 'Jobs');
 
 /*
 |--------------------------------------------------------------------------

--- a/tests/Unit/JobMiddleware/HasRequiredScopeMiddlewareTest.php
+++ b/tests/Unit/JobMiddleware/HasRequiredScopeMiddlewareTest.php
@@ -5,7 +5,7 @@ use Seatplus\Eveapi\Jobs\Middleware\HasRequiredScopeMiddleware;
 use Seatplus\Eveapi\Models\RefreshToken;
 
 it('passes the middleware if HasRequiredScopeInterface is not implemented', function () {
-    $middleware = new HasRequiredScopeMiddleware();
+    $middleware = new HasRequiredScopeMiddleware;
 
     $job = Mockery::mock(EsiBase::class);
 
@@ -45,7 +45,7 @@ it('passes the job if refresh_token for required scope is found', function () {
 
 function prepareJobMiddleware(bool $should_fail = true)
 {
-    $middleware = new HasRequiredScopeMiddleware();
+    $middleware = new HasRequiredScopeMiddleware;
 
     $job = Mockery::mock(EsiBase::class, \Seatplus\Eveapi\Esi\HasRequiredScopeInterface::class);
 

--- a/tests/Unit/Models/AssetModelTest.php
+++ b/tests/Unit/Models/AssetModelTest.php
@@ -52,7 +52,7 @@ it('has scope assets location ids', function () {
 
 it('has assetable relationship', function () {
     $test_asset = Asset::factory()->create([
-        'assetable_id' => $this->test_character->character_id, //CharacterInfo::factory(),
+        'assetable_id' => $this->test_character->character_id, // CharacterInfo::factory(),
         'assetable_type' => CharacterInfo::class,
     ]);
 
@@ -64,7 +64,7 @@ it('has content relationship', function () {
         'location_flag' => 'Hangar',
     ]);
 
-    //Create Content
+    // Create Content
     $test_asset->content()->save(Asset::factory()->create([
         'location_flag' => 'cargo',
     ]));
@@ -77,7 +77,7 @@ it('has container relationship', function () {
         'location_flag' => 'Hangar',
     ]);
 
-    //Create Content
+    // Create Content
     $test_asset->content()->save(Asset::factory()->create([
         'location_flag' => 'cargo',
     ]));

--- a/tests/Unit/Models/CorporationInfoTest.php
+++ b/tests/Unit/Models/CorporationInfoTest.php
@@ -62,7 +62,7 @@ it('has morphable sso scope', function () {
         ->hasSsoScopes()
         ->create();
 
-    //$corporation_info->ssoScopes()->save(SsoScopes::factory()->make());
+    // $corporation_info->ssoScopes()->save(SsoScopes::factory()->make());
 
     expect($corporation_info->refresh()->ssoScopes)->toBeInstanceOf(SsoScopes::class);
 });

--- a/tests/Unit/Models/UniverseTypesModelTest.php
+++ b/tests/Unit/Models/UniverseTypesModelTest.php
@@ -11,7 +11,7 @@ beforeEach(function () {
 it('has group', function () {
     $group = Event::fakeFor(fn () => Group::factory()->create(['group_id' => $this->type->group_id]));
 
-    //$this->type->group()->save($group);
+    // $this->type->group()->save($group);
 
     $this->assertNotNull($this->type->group);
 });

--- a/tests/Unit/Services/Character/RefreshCharacterAffiliationsServiceTest.php
+++ b/tests/Unit/Services/Character/RefreshCharacterAffiliationsServiceTest.php
@@ -25,7 +25,7 @@ describe('dispatches CharacterAffiliationJob for ', function () {
         ]);
 
         // act
-        $service = new RefreshCharacterAffiliationsService();
+        $service = new RefreshCharacterAffiliationsService;
         $service();
 
         // assert
@@ -50,7 +50,7 @@ describe('dispatches CharacterAffiliationJob for ', function () {
             ->queue(testCharacter()->character_id);
 
         // act
-        $service = new RefreshCharacterAffiliationsService();
+        $service = new RefreshCharacterAffiliationsService;
         $service();
 
         // assert
@@ -71,7 +71,7 @@ describe('dispatches CharacterAffiliationJob for ', function () {
         CharacterAffiliation::query()->delete();
 
         // act
-        $service = new RefreshCharacterAffiliationsService();
+        $service = new RefreshCharacterAffiliationsService;
         $service();
 
         // assert
@@ -98,7 +98,7 @@ describe('does not dispatches CharacterAffiliationJob ', function () {
         ]);
 
         // act
-        $service = new RefreshCharacterAffiliationsService();
+        $service = new RefreshCharacterAffiliationsService;
         $service();
 
         // assert

--- a/tests/Unit/Services/ResolveLocation/StationResolverTest.php
+++ b/tests/Unit/Services/ResolveLocation/StationResolverTest.php
@@ -30,7 +30,7 @@ describe('isStructure or recently updated station', function () {
             'locatable_type' => Structure::class,
         ]);
 
-        $resolveStationPipe = new StationResolver();
+        $resolveStationPipe = new StationResolver;
 
         Log::shouldReceive()
             ->never();
@@ -55,7 +55,7 @@ describe('isStructure or recently updated station', function () {
             'locatable_type' => Station::class,
         ]);
 
-        $resolveStationPipe = new StationResolver();
+        $resolveStationPipe = new StationResolver;
 
         Log::shouldReceive()
             ->never();
@@ -89,7 +89,7 @@ describe('is potential station', function () {
             'locatable_type' => Station::class,
         ]);
 
-        $resolveStationPipe = new StationResolver();
+        $resolveStationPipe = new StationResolver;
 
         // Act
         $result = $resolveStationPipe->handle($location);
@@ -131,7 +131,7 @@ describe('is potential station', function () {
         Log::shouldReceive('info')->once();
 
         // Act
-        $stationResolver = new StationResolver();
+        $stationResolver = new StationResolver;
         $result = $stationResolver->handle($location);
 
         // Assert

--- a/tests/Unit/Services/ResolveLocation/StructureRefreshTokenFinderTest.php
+++ b/tests/Unit/Services/ResolveLocation/StructureRefreshTokenFinderTest.php
@@ -49,7 +49,7 @@ describe('filters through different finders', function () {
                 'resolved' => true,
             ]);
 
-        $instance = new ThroughSuccessfulRefreshTokenFinder();
+        $instance = new ThroughSuccessfulRefreshTokenFinder;
 
         executeFindStructureRefreshTokenTest($instance);
 
@@ -62,7 +62,7 @@ describe('filters through different finders', function () {
             'assetable_type' => CharacterInfo::class,
         ]);
 
-        $instance = new ThroughCharacterAssetsFinder();
+        $instance = new ThroughCharacterAssetsFinder;
 
         executeFindStructureRefreshTokenTest($instance);
     });
@@ -73,7 +73,7 @@ describe('filters through different finders', function () {
             'issuer_id' => test()->character_id,
         ]);
 
-        $instance = new ThroughContractsFinder();
+        $instance = new ThroughContractsFinder;
 
         executeFindStructureRefreshTokenTest($instance);
     });
@@ -84,7 +84,7 @@ describe('filters through different finders', function () {
             'character_id' => test()->character_id,
         ]);
 
-        $instance = new ThroughCorporationMemberTrackingFinder();
+        $instance = new ThroughCorporationMemberTrackingFinder;
 
         executeFindStructureRefreshTokenTest($instance);
     });
@@ -96,7 +96,7 @@ describe('filters through different finders', function () {
             'corporation_id' => test()->corporation_id,
         ]);
 
-        $instance = new ThroughCorporationMemberTrackingFinder();
+        $instance = new ThroughCorporationMemberTrackingFinder;
 
         executeFindStructureRefreshTokenTest($instance);
     });
@@ -110,13 +110,13 @@ describe('filters through different finders', function () {
                 'attempts' => 1,
             ]);
 
-        $instance = new ThroughPreviouslyFailedRefreshTokenFinder();
+        $instance = new ThroughPreviouslyFailedRefreshTokenFinder;
 
         executeFindStructureRefreshTokenTest($instance);
     });
 
     it('finds token ThroughRandomRefreshTokenFinder', function () {
-        $instance = new ThroughRandomRefreshTokenFinder();
+        $instance = new ThroughRandomRefreshTokenFinder;
 
         executeFindStructureRefreshTokenTest($instance);
     });
@@ -128,7 +128,7 @@ describe('filters through different finders', function () {
             'wallet_transactionable_type' => CharacterInfo::class,
         ]);
 
-        $instance = new ThroughWalletTransactionsFinder();
+        $instance = new ThroughWalletTransactionsFinder;
 
         executeFindStructureRefreshTokenTest($instance);
     });
@@ -140,7 +140,7 @@ describe('filters through different finders', function () {
             'wallet_transactionable_type' => CorporationInfo::class,
         ]);
 
-        $instance = new ThroughWalletTransactionsFinder();
+        $instance = new ThroughWalletTransactionsFinder;
 
         executeFindStructureRefreshTokenTest($instance);
     });
@@ -209,7 +209,7 @@ it('goes through all finder classes', function () {
             'attempts' => 1,
         ]);
 
-    $instance = new StructureRefreshTokenFinder();
+    $instance = new StructureRefreshTokenFinder;
 
     // make sure the ThrougRandomRefreshTokenFinder did not result positively
     $random_token = (new ThroughRandomRefreshTokenFinder)->handle(test()->location_id, LocationRefreshToken::all());

--- a/tests/Unit/Services/ResolveLocation/StructureResolverTest.php
+++ b/tests/Unit/Services/ResolveLocation/StructureResolverTest.php
@@ -35,7 +35,7 @@ describe('isStation or recently updated structure', function () {
             'locatable_type' => Station::class,
         ]);
 
-        $resolveStructurePipe = new StructureResolver();
+        $resolveStructurePipe = new StructureResolver;
 
         Log::shouldReceive()
             ->never();
@@ -64,7 +64,7 @@ describe('isStation or recently updated structure', function () {
             'locatable_type' => Structure::class,
         ]);
 
-        $resolveStructurePipe = new StructureResolver();
+        $resolveStructurePipe = new StructureResolver;
 
         Log::shouldReceive()
             ->never();

--- a/tests/Unit/Services/RestrieveEsiDataTest.php
+++ b/tests/Unit/Services/RestrieveEsiDataTest.php
@@ -5,7 +5,7 @@ use Seatplus\Eveapi\Models\RefreshToken;
 use Seatplus\Eveapi\Services\Esi\RetrieveEsiData;
 
 test('it returns client for an unauthenticated request', function () {
-    $retrieve = new RetrieveEsiData();
+    $retrieve = new RetrieveEsiData;
 
     $request_container = new EsiRequestContainer(
         method: 'get',
@@ -28,7 +28,7 @@ test('it returns client for an authenticated request', function () {
         return RefreshToken::factory()->create();
     });
 
-    $retrieve = new RetrieveEsiData();
+    $retrieve = new RetrieveEsiData;
 
     $request_container = new EsiRequestContainer(
         method: 'get',
@@ -58,7 +58,7 @@ it('updates outdated refresh_tokens', function () {
         'expires_on' => now()->addSeconds(50),
     ]);
 
-    $retrieve = new RetrieveEsiData();
+    $retrieve = new RetrieveEsiData;
 
     $request_container = new EsiRequestContainer(
         method: 'get',


### PR DESCRIPTION
Extend maintenance job with  GetMissingCharacterInfos to handle missing character information

It could happen that refresh_tokens were present but the character was not. This may cause errors

This addresses partially https://github.com/seatplus/eveapi/issues/665