### PR TITLE
Use null-safe operator for character properties access

### DIFF
--- a/src/Jobs/Seatplus/Batch/CharacterBatchJob.php
+++ b/src/Jobs/Seatplus/Batch/CharacterBatchJob.php
@@ -186,7 +186,7 @@ class CharacterBatchJob implements ShouldBeUnique, ShouldQueue
         }
 
         // Get corporation_id from character
-        $corporation_id = $this->refresh_token->character->corporation_id;
+        $corporation_id = $this->refresh_token->character?->corporation_id;
 
         // Return empty array if character has no corporation, this should never happen but just in case
         if (! $corporation_id) {
@@ -209,7 +209,7 @@ class CharacterBatchJob implements ShouldBeUnique, ShouldQueue
         }
 
         // Get alliance_id from character
-        $alliance_id = $this->refresh_token->character->alliance_id;
+        $alliance_id = $this->refresh_token->character?->alliance_id;
 
         // Return empty array if character has no alliance
         if (! $alliance_id) {


### PR DESCRIPTION
Refactored character property access to use the null-safe operator (`?->`) for `corporation_id` and `alliance_id`. This ensures that the code handles cases where the `character` object may be null, improving overall robustness and preventing potential errors.

This addresses #665 