### PR TITLE
chore: upgrade to Laravel 13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,22 +22,22 @@
             "Seatplus\\Eveapi\\Tests\\": "tests/"
         }
     },
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
         "php": "^8.5",
         "ext-json": "*",
         "ext-redis": "*",
-        "laravel/framework": "^11.0",
+        "laravel/framework": "^13.0",
         "laravel/horizon": "^5.0",
         "seatplus/esi-client": "^4.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^9.0",
+        "orchestra/testbench": "^11.0",
         "nunomaduro/collision": "^v8.1",
         "itsgoingd/clockwork": "^5.0",
         "pestphp/pest": "^4.0",
-        "pestphp/pest-plugin-laravel": "^4.0",
+        "pestphp/pest-plugin-laravel": "^4.1",
         "pestphp/pest-plugin-type-coverage": "^4.0",
         "phpstan/phpstan-deprecation-rules": "^2.0",
         "phpstan/phpstan-phpunit": "^2.0",
@@ -80,6 +80,10 @@
                 "symlink": true,
                 "canonical": false
             }
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/seatplus/esi-schema"
         }
     ]
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3f70bee3d8d4a3b31a0cf4e6cfa98949",
+    "content-hash": "b1a3279130588cd78b0aee723c36602a",
     "packages": [
         {
             "name": "brick/math",
@@ -1204,24 +1204,24 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v11.51.0",
+            "version": "v13.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "c8f9a04594b7044a189a3194cfb3594251eb74e5"
+                "reference": "e7db333a025a1e93ebca7744953069d7719f4bcf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/c8f9a04594b7044a189a3194cfb3594251eb74e5",
-                "reference": "c8f9a04594b7044a189a3194cfb3594251eb74e5",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/e7db333a025a1e93ebca7744953069d7719f4bcf",
+                "reference": "e7db333a025a1e93ebca7744953069d7719f4bcf",
                 "shasum": ""
             },
             "require": {
-                "brick/math": "^0.9.3|^0.10.2|^0.11|^0.12|^0.13|^0.14",
+                "brick/math": "^0.14.2 || ^0.15 || ^0.16 || ^0.17",
                 "composer-runtime-api": "^2.2",
                 "doctrine/inflector": "^2.0.5",
                 "dragonmantank/cron-expression": "^3.4",
-                "egulias/email-validator": "^3.2.1|^4.0",
+                "egulias/email-validator": "^4.0",
                 "ext-ctype": "*",
                 "ext-filter": "*",
                 "ext-hash": "*",
@@ -1231,33 +1231,36 @@
                 "ext-tokenizer": "*",
                 "fruitcake/php-cors": "^1.3",
                 "guzzlehttp/guzzle": "^7.8.2",
+                "guzzlehttp/promises": "^2.0.3",
                 "guzzlehttp/uri-template": "^1.0",
-                "laravel/prompts": "^0.1.18|^0.2.0|^0.3.0",
-                "laravel/serializable-closure": "^1.3|^2.0",
-                "league/commonmark": "^2.7",
+                "laravel/prompts": "^0.3.0",
+                "laravel/serializable-closure": "^2.0.10",
+                "league/commonmark": "^2.8.1",
                 "league/flysystem": "^3.25.1",
                 "league/flysystem-local": "^3.25.1",
                 "league/uri": "^7.5.1",
                 "monolog/monolog": "^3.0",
-                "nesbot/carbon": "^2.72.6|^3.8.4",
+                "nesbot/carbon": "^3.8.4",
                 "nunomaduro/termwind": "^2.0",
-                "php": "^8.2",
-                "psr/container": "^1.1.1|^2.0.1",
-                "psr/log": "^1.0|^2.0|^3.0",
-                "psr/simple-cache": "^1.0|^2.0|^3.0",
+                "php": "^8.3",
+                "psr/container": "^1.1.1 || ^2.0.1",
+                "psr/log": "^1.0 || ^2.0 || ^3.0",
+                "psr/simple-cache": "^1.0 || ^2.0 || ^3.0",
                 "ramsey/uuid": "^4.7",
-                "symfony/console": "^7.0.3",
-                "symfony/error-handler": "^7.0.3",
-                "symfony/finder": "^7.0.3",
-                "symfony/http-foundation": "^7.2.0",
-                "symfony/http-kernel": "^7.0.3",
-                "symfony/mailer": "^7.0.3",
-                "symfony/mime": "^7.0.3",
-                "symfony/polyfill-php83": "^1.31",
-                "symfony/process": "^7.0.3",
-                "symfony/routing": "^7.0.3",
-                "symfony/uid": "^7.0.3",
-                "symfony/var-dumper": "^7.0.3",
+                "symfony/console": "^7.4.0 || ^8.0.0",
+                "symfony/error-handler": "^7.4.0 || ^8.0.0",
+                "symfony/finder": "^7.4.0 || ^8.0.0",
+                "symfony/http-foundation": "^7.4.0 || ^8.0.0",
+                "symfony/http-kernel": "^7.4.0 || ^8.0.0",
+                "symfony/mailer": "^7.4.0 || ^8.0.0",
+                "symfony/mime": "^7.4.0 || ^8.0.0",
+                "symfony/polyfill-php84": "^1.36",
+                "symfony/polyfill-php85": "^1.36",
+                "symfony/polyfill-php86": "^1.36",
+                "symfony/process": "^7.4.5 || ^8.0.5",
+                "symfony/routing": "^7.4.0 || ^8.0.0",
+                "symfony/uid": "^7.4.0 || ^8.0.0",
+                "symfony/var-dumper": "^7.4.0 || ^8.0.0",
                 "tijsverkoyen/css-to-inline-styles": "^2.2.5",
                 "vlucas/phpdotenv": "^5.6.1",
                 "voku/portable-ascii": "^2.0.2"
@@ -1266,9 +1269,9 @@
                 "tightenco/collect": "<5.5.33"
             },
             "provide": {
-                "psr/container-implementation": "1.1|2.0",
-                "psr/log-implementation": "1.0|2.0|3.0",
-                "psr/simple-cache-implementation": "1.0|2.0|3.0"
+                "psr/container-implementation": "1.1 || 2.0",
+                "psr/log-implementation": "1.0 || 2.0 || 3.0",
+                "psr/simple-cache-implementation": "1.0 || 2.0 || 3.0"
             },
             "replace": {
                 "illuminate/auth": "self.version",
@@ -1289,6 +1292,7 @@
                 "illuminate/filesystem": "self.version",
                 "illuminate/hashing": "self.version",
                 "illuminate/http": "self.version",
+                "illuminate/json-schema": "self.version",
                 "illuminate/log": "self.version",
                 "illuminate/macroable": "self.version",
                 "illuminate/mail": "self.version",
@@ -1298,6 +1302,7 @@
                 "illuminate/process": "self.version",
                 "illuminate/queue": "self.version",
                 "illuminate/redis": "self.version",
+                "illuminate/reflection": "self.version",
                 "illuminate/routing": "self.version",
                 "illuminate/session": "self.version",
                 "illuminate/support": "self.version",
@@ -1312,7 +1317,6 @@
                 "aws/aws-sdk-php": "^3.322.9",
                 "ext-gmp": "*",
                 "fakerphp/faker": "^1.24",
-                "guzzlehttp/promises": "^2.0.3",
                 "guzzlehttp/psr7": "^2.4",
                 "laravel/pint": "^1.18",
                 "league/flysystem-aws-s3-v3": "^3.25.1",
@@ -1321,22 +1325,24 @@
                 "league/flysystem-read-only": "^3.25.1",
                 "league/flysystem-sftp-v3": "^3.25.1",
                 "mockery/mockery": "^1.6.10",
-                "orchestra/testbench-core": "^9.18.0",
-                "pda/pheanstalk": "^5.0.6",
+                "opis/json-schema": "^2.4.1",
+                "orchestra/testbench-core": "^11.0.0",
+                "pda/pheanstalk": "^7.0.0 || ^8.0.0",
                 "php-http/discovery": "^1.15",
-                "phpstan/phpstan": "2.1.41",
-                "phpunit/phpunit": "^10.5.35|^11.3.6|^12.0.1",
-                "predis/predis": "^2.3",
-                "resend/resend-php": "^0.10.0",
-                "symfony/cache": "^7.0.3",
-                "symfony/http-client": "^7.0.3",
-                "symfony/psr-http-message-bridge": "^7.0.3",
-                "symfony/translation": "^7.0.3"
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^11.5.50 || ^12.5.8 || ^13.0.3",
+                "predis/predis": "^2.3 || ^3.0",
+                "rector/rector": "^2.3",
+                "resend/resend-php": "^1.0",
+                "symfony/cache": "^7.4.0 || ^8.0.0",
+                "symfony/http-client": "^7.4.0 || ^8.0.0",
+                "symfony/psr-http-message-bridge": "^7.4.0 || ^8.0.0",
+                "symfony/translation": "^7.4.0 || ^8.0.0"
             },
             "suggest": {
                 "ably/ably-php": "Required to use the Ably broadcast driver (^1.0).",
                 "aws/aws-sdk-php": "Required to use the SQS queue driver, DynamoDb failed job storage, and SES mail driver (^3.322.9).",
-                "brianium/paratest": "Required to run tests in parallel (^7.0|^8.0).",
+                "brianium/paratest": "Required to run tests in parallel (^7.0 || ^8.0).",
                 "ext-apcu": "Required to use the APC cache driver.",
                 "ext-fileinfo": "Required to use the Filesystem class.",
                 "ext-ftp": "Required to use the Flysystem FTP driver.",
@@ -1345,8 +1351,8 @@
                 "ext-pcntl": "Required to use all features of the queue worker and console signal trapping.",
                 "ext-pdo": "Required to use all database features.",
                 "ext-posix": "Required to use all features of the queue worker.",
-                "ext-redis": "Required to use the Redis cache and queue drivers (^4.0|^5.0|^6.0).",
-                "fakerphp/faker": "Required to use the eloquent factory builder (^1.9.1).",
+                "ext-redis": "Required to use the Redis cache and queue drivers (^4.0 || ^5.0 || ^6.0).",
+                "fakerphp/faker": "Required to generate fake data using the fake() helper (^1.23).",
                 "filp/whoops": "Required for friendly error pages in development (^2.14.3).",
                 "laravel/tinker": "Required to use the tinker console command (^2.0).",
                 "league/flysystem-aws-s3-v3": "Required to use the Flysystem S3 driver (^3.25.1).",
@@ -1355,24 +1361,25 @@
                 "league/flysystem-read-only": "Required to use read-only disks (^3.25.1)",
                 "league/flysystem-sftp-v3": "Required to use the Flysystem SFTP driver (^3.25.1).",
                 "mockery/mockery": "Required to use mocking (^1.6).",
-                "pda/pheanstalk": "Required to use the beanstalk queue driver (^5.0).",
+                "pda/pheanstalk": "Required to use the beanstalk queue driver (^7.0 || ^8.0).",
                 "php-http/discovery": "Required to use PSR-7 bridging features (^1.15).",
-                "phpunit/phpunit": "Required to use assertions and run tests (^10.5.35|^11.3.6|^12.0.1).",
-                "predis/predis": "Required to use the predis connector (^2.3).",
+                "phpunit/phpunit": "Required to use assertions and run tests (^11.5.50 || ^12.5.8 || ^13.0.3).",
+                "predis/predis": "Required to use the predis connector (^2.3 || ^3.0).",
                 "psr/http-message": "Required to allow Storage::put to accept a StreamInterface (^1.0).",
-                "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^6.0|^7.0).",
-                "resend/resend-php": "Required to enable support for the Resend mail transport (^0.10.0).",
-                "symfony/cache": "Required to PSR-6 cache bridge (^7.0).",
-                "symfony/filesystem": "Required to enable support for relative symbolic links (^7.0).",
-                "symfony/http-client": "Required to enable support for the Symfony API mail transports (^7.0).",
-                "symfony/mailgun-mailer": "Required to enable support for the Mailgun mail transport (^7.0).",
-                "symfony/postmark-mailer": "Required to enable support for the Postmark mail transport (^7.0).",
-                "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^7.0)."
+                "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^6.0 || ^7.0).",
+                "resend/resend-php": "Required to enable support for the Resend mail transport (^0.10.0 || ^1.0).",
+                "spatie/fork": "Required to use the 'fork' concurrency driver (^1.2).",
+                "symfony/cache": "Required to PSR-6 cache bridge (^7.4 || ^8.0).",
+                "symfony/filesystem": "Required to enable support for relative symbolic links (^7.4 || ^8.0).",
+                "symfony/http-client": "Required to enable support for the Symfony API mail transports (^7.4 || ^8.0).",
+                "symfony/mailgun-mailer": "Required to enable support for the Mailgun mail transport (^7.4 || ^8.0).",
+                "symfony/postmark-mailer": "Required to enable support for the Postmark mail transport (^7.4 || ^8.0).",
+                "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^7.4 || ^8.0)."
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "11.x-dev"
+                    "dev-master": "13.0.x-dev"
                 }
             },
             "autoload": {
@@ -1383,6 +1390,7 @@
                     "src/Illuminate/Filesystem/functions.php",
                     "src/Illuminate/Foundation/helpers.php",
                     "src/Illuminate/Log/functions.php",
+                    "src/Illuminate/Reflection/helpers.php",
                     "src/Illuminate/Support/functions.php",
                     "src/Illuminate/Support/helpers.php"
                 ],
@@ -1391,7 +1399,8 @@
                     "Illuminate\\Support\\": [
                         "src/Illuminate/Macroable/",
                         "src/Illuminate/Collections/",
-                        "src/Illuminate/Conditionable/"
+                        "src/Illuminate/Conditionable/",
+                        "src/Illuminate/Reflection/"
                     ]
                 }
             },
@@ -1415,7 +1424,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2026-03-26T14:54:53+00:00"
+            "time": "2026-05-05T21:01:14+00:00"
         },
         {
             "name": "laravel/horizon",
@@ -2337,42 +2346,40 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "2.73.0",
+            "version": "3.11.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/CarbonPHP/carbon.git",
-                "reference": "9228ce90e1035ff2f0db84b40ec2e023ed802075"
+                "reference": "e890471a3494740f7d9326d72ce6a8c559ffee60"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/9228ce90e1035ff2f0db84b40ec2e023ed802075",
-                "reference": "9228ce90e1035ff2f0db84b40ec2e023ed802075",
+                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/e890471a3494740f7d9326d72ce6a8c559ffee60",
+                "reference": "e890471a3494740f7d9326d72ce6a8c559ffee60",
                 "shasum": ""
             },
             "require": {
-                "carbonphp/carbon-doctrine-types": "*",
+                "carbonphp/carbon-doctrine-types": "<100.0",
                 "ext-json": "*",
-                "php": "^7.1.8 || ^8.0",
+                "php": "^8.1",
                 "psr/clock": "^1.0",
+                "symfony/clock": "^6.3.12 || ^7.0 || ^8.0",
                 "symfony/polyfill-mbstring": "^1.0",
-                "symfony/polyfill-php80": "^1.16",
-                "symfony/translation": "^3.4 || ^4.0 || ^5.0 || ^6.0"
+                "symfony/translation": "^4.4.18 || ^5.2.1 || ^6.0 || ^7.0 || ^8.0"
             },
             "provide": {
                 "psr/clock-implementation": "1.0"
             },
             "require-dev": {
-                "doctrine/dbal": "^2.0 || ^3.1.4 || ^4.0",
-                "doctrine/orm": "^2.7 || ^3.0",
-                "friendsofphp/php-cs-fixer": "^3.0",
-                "kylekatarnls/multi-tester": "^2.0",
-                "ondrejmirtes/better-reflection": "<6",
-                "phpmd/phpmd": "^2.9",
-                "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "^0.12.99 || ^1.7.14",
-                "phpunit/php-file-iterator": "^2.0.5 || ^3.0.6",
-                "phpunit/phpunit": "^7.5.20 || ^8.5.26 || ^9.5.20",
-                "squizlabs/php_codesniffer": "^3.4"
+                "doctrine/dbal": "^3.6.3 || ^4.0",
+                "doctrine/orm": "^2.15.2 || ^3.0",
+                "friendsofphp/php-cs-fixer": "^v3.87.1",
+                "kylekatarnls/multi-tester": "^2.5.3",
+                "phpmd/phpmd": "^2.15.0",
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^2.1.22",
+                "phpunit/phpunit": "^10.5.53",
+                "squizlabs/php_codesniffer": "^3.13.4 || ^4.0.0"
             },
             "bin": [
                 "bin/carbon"
@@ -2415,16 +2422,16 @@
                 }
             ],
             "description": "An API extension for DateTime that supports 281 different languages.",
-            "homepage": "https://carbon.nesbot.com",
+            "homepage": "https://carbonphp.github.io/carbon/",
             "keywords": [
                 "date",
                 "datetime",
                 "time"
             ],
             "support": {
-                "docs": "https://carbon.nesbot.com/docs",
-                "issues": "https://github.com/briannesbitt/Carbon/issues",
-                "source": "https://github.com/briannesbitt/Carbon"
+                "docs": "https://carbonphp.github.io/carbon/guide/getting-started/introduction.html",
+                "issues": "https://github.com/CarbonPHP/carbon/issues",
+                "source": "https://github.com/CarbonPHP/carbon"
             },
             "funding": [
                 {
@@ -2440,7 +2447,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-01-08T20:10:23+00:00"
+            "time": "2026-04-07T09:57:54+00:00"
         },
         {
             "name": "nette/schema",
@@ -2511,16 +2518,16 @@
         },
         {
             "name": "nette/utils",
-            "version": "v4.1.3",
+            "version": "v4.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/utils.git",
-                "reference": "bb3ea637e3d131d72acc033cfc2746ee893349fe"
+                "reference": "7da6c396d7ebe142bc857c20479d5e70a5e1aac7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/utils/zipball/bb3ea637e3d131d72acc033cfc2746ee893349fe",
-                "reference": "bb3ea637e3d131d72acc033cfc2746ee893349fe",
+                "url": "https://api.github.com/repos/nette/utils/zipball/7da6c396d7ebe142bc857c20479d5e70a5e1aac7",
+                "reference": "7da6c396d7ebe142bc857c20479d5e70a5e1aac7",
                 "shasum": ""
             },
             "require": {
@@ -2596,9 +2603,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/utils/issues",
-                "source": "https://github.com/nette/utils/tree/v4.1.3"
+                "source": "https://github.com/nette/utils/tree/v4.1.4"
             },
-            "time": "2026-02-13T03:05:33+00:00"
+            "time": "2026-05-11T20:49:54+00:00"
         },
         {
             "name": "nunomaduro/termwind",
@@ -3378,15 +3385,16 @@
             "dist": {
                 "type": "path",
                 "url": "../esi-client",
-                "reference": "bc756000b9eb43fc341317c03bd0682c9b20a153"
+                "reference": "66e886b3bd965637267caa6ac619471b55276646"
             },
             "require": {
                 "ext-json": "*",
                 "firebase/php-jwt": "^7.0",
                 "kevinrob/guzzle-cache-middleware": "^4.0",
                 "monolog/monolog": "^3.7",
-                "nesbot/carbon": "^2.53",
-                "php": "^8.5"
+                "nesbot/carbon": "^3.0",
+                "php": "^8.5",
+                "seatplus/esi-schema": "dev-fix/ci-phpunit-config as 1.x-dev"
             },
             "require-dev": {
                 "ext-openssl": "*",
@@ -3399,7 +3407,8 @@
                 "pestphp/pest": "^4.0",
                 "pestphp/pest-plugin-type-coverage": "^4.0",
                 "phpstan/phpstan": "^2.1.46",
-                "rector/rector": "^2.0"
+                "rector/rector": "^2.0",
+                "symfony/yaml": "^8.0"
             },
             "type": "library",
             "autoload": {
@@ -3469,48 +3478,186 @@
             }
         },
         {
-            "name": "symfony/console",
-            "version": "v7.4.9",
+            "name": "seatplus/esi-schema",
+            "version": "dev-fix/ci-phpunit-config",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/console.git",
-                "reference": "d7d2b64a45a89d607865927b176fa51c33ddbb58"
+                "url": "https://github.com/seatplus/esi-schema.git",
+                "reference": "e235c1142c472a2e5374b584087b78dfb7c92e84"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/d7d2b64a45a89d607865927b176fa51c33ddbb58",
-                "reference": "d7d2b64a45a89d607865927b176fa51c33ddbb58",
+                "url": "https://api.github.com/repos/seatplus/esi-schema/zipball/e235c1142c472a2e5374b584087b78dfb7c92e84",
+                "reference": "e235c1142c472a2e5374b584087b78dfb7c92e84",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/polyfill-mbstring": "~1.0",
-                "symfony/service-contracts": "^2.5|^3",
-                "symfony/string": "^7.2|^8.0"
+                "php": "^8.3"
             },
-            "conflict": {
-                "symfony/dependency-injection": "<6.4",
-                "symfony/dotenv": "<6.4",
-                "symfony/event-dispatcher": "<6.4",
-                "symfony/lock": "<6.4",
-                "symfony/process": "<6.4"
+            "require-dev": {
+                "laravel/pint": "^1.0",
+                "monolog/monolog": "^3.0",
+                "pestphp/pest": "^3.0",
+                "pestphp/pest-plugin-type-coverage": "^3.0",
+                "phpstan/phpstan": "^2.0",
+                "symfony/yaml": "^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Seatplus\\EsiSchema\\": "src/"
+                }
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "@test:lint",
+                    "@test:types",
+                    "@test:type-coverage",
+                    "@test:unit"
+                ],
+                "test:unit": [
+                    "vendor/bin/pest --no-coverage"
+                ],
+                "test:lint": [
+                    "vendor/bin/pint --test"
+                ],
+                "lint": [
+                    "vendor/bin/pint"
+                ],
+                "test:types": [
+                    "vendor/bin/phpstan analyse --no-progress"
+                ],
+                "test:type-coverage": [
+                    "vendor/bin/pest --type-coverage --min=100"
+                ]
+            },
+            "license": [
+                "MIT"
+            ],
+            "description": "Generated ESI response DTOs, versioned independently by ESI compatibility date. Zero runtime dependencies.",
+            "support": {
+                "source": "https://github.com/seatplus/esi-schema/tree/fix/ci-phpunit-config",
+                "issues": "https://github.com/seatplus/esi-schema/issues"
+            },
+            "time": "2026-05-12T20:00:14+00:00"
+        },
+        {
+            "name": "symfony/clock",
+            "version": "v8.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/clock.git",
+                "reference": "b55a638b189a6faa875e0ccdb00908fb87af95b3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/clock/zipball/b55a638b189a6faa875e0ccdb00908fb87af95b3",
+                "reference": "b55a638b189a6faa875e0ccdb00908fb87af95b3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "psr/clock": "^1.0"
+            },
+            "provide": {
+                "psr/clock-implementation": "1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/now.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\Clock\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Decouples applications from the system clock",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "clock",
+                "psr20",
+                "time"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/clock/tree/v8.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-30T15:14:47+00:00"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v8.0.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "7113778e2e91f4709cb3194a75dfa9c0d028d94d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/7113778e2e91f4709cb3194a75dfa9c0d028d94d",
+                "reference": "7113778e2e91f4709cb3194a75dfa9c0d028d94d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "symfony/polyfill-mbstring": "^1.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/string": "^7.4|^8.0"
             },
             "provide": {
                 "psr/log-implementation": "1.0|2.0|3.0"
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^6.4|^7.0|^8.0",
-                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
-                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
-                "symfony/http-foundation": "^6.4|^7.0|^8.0",
-                "symfony/http-kernel": "^6.4|^7.0|^8.0",
-                "symfony/lock": "^6.4|^7.0|^8.0",
-                "symfony/messenger": "^6.4|^7.0|^8.0",
-                "symfony/process": "^6.4|^7.0|^8.0",
-                "symfony/stopwatch": "^6.4|^7.0|^8.0",
-                "symfony/var-dumper": "^6.4|^7.0|^8.0"
+                "symfony/config": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/event-dispatcher": "^7.4|^8.0",
+                "symfony/http-foundation": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/lock": "^7.4|^8.0",
+                "symfony/messenger": "^7.4|^8.0",
+                "symfony/process": "^7.4|^8.0",
+                "symfony/stopwatch": "^7.4|^8.0",
+                "symfony/var-dumper": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -3544,7 +3691,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.4.9"
+                "source": "https://github.com/symfony/console/tree/v8.0.9"
             },
             "funding": [
                 {
@@ -3564,7 +3711,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-22T15:21:55+00:00"
+            "time": "2026-04-29T15:02:55+00:00"
         },
         {
             "name": "symfony/css-selector",
@@ -3708,33 +3855,32 @@
         },
         {
             "name": "symfony/error-handler",
-            "version": "v7.4.8",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/error-handler.git",
-                "reference": "8dd79d8af777ee6cba2fd4d98da6ffb839f3c0fa"
+                "reference": "c1119fe8dcfc3825ec74ec061b96ef0c8f281517"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/error-handler/zipball/8dd79d8af777ee6cba2fd4d98da6ffb839f3c0fa",
-                "reference": "8dd79d8af777ee6cba2fd4d98da6ffb839f3c0fa",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/c1119fe8dcfc3825ec74ec061b96ef0c8f281517",
+                "reference": "c1119fe8dcfc3825ec74ec061b96ef0c8f281517",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
+                "php": ">=8.4",
                 "psr/log": "^1|^2|^3",
                 "symfony/polyfill-php85": "^1.32",
-                "symfony/var-dumper": "^6.4|^7.0|^8.0"
+                "symfony/var-dumper": "^7.4|^8.0"
             },
             "conflict": {
-                "symfony/deprecation-contracts": "<2.5",
-                "symfony/http-kernel": "<6.4"
+                "symfony/deprecation-contracts": "<2.5"
             },
             "require-dev": {
-                "symfony/console": "^6.4|^7.0|^8.0",
+                "symfony/console": "^7.4|^8.0",
                 "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/http-kernel": "^6.4|^7.0|^8.0",
-                "symfony/serializer": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/serializer": "^7.4|^8.0",
                 "symfony/webpack-encore-bundle": "^1.0|^2.0"
             },
             "bin": [
@@ -3766,7 +3912,7 @@
             "description": "Provides tools to manage errors and ease debugging PHP code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/error-handler/tree/v7.4.8"
+                "source": "https://github.com/symfony/error-handler/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -3786,7 +3932,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -3955,23 +4101,23 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v7.4.8",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "e0be088d22278583a82da281886e8c3592fbf149"
+                "reference": "8da41214757b87d97f181e3d14a4179286151007"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/e0be088d22278583a82da281886e8c3592fbf149",
-                "reference": "e0be088d22278583a82da281886e8c3592fbf149",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/8da41214757b87d97f181e3d14a4179286151007",
+                "reference": "8da41214757b87d97f181e3d14a4179286151007",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "symfony/filesystem": "^6.4|^7.0|^8.0"
+                "symfony/filesystem": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -3999,7 +4145,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v7.4.8"
+                "source": "https://github.com/symfony/finder/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -4019,41 +4165,39 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v7.4.8",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "9381209597ec66c25be154cbf2289076e64d1eab"
+                "reference": "02656f7ebeae5c155d659e946f6b3a33df24051b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/9381209597ec66c25be154cbf2289076e64d1eab",
-                "reference": "9381209597ec66c25be154cbf2289076e64d1eab",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/02656f7ebeae5c155d659e946f6b3a33df24051b",
+                "reference": "02656f7ebeae5c155d659e946f6b3a33df24051b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3",
+                "php": ">=8.4",
                 "symfony/polyfill-mbstring": "^1.1"
             },
             "conflict": {
-                "doctrine/dbal": "<3.6",
-                "symfony/cache": "<6.4.12|>=7.0,<7.1.5"
+                "doctrine/dbal": "<4.3"
             },
             "require-dev": {
-                "doctrine/dbal": "^3.6|^4",
+                "doctrine/dbal": "^4.3",
                 "predis/predis": "^1.1|^2.0",
-                "symfony/cache": "^6.4.12|^7.1.5|^8.0",
-                "symfony/clock": "^6.4|^7.0|^8.0",
-                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
-                "symfony/expression-language": "^6.4|^7.0|^8.0",
-                "symfony/http-kernel": "^6.4|^7.0|^8.0",
-                "symfony/mime": "^6.4|^7.0|^8.0",
-                "symfony/rate-limiter": "^6.4|^7.0|^8.0"
+                "symfony/cache": "^7.4|^8.0",
+                "symfony/clock": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/expression-language": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/mime": "^7.4|^8.0",
+                "symfony/rate-limiter": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -4081,7 +4225,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v7.4.8"
+                "source": "https://github.com/symfony/http-foundation/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -4101,78 +4245,63 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v7.4.10",
+            "version": "v8.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "23486f59234c6fd6e8f1bec97124f3829d686627"
+                "reference": "fb3f65b3d4ca2dad31c80d323819a762ca31d6ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/23486f59234c6fd6e8f1bec97124f3829d686627",
-                "reference": "23486f59234c6fd6e8f1bec97124f3829d686627",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/fb3f65b3d4ca2dad31c80d323819a762ca31d6ac",
+                "reference": "fb3f65b3d4ca2dad31c80d323819a762ca31d6ac",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
+                "php": ">=8.4",
                 "psr/log": "^1|^2|^3",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/error-handler": "^6.4|^7.0|^8.0",
-                "symfony/event-dispatcher": "^7.3|^8.0",
+                "symfony/error-handler": "^7.4|^8.0",
+                "symfony/event-dispatcher": "^7.4|^8.0",
                 "symfony/http-foundation": "^7.4|^8.0",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
-                "symfony/browser-kit": "<6.4",
-                "symfony/cache": "<6.4",
-                "symfony/config": "<6.4",
-                "symfony/console": "<6.4",
-                "symfony/dependency-injection": "<6.4",
-                "symfony/doctrine-bridge": "<6.4",
                 "symfony/flex": "<2.10",
-                "symfony/form": "<6.4",
-                "symfony/http-client": "<6.4",
                 "symfony/http-client-contracts": "<2.5",
-                "symfony/mailer": "<6.4",
-                "symfony/messenger": "<6.4",
-                "symfony/translation": "<6.4",
                 "symfony/translation-contracts": "<2.5",
-                "symfony/twig-bridge": "<6.4",
-                "symfony/validator": "<6.4",
-                "symfony/var-dumper": "<6.4",
-                "twig/twig": "<3.12"
+                "twig/twig": "<3.21"
             },
             "provide": {
                 "psr/log-implementation": "1.0|2.0|3.0"
             },
             "require-dev": {
                 "psr/cache": "^1.0|^2.0|^3.0",
-                "symfony/browser-kit": "^6.4|^7.0|^8.0",
-                "symfony/clock": "^6.4|^7.0|^8.0",
-                "symfony/config": "^6.4|^7.0|^8.0",
-                "symfony/console": "^6.4|^7.0|^8.0",
-                "symfony/css-selector": "^6.4|^7.0|^8.0",
-                "symfony/dependency-injection": "^6.4.1|^7.0.1|^8.0",
-                "symfony/dom-crawler": "^6.4|^7.0|^8.0",
-                "symfony/expression-language": "^6.4|^7.0|^8.0",
-                "symfony/finder": "^6.4|^7.0|^8.0",
+                "symfony/browser-kit": "^7.4|^8.0",
+                "symfony/clock": "^7.4|^8.0",
+                "symfony/config": "^7.4|^8.0",
+                "symfony/console": "^7.4|^8.0",
+                "symfony/css-selector": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/dom-crawler": "^7.4|^8.0",
+                "symfony/expression-language": "^7.4|^8.0",
+                "symfony/finder": "^7.4|^8.0",
                 "symfony/http-client-contracts": "^2.5|^3",
-                "symfony/process": "^6.4|^7.0|^8.0",
-                "symfony/property-access": "^7.1|^8.0",
-                "symfony/routing": "^6.4|^7.0|^8.0",
-                "symfony/serializer": "^7.1|^8.0",
-                "symfony/stopwatch": "^6.4|^7.0|^8.0",
-                "symfony/translation": "^6.4|^7.0|^8.0",
+                "symfony/process": "^7.4|^8.0",
+                "symfony/property-access": "^7.4|^8.0",
+                "symfony/routing": "^7.4|^8.0",
+                "symfony/serializer": "^7.4|^8.0",
+                "symfony/stopwatch": "^7.4|^8.0",
+                "symfony/translation": "^7.4|^8.0",
                 "symfony/translation-contracts": "^2.5|^3",
-                "symfony/uid": "^6.4|^7.0|^8.0",
-                "symfony/validator": "^6.4|^7.0|^8.0",
-                "symfony/var-dumper": "^6.4|^7.0|^8.0",
-                "symfony/var-exporter": "^6.4|^7.0|^8.0",
-                "twig/twig": "^3.12"
+                "symfony/uid": "^7.4|^8.0",
+                "symfony/validator": "^7.4|^8.0",
+                "symfony/var-dumper": "^7.4|^8.0",
+                "symfony/var-exporter": "^7.4|^8.0",
+                "twig/twig": "^3.21"
             },
             "type": "library",
             "autoload": {
@@ -4200,7 +4329,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v7.4.10"
+                "source": "https://github.com/symfony/http-kernel/tree/v8.0.10"
             },
             "funding": [
                 {
@@ -4220,43 +4349,39 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-06T12:07:34+00:00"
+            "time": "2026-05-06T12:27:31+00:00"
         },
         {
             "name": "symfony/mailer",
-            "version": "v7.4.8",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mailer.git",
-                "reference": "f6ea532250b476bfc1b56699b388a1bdbf168f62"
+                "reference": "ca5f6edaf8780ece814404b58a4482b22b509c56"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mailer/zipball/f6ea532250b476bfc1b56699b388a1bdbf168f62",
-                "reference": "f6ea532250b476bfc1b56699b388a1bdbf168f62",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/ca5f6edaf8780ece814404b58a4482b22b509c56",
+                "reference": "ca5f6edaf8780ece814404b58a4482b22b509c56",
                 "shasum": ""
             },
             "require": {
                 "egulias/email-validator": "^2.1.10|^3|^4",
-                "php": ">=8.2",
+                "php": ">=8.4",
                 "psr/event-dispatcher": "^1",
                 "psr/log": "^1|^2|^3",
-                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
-                "symfony/mime": "^7.2|^8.0",
+                "symfony/event-dispatcher": "^7.4|^8.0",
+                "symfony/mime": "^7.4|^8.0",
                 "symfony/service-contracts": "^2.5|^3"
             },
             "conflict": {
-                "symfony/http-client-contracts": "<2.5",
-                "symfony/http-kernel": "<6.4",
-                "symfony/messenger": "<6.4",
-                "symfony/mime": "<6.4",
-                "symfony/twig-bridge": "<6.4"
+                "symfony/http-client-contracts": "<2.5"
             },
             "require-dev": {
-                "symfony/console": "^6.4|^7.0|^8.0",
-                "symfony/http-client": "^6.4|^7.0|^8.0",
-                "symfony/messenger": "^6.4|^7.0|^8.0",
-                "symfony/twig-bridge": "^6.4|^7.0|^8.0"
+                "symfony/console": "^7.4|^8.0",
+                "symfony/http-client": "^7.4|^8.0",
+                "symfony/messenger": "^7.4|^8.0",
+                "symfony/twig-bridge": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -4284,7 +4409,7 @@
             "description": "Helps sending emails",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/mailer/tree/v7.4.8"
+                "source": "https://github.com/symfony/mailer/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -4304,44 +4429,41 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/mime",
-            "version": "v7.4.9",
+            "version": "v8.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "2d550c4758ba4c47519a6667c36553d535705b0c"
+                "reference": "a9fcb293650c054b62a5b406f4e92e7b711ea333"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/2d550c4758ba4c47519a6667c36553d535705b0c",
-                "reference": "2d550c4758ba4c47519a6667c36553d535705b0c",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/a9fcb293650c054b62a5b406f4e92e7b711ea333",
+                "reference": "a9fcb293650c054b62a5b406f4e92e7b711ea333",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3",
+                "php": ">=8.4",
                 "symfony/polyfill-intl-idn": "^1.10",
                 "symfony/polyfill-mbstring": "^1.0"
             },
             "conflict": {
                 "egulias/email-validator": "~3.0.0",
                 "phpdocumentor/reflection-docblock": "<5.2|>=7",
-                "phpdocumentor/type-resolver": "<1.5.1",
-                "symfony/mailer": "<6.4",
-                "symfony/serializer": "<6.4.3|>7.0,<7.0.3"
+                "phpdocumentor/type-resolver": "<1.5.1"
             },
             "require-dev": {
                 "egulias/email-validator": "^2.1.10|^3.1|^4",
                 "league/html-to-markdown": "^5.0",
                 "phpdocumentor/reflection-docblock": "^5.2|^6.0",
-                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
-                "symfony/process": "^6.4|^7.0|^8.0",
-                "symfony/property-access": "^6.4|^7.0|^8.0",
-                "symfony/property-info": "^6.4|^7.0|^8.0",
-                "symfony/serializer": "^6.4.3|^7.0.3|^8.0"
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/process": "^7.4|^8.0",
+                "symfony/property-access": "^7.4|^8.0",
+                "symfony/property-info": "^7.4|^8.0",
+                "symfony/serializer": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -4373,7 +4495,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v7.4.9"
+                "source": "https://github.com/symfony/mime/tree/v8.0.9"
             },
             "funding": [
                 {
@@ -4393,7 +4515,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-29T13:21:53+00:00"
+            "time": "2026-04-29T15:02:55+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -4982,6 +5104,86 @@
             "time": "2026-04-10T17:25:58+00:00"
         },
         {
+            "name": "symfony/polyfill-php84",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php84.git",
+                "reference": "88486db2c389b290bf87ff1de7ebc1e13e42bb06"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/88486db2c389b290bf87ff1de7ebc1e13e42bb06",
+                "reference": "88486db2c389b290bf87ff1de7ebc1e13e42bb06",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php84\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.4+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php84/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T18:47:49+00:00"
+        },
+        {
             "name": "symfony/polyfill-php85",
             "version": "v1.37.0",
             "source": {
@@ -5060,6 +5262,86 @@
                 }
             ],
             "time": "2026-04-26T13:10:57+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php86",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php86.git",
+                "reference": "33d8fc5a705481e21fe3a81212b26f9b1f61749c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php86/zipball/33d8fc5a705481e21fe3a81212b26f9b1f61749c",
+                "reference": "33d8fc5a705481e21fe3a81212b26f9b1f61749c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php86\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.6+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php86/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-26T13:13:48+00:00"
         },
         {
             "name": "symfony/polyfill-uuid",
@@ -5146,20 +5428,20 @@
         },
         {
             "name": "symfony/process",
-            "version": "v7.4.8",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "60f19cd3badc8de688421e21e4305eba50f8089a"
+                "reference": "cb8939aff03470d1a9d1d1b66d08c6fa71b3bbdc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/60f19cd3badc8de688421e21e4305eba50f8089a",
-                "reference": "60f19cd3badc8de688421e21e4305eba50f8089a",
+                "url": "https://api.github.com/repos/symfony/process/zipball/cb8939aff03470d1a9d1d1b66d08c6fa71b3bbdc",
+                "reference": "cb8939aff03470d1a9d1d1b66d08c6fa71b3bbdc",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.4"
             },
             "type": "library",
             "autoload": {
@@ -5187,7 +5469,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v7.4.8"
+                "source": "https://github.com/symfony/process/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -5207,38 +5489,33 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/routing",
-            "version": "v7.4.9",
+            "version": "v8.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "287771d8bc86eacb30678dd10eda6c64a859951f"
+                "reference": "75d1bd8e5da3424e4db2fc3ff0222cb4d0c73038"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/287771d8bc86eacb30678dd10eda6c64a859951f",
-                "reference": "287771d8bc86eacb30678dd10eda6c64a859951f",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/75d1bd8e5da3424e4db2fc3ff0222cb4d0c73038",
+                "reference": "75d1bd8e5da3424e4db2fc3ff0222cb4d0c73038",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
+                "php": ">=8.4",
                 "symfony/deprecation-contracts": "^2.5|^3"
-            },
-            "conflict": {
-                "symfony/config": "<6.4",
-                "symfony/dependency-injection": "<6.4",
-                "symfony/yaml": "<6.4"
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^6.4|^7.0|^8.0",
-                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
-                "symfony/expression-language": "^6.4|^7.0|^8.0",
-                "symfony/http-foundation": "^6.4|^7.0|^8.0",
-                "symfony/yaml": "^6.4|^7.0|^8.0"
+                "symfony/config": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/expression-language": "^7.4|^8.0",
+                "symfony/http-foundation": "^7.4|^8.0",
+                "symfony/yaml": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -5272,7 +5549,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v7.4.9"
+                "source": "https://github.com/symfony/routing/tree/v8.0.9"
             },
             "funding": [
                 {
@@ -5292,7 +5569,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-22T15:21:55+00:00"
+            "time": "2026-04-29T15:02:55+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -5473,51 +5750,45 @@
         },
         {
             "name": "symfony/translation",
-            "version": "v6.4.38",
+            "version": "v8.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "afaa31b0c12d9a659eed1ea97f268a614cc1299c"
+                "reference": "f63e9342e12646a57c91ef8a366a4f9d8e557b67"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/afaa31b0c12d9a659eed1ea97f268a614cc1299c",
-                "reference": "afaa31b0c12d9a659eed1ea97f268a614cc1299c",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/f63e9342e12646a57c91ef8a366a4f9d8e557b67",
+                "reference": "f63e9342e12646a57c91ef8a366a4f9d8e557b67",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/polyfill-mbstring": "~1.0",
-                "symfony/translation-contracts": "^2.5|^3.0"
+                "php": ">=8.4",
+                "symfony/polyfill-mbstring": "^1.0",
+                "symfony/translation-contracts": "^3.6.1"
             },
             "conflict": {
-                "symfony/config": "<5.4",
-                "symfony/console": "<5.4",
-                "symfony/dependency-injection": "<5.4",
+                "nikic/php-parser": "<5.0",
                 "symfony/http-client-contracts": "<2.5",
-                "symfony/http-kernel": "<5.4",
-                "symfony/service-contracts": "<2.5",
-                "symfony/twig-bundle": "<5.4",
-                "symfony/yaml": "<5.4"
+                "symfony/service-contracts": "<2.5"
             },
             "provide": {
                 "symfony/translation-implementation": "2.3|3.0"
             },
             "require-dev": {
-                "nikic/php-parser": "^4.18|^5.0",
+                "nikic/php-parser": "^5.0",
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^5.4|^6.0|^7.0",
-                "symfony/console": "^5.4|^6.0|^7.0",
-                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
-                "symfony/finder": "^5.4|^6.0|^7.0",
+                "symfony/config": "^7.4|^8.0",
+                "symfony/console": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/finder": "^7.4|^8.0",
                 "symfony/http-client-contracts": "^2.5|^3.0",
-                "symfony/http-kernel": "^5.4|^6.0|^7.0",
-                "symfony/intl": "^5.4|^6.0|^7.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/intl": "^7.4|^8.0",
                 "symfony/polyfill-intl-icu": "^1.21",
-                "symfony/routing": "^5.4|^6.0|^7.0",
+                "symfony/routing": "^7.4|^8.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/yaml": "^5.4|^6.0|^7.0"
+                "symfony/yaml": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -5548,7 +5819,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v6.4.38"
+                "source": "https://github.com/symfony/translation/tree/v8.0.10"
             },
             "funding": [
                 {
@@ -5568,7 +5839,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-06T08:55:54+00:00"
+            "time": "2026-05-06T11:30:54+00:00"
         },
         {
             "name": "symfony/translation-contracts",
@@ -5654,24 +5925,24 @@
         },
         {
             "name": "symfony/uid",
-            "version": "v7.4.9",
+            "version": "v8.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/uid.git",
-                "reference": "2676b524340abcfe4d6151ec698463cebafee439"
+                "reference": "4d9d6510bbe88ebb4608b7200d18606cdf80825c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/uid/zipball/2676b524340abcfe4d6151ec698463cebafee439",
-                "reference": "2676b524340abcfe4d6151ec698463cebafee439",
+                "url": "https://api.github.com/repos/symfony/uid/zipball/4d9d6510bbe88ebb4608b7200d18606cdf80825c",
+                "reference": "4d9d6510bbe88ebb4608b7200d18606cdf80825c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
+                "php": ">=8.4",
                 "symfony/polyfill-uuid": "^1.15"
             },
             "require-dev": {
-                "symfony/console": "^6.4|^7.0|^8.0"
+                "symfony/console": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -5708,7 +5979,7 @@
                 "uuid"
             ],
             "support": {
-                "source": "https://github.com/symfony/uid/tree/v7.4.9"
+                "source": "https://github.com/symfony/uid/tree/v8.0.9"
             },
             "funding": [
                 {
@@ -5728,35 +5999,35 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-30T15:19:22+00:00"
+            "time": "2026-04-30T16:10:06+00:00"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v7.4.8",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "9510c3966f749a1d1ff0059e1eabef6cc621e7fd"
+                "reference": "cfb7badd53bf4177f6e9416cfbbccc13c0e773a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/9510c3966f749a1d1ff0059e1eabef6cc621e7fd",
-                "reference": "9510c3966f749a1d1ff0059e1eabef6cc621e7fd",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/cfb7badd53bf4177f6e9416cfbbccc13c0e773a1",
+                "reference": "cfb7badd53bf4177f6e9416cfbbccc13c0e773a1",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/polyfill-mbstring": "~1.0"
+                "php": ">=8.4",
+                "symfony/polyfill-mbstring": "^1.0"
             },
             "conflict": {
-                "symfony/console": "<6.4"
+                "symfony/console": "<7.4",
+                "symfony/error-handler": "<7.4"
             },
             "require-dev": {
-                "symfony/console": "^6.4|^7.0|^8.0",
-                "symfony/http-kernel": "^6.4|^7.0|^8.0",
-                "symfony/process": "^6.4|^7.0|^8.0",
-                "symfony/uid": "^6.4|^7.0|^8.0",
+                "symfony/console": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/process": "^7.4|^8.0",
+                "symfony/uid": "^7.4|^8.0",
                 "twig/twig": "^3.12"
             },
             "bin": [
@@ -5795,7 +6066,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v7.4.8"
+                "source": "https://github.com/symfony/var-dumper/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -5815,7 +6086,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T13:44:50+00:00"
+            "time": "2026-03-31T07:15:36+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",
@@ -7094,33 +7365,33 @@
         },
         {
             "name": "laravel/tinker",
-            "version": "v2.11.1",
+            "version": "v3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/tinker.git",
-                "reference": "c9f80cc835649b5c1842898fb043f8cc098dd741"
+                "reference": "4faba77764bd33411735936acdf30446d058c78b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/tinker/zipball/c9f80cc835649b5c1842898fb043f8cc098dd741",
-                "reference": "c9f80cc835649b5c1842898fb043f8cc098dd741",
+                "url": "https://api.github.com/repos/laravel/tinker/zipball/4faba77764bd33411735936acdf30446d058c78b",
+                "reference": "4faba77764bd33411735936acdf30446d058c78b",
                 "shasum": ""
             },
             "require": {
-                "illuminate/console": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
-                "illuminate/contracts": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
-                "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
-                "php": "^7.2.5|^8.0",
-                "psy/psysh": "^0.11.1|^0.12.0",
-                "symfony/var-dumper": "^4.3.4|^5.0|^6.0|^7.0|^8.0"
+                "illuminate/console": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+                "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+                "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+                "php": "^8.1",
+                "psy/psysh": "^0.12.0",
+                "symfony/var-dumper": "^5.4|^6.0|^7.0|^8.0"
             },
             "require-dev": {
                 "mockery/mockery": "~1.3.3|^1.4.2",
                 "phpstan/phpstan": "^1.10",
-                "phpunit/phpunit": "^8.5.8|^9.3.3|^10.0"
+                "phpunit/phpunit": "^10.5|^11.5"
             },
             "suggest": {
-                "illuminate/database": "The Illuminate Database package (^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0)."
+                "illuminate/database": "The Illuminate Database package (^8.0|^9.0|^10.0|^11.0|^12.0|^13.0)."
             },
             "type": "library",
             "extra": {
@@ -7128,6 +7399,9 @@
                     "providers": [
                         "Laravel\\Tinker\\TinkerServiceProvider"
                     ]
+                },
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
                 }
             },
             "autoload": {
@@ -7154,9 +7428,9 @@
             ],
             "support": {
                 "issues": "https://github.com/laravel/tinker/issues",
-                "source": "https://github.com/laravel/tinker/tree/v2.11.1"
+                "source": "https://github.com/laravel/tinker/tree/v3.0.2"
             },
-            "time": "2026-02-06T14:12:35+00:00"
+            "time": "2026-03-17T14:54:13+00:00"
         },
         {
             "name": "mockery/mockery",
@@ -7536,39 +7810,37 @@
         },
         {
             "name": "orchestra/canvas",
-            "version": "v9.2.2",
+            "version": "v11.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/orchestral/canvas.git",
-                "reference": "002d948834c0899e511f5ac0381669363d7881e5"
+                "reference": "d240410f4cd89b380d7d89b5bbaf60c32f4fb691"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/orchestral/canvas/zipball/002d948834c0899e511f5ac0381669363d7881e5",
-                "reference": "002d948834c0899e511f5ac0381669363d7881e5",
+                "url": "https://api.github.com/repos/orchestral/canvas/zipball/d240410f4cd89b380d7d89b5bbaf60c32f4fb691",
+                "reference": "d240410f4cd89b380d7d89b5bbaf60c32f4fb691",
                 "shasum": ""
             },
             "require": {
                 "composer-runtime-api": "^2.2",
                 "composer/semver": "^3.0",
-                "illuminate/console": "^11.43.0",
-                "illuminate/database": "^11.43.0",
-                "illuminate/filesystem": "^11.43.0",
-                "illuminate/support": "^11.43.0",
-                "orchestra/canvas-core": "^9.1.1",
-                "orchestra/sidekick": "^1.0.2",
-                "orchestra/testbench-core": "^9.11.0",
-                "php": "^8.2",
-                "symfony/polyfill-php83": "^1.31",
-                "symfony/yaml": "^7.0.3"
+                "illuminate/console": "^13.0.0",
+                "illuminate/database": "^13.0.0",
+                "illuminate/filesystem": "^13.0.0",
+                "illuminate/support": "^13.0.0",
+                "orchestra/canvas-core": "^11.0.0",
+                "orchestra/sidekick": "~1.1.23|~1.2.20",
+                "orchestra/testbench-core": "^11.0.0",
+                "php": "^8.3",
+                "symfony/yaml": "^7.4.0|^8.0.0"
             },
             "require-dev": {
-                "laravel/framework": "^11.43.0",
-                "laravel/pint": "^1.21",
+                "laravel/framework": "^13.0.0",
+                "laravel/pint": "^1.24",
                 "mockery/mockery": "^1.6.10",
-                "phpstan/phpstan": "^2.1",
-                "phpunit/phpunit": "^11.5.7",
-                "spatie/laravel-ray": "^1.39.1"
+                "phpstan/phpstan": "^2.1.14",
+                "phpunit/phpunit": "^11.5.50|^12.5.8|^13.0.0"
             },
             "bin": [
                 "canvas"
@@ -7603,41 +7875,40 @@
             "description": "Code Generators for Laravel Applications and Packages",
             "support": {
                 "issues": "https://github.com/orchestral/canvas/issues",
-                "source": "https://github.com/orchestral/canvas/tree/v9.2.2"
+                "source": "https://github.com/orchestral/canvas/tree/v11.0.1"
             },
-            "time": "2025-02-19T04:27:08+00:00"
+            "time": "2026-03-18T22:46:12+00:00"
         },
         {
             "name": "orchestra/canvas-core",
-            "version": "v9.2.0",
+            "version": "v11.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/orchestral/canvas-core.git",
-                "reference": "cd7cf4da17a814cc780b7e85d48ca53cbf8afbb6"
+                "reference": "88d091ff989748e2ca447bca0cd06ab14671ba82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/orchestral/canvas-core/zipball/cd7cf4da17a814cc780b7e85d48ca53cbf8afbb6",
-                "reference": "cd7cf4da17a814cc780b7e85d48ca53cbf8afbb6",
+                "url": "https://api.github.com/repos/orchestral/canvas-core/zipball/88d091ff989748e2ca447bca0cd06ab14671ba82",
+                "reference": "88d091ff989748e2ca447bca0cd06ab14671ba82",
                 "shasum": ""
             },
             "require": {
                 "composer-runtime-api": "^2.2",
                 "composer/semver": "^3.0",
-                "illuminate/console": "^11.43.0",
-                "illuminate/support": "^11.43.0",
+                "illuminate/console": "^13.0",
+                "illuminate/support": "^13.0",
                 "orchestra/sidekick": "~1.1.23|~1.2.20",
-                "php": "^8.2",
-                "symfony/polyfill-php83": "^1.31"
+                "php": "^8.3"
             },
             "require-dev": {
-                "laravel/framework": "^11.43.0",
-                "laravel/pint": "^1.20",
+                "laravel/framework": "^13.0",
+                "laravel/pint": "^1.24",
                 "mockery/mockery": "^1.6.10",
-                "orchestra/testbench-core": "^9.12.0",
+                "orchestra/testbench-core": "^11.0",
                 "phpstan/phpstan": "^2.1.17",
-                "phpunit/phpunit": "^11.5.7",
-                "symfony/yaml": "^7.0.3"
+                "phpunit/phpunit": "^11.5.50|^12.5.8|^13.0.0",
+                "symfony/yaml": "^7.4|^8.0"
             },
             "type": "library",
             "extra": {
@@ -7669,9 +7940,9 @@
             "description": "Code Generators Builder for Laravel Applications and Packages",
             "support": {
                 "issues": "https://github.com/orchestral/canvas/issues",
-                "source": "https://github.com/orchestral/canvas-core/tree/v9.2.0"
+                "source": "https://github.com/orchestral/canvas-core/tree/v11.0.0"
             },
-            "time": "2026-03-06T13:46:04+00:00"
+            "time": "2026-03-16T15:10:50+00:00"
         },
         {
             "name": "orchestra/sidekick",
@@ -7734,29 +8005,29 @@
         },
         {
             "name": "orchestra/testbench",
-            "version": "v9.17.0",
+            "version": "v11.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/orchestral/testbench.git",
-                "reference": "3288cbc77378c8b79132e482557cc18ac2fcfebe"
+                "reference": "997f33e5200c7e8db4756b35a9deb3f5f3086759"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/orchestral/testbench/zipball/3288cbc77378c8b79132e482557cc18ac2fcfebe",
-                "reference": "3288cbc77378c8b79132e482557cc18ac2fcfebe",
+                "url": "https://api.github.com/repos/orchestral/testbench/zipball/997f33e5200c7e8db4756b35a9deb3f5f3086759",
+                "reference": "997f33e5200c7e8db4756b35a9deb3f5f3086759",
                 "shasum": ""
             },
             "require": {
                 "composer-runtime-api": "^2.2",
                 "fakerphp/faker": "^1.23",
-                "laravel/framework": "^11.50.0",
+                "laravel/framework": "^13.1.1",
                 "mockery/mockery": "^1.6.10",
-                "orchestra/testbench-core": "^9.20.0",
-                "orchestra/workbench": "^9.14.0",
-                "php": "^8.2",
-                "phpunit/phpunit": "^10.5.35|^11.3.6|^12.0.1",
-                "symfony/process": "^7.0.3",
-                "symfony/yaml": "^7.0.3",
+                "orchestra/testbench-core": "^11.2.0",
+                "orchestra/workbench": "^11.0.1",
+                "php": "^8.3",
+                "phpunit/phpunit": "^11.5.50|^12.5.8|^13.0.0",
+                "symfony/process": "^7.4.5|^8.0.5",
+                "symfony/yaml": "^7.4|^8.0",
                 "vlucas/phpdotenv": "^5.6.1"
             },
             "type": "library",
@@ -7783,64 +8054,62 @@
             ],
             "support": {
                 "issues": "https://github.com/orchestral/testbench/issues",
-                "source": "https://github.com/orchestral/testbench/tree/v9.17.0"
+                "source": "https://github.com/orchestral/testbench/tree/v11.1.0"
             },
-            "time": "2026-03-18T12:59:34+00:00"
+            "time": "2026-04-09T05:11:06+00:00"
         },
         {
             "name": "orchestra/testbench-core",
-            "version": "v9.22.1",
+            "version": "v11.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/orchestral/testbench-core.git",
-                "reference": "751b2b086ff6dbc55102781ae299e9f73a67ee42"
+                "reference": "d513b67742796986c983104ab5d5c818399ceab8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/orchestral/testbench-core/zipball/751b2b086ff6dbc55102781ae299e9f73a67ee42",
-                "reference": "751b2b086ff6dbc55102781ae299e9f73a67ee42",
+                "url": "https://api.github.com/repos/orchestral/testbench-core/zipball/d513b67742796986c983104ab5d5c818399ceab8",
+                "reference": "d513b67742796986c983104ab5d5c818399ceab8",
                 "shasum": ""
             },
             "require": {
                 "composer-runtime-api": "^2.2",
                 "orchestra/sidekick": "~1.1.23|~1.2.20",
-                "php": "^8.2",
+                "php": "^8.3",
                 "symfony/deprecation-contracts": "^2.5|^3.0",
-                "symfony/polyfill-php83": "^1.33"
+                "symfony/polyfill-php84": "^1.34.0"
             },
             "conflict": {
                 "brianium/paratest": "<7.3.0|>=8.0.0",
-                "laravel/framework": "<11.50.0|>=12.0.0",
-                "laravel/serializable-closure": "<1.3.0|>=2.0.0 <2.0.3|>=3.0.0",
-                "nunomaduro/collision": "<8.0.0|>=9.0.0",
-                "orchestra/testbench-dusk": "<9.10.0|>=10.0.0",
-                "pestphp/pest": "<2.0.0",
-                "phpunit/phpunit": "<10.5.35|>=11.0.0 <11.3.6|>=12.0.0 <12.0.1|>=12.6.0"
+                "laravel/framework": "<13.7.0|>=14.0.0",
+                "laravel/serializable-closure": ">=2.0.0 <2.0.10|>=3.0.0",
+                "nunomaduro/collision": "<8.9.0|>=9.0.0",
+                "phpunit/phpunit": "<11.5.50|>=12.0.0 <12.5.8|>=13.2.0"
             },
             "require-dev": {
                 "fakerphp/faker": "^1.24",
-                "laravel/framework": "^11.50.0",
+                "laravel/framework": "^13.7.0",
                 "laravel/pint": "^1.24",
-                "laravel/serializable-closure": "^1.3|^2.0.4",
+                "laravel/serializable-closure": "^2.0.10",
                 "mockery/mockery": "^1.6.10",
-                "phpstan/phpstan": "^2.1.33",
-                "phpunit/phpunit": "^10.5.35|^11.3.6|^12.0.1",
-                "spatie/laravel-ray": "^1.40.2",
-                "symfony/process": "^7.0.3",
-                "symfony/yaml": "^7.0.3",
+                "phpstan/phpstan": "^2.1.38",
+                "phpunit/phpunit": "^11.5.50|^12.5.8|^13.0.0",
+                "spatie/laravel-ray": "^1.43.6",
+                "symfony/process": "^7.4.5|^8.0.5",
+                "symfony/yaml": "^7.4.0|^8.0.0",
                 "vlucas/phpdotenv": "^5.6.1"
             },
             "suggest": {
                 "brianium/paratest": "Allow using parallel testing (^7.3).",
                 "ext-pcntl": "Required to use all features of the console signal trapping.",
                 "fakerphp/faker": "Allow using Faker for testing (^1.23).",
-                "laravel/framework": "Required for testing (^11.50.0).",
+                "laravel/framework": "Required for testing (^13.7.0).",
                 "mockery/mockery": "Allow using Mockery for testing (^1.6).",
-                "nunomaduro/collision": "Allow using Laravel style tests output and parallel testing (^8.0).",
-                "orchestra/testbench-dusk": "Allow using Laravel Dusk for testing (^9.10).",
-                "phpunit/phpunit": "Allow using PHPUnit for testing (^10.5.35|^11.3.6|^12.0.1).",
-                "symfony/process": "Required to use Orchestra\\Testbench\\remote function (^7.0).",
-                "symfony/yaml": "Required for Testbench CLI (^7.0).",
+                "nunomaduro/collision": "Allow using Laravel style tests output and parallel testing (^8.9).",
+                "orchestra/testbench-dusk": "Allow using Laravel Dusk for testing (^11.0).",
+                "phpunit/phpunit": "Allow using PHPUnit for testing (^11.5.50|^12.5.8|^13.0.0).",
+                "symfony/process": "Required to use Orchestra\\Testbench\\remote function (^7.4|^8.0).",
+                "symfony/yaml": "Required for Testbench CLI (^7.4|^8.0).",
                 "vlucas/phpdotenv": "Required for Testbench CLI (^5.6.1)."
             },
             "bin": [
@@ -7880,44 +8149,42 @@
                 "issues": "https://github.com/orchestral/testbench/issues",
                 "source": "https://github.com/orchestral/testbench-core"
             },
-            "time": "2026-04-24T08:25:23+00:00"
+            "time": "2026-05-06T02:48:24+00:00"
         },
         {
             "name": "orchestra/workbench",
-            "version": "v9.15.0",
+            "version": "v11.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/orchestral/workbench.git",
-                "reference": "08d11d9e2e8dbc9cc0477948a13aef2b528bccfb"
+                "reference": "e750c7bcae4405e054ff286475502e23274de04b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/orchestral/workbench/zipball/08d11d9e2e8dbc9cc0477948a13aef2b528bccfb",
-                "reference": "08d11d9e2e8dbc9cc0477948a13aef2b528bccfb",
+                "url": "https://api.github.com/repos/orchestral/workbench/zipball/e750c7bcae4405e054ff286475502e23274de04b",
+                "reference": "e750c7bcae4405e054ff286475502e23274de04b",
                 "shasum": ""
             },
             "require": {
                 "composer-runtime-api": "^2.2",
                 "fakerphp/faker": "^1.23",
-                "laravel/framework": "^11.44.2",
-                "laravel/pail": "^1.2.3",
-                "laravel/tinker": "^2.9",
-                "nunomaduro/collision": "^8.0",
-                "orchestra/canvas": "^9.2.2",
-                "orchestra/canvas-core": "^9.2.0",
+                "laravel/framework": "^13.0.0",
+                "laravel/pail": "^1.2.5",
+                "laravel/tinker": "^3.0.0",
+                "nunomaduro/collision": "^8.9",
+                "orchestra/canvas": "^11.0.1",
                 "orchestra/sidekick": "~1.1.23|~1.2.20",
-                "orchestra/testbench-core": "^9.21.0",
-                "php": "^8.2",
-                "symfony/polyfill-php83": "^1.32",
-                "symfony/process": "^7.0.3",
-                "symfony/yaml": "^7.0.3"
+                "orchestra/testbench-core": "^11.1.0",
+                "php": "^8.3",
+                "symfony/process": "^7.4|^8.0",
+                "symfony/yaml": "^7.4|^8.0"
             },
             "require-dev": {
-                "laravel/pint": "^1.22",
-                "mockery/mockery": "^1.6.10",
+                "laravel/pint": "^1.22.0",
+                "mockery/mockery": "^1.6.12",
                 "phpstan/phpstan": "^2.1.33",
-                "phpunit/phpunit": "^10.5.35|^11.3.6|^12.0.1",
-                "spatie/laravel-ray": "^1.40.2"
+                "phpunit/phpunit": "^11.5.50|^12.5.8|^13.0.0",
+                "spatie/laravel-ray": "^1.43.6"
             },
             "suggest": {
                 "ext-pcntl": "Required to use all features of the console signal trapping."
@@ -7947,9 +8214,9 @@
             ],
             "support": {
                 "issues": "https://github.com/orchestral/workbench/issues",
-                "source": "https://github.com/orchestral/workbench/tree/v9.15.0"
+                "source": "https://github.com/orchestral/workbench/tree/v11.1.0"
             },
-            "time": "2026-03-24T15:12:11+00:00"
+            "time": "2026-03-24T23:09:55+00:00"
         },
         {
             "name": "pestphp/pest",
@@ -9501,16 +9768,16 @@
         },
         {
             "name": "rector/rector",
-            "version": "2.4.2",
+            "version": "2.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "e645b6463c6a88ea5b44b17d3387d35a912c7946"
+                "reference": "891824c6c59f02a56a5dd58ea8edc44e6c0ece29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/e645b6463c6a88ea5b44b17d3387d35a912c7946",
-                "reference": "e645b6463c6a88ea5b44b17d3387d35a912c7946",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/891824c6c59f02a56a5dd58ea8edc44e6c0ece29",
+                "reference": "891824c6c59f02a56a5dd58ea8edc44e6c0ece29",
                 "shasum": ""
             },
             "require": {
@@ -9549,7 +9816,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.4.2"
+                "source": "https://github.com/rectorphp/rector/tree/2.4.3"
             },
             "funding": [
                 {
@@ -9557,7 +9824,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-16T13:07:34+00:00"
+            "time": "2026-05-12T11:17:24+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -10510,28 +10777,27 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v7.4.10",
+            "version": "v8.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "c660d6538545a3e8e65a5621ee3d7a6d352892c7"
+                "reference": "aa9ee60c41d9b20a2468c41ff0a32e2a7405ac05"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/c660d6538545a3e8e65a5621ee3d7a6d352892c7",
-                "reference": "c660d6538545a3e8e65a5621ee3d7a6d352892c7",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/aa9ee60c41d9b20a2468c41ff0a32e2a7405ac05",
+                "reference": "aa9ee60c41d9b20a2468c41ff0a32e2a7405ac05",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3",
+                "php": ">=8.4",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
-                "symfony/console": "<6.4"
+                "symfony/console": "<7.4"
             },
             "require-dev": {
-                "symfony/console": "^6.4|^7.0|^8.0"
+                "symfony/console": "^7.4|^8.0"
             },
             "bin": [
                 "Resources/bin/yaml-lint"
@@ -10562,7 +10828,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v7.4.10"
+                "source": "https://github.com/symfony/yaml/tree/v8.0.10"
             },
             "funding": [
                 {
@@ -10582,7 +10848,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-05T08:01:55+00:00"
+            "time": "2026-05-05T08:10:04+00:00"
         },
         {
             "name": "ta-tikoma/phpunit-architecture-test",
@@ -10814,7 +11080,7 @@
         }
     ],
     "aliases": [],
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/config/eveapi.config.php
+++ b/config/eveapi.config.php
@@ -1,5 +1,7 @@
 <?php
 
+use Monolog\Logger;
+
 /*
  * MIT License
  *
@@ -37,7 +39,7 @@ return [
         'sso_host' => env('EVE_SSO_HOST', 'login.eveonline.com'),
         'sso_port' => env('EVE_SSO_PORT', 443),
         // Loging
-        'logger_level' => \Monolog\Logger::INFO, // valid entries are RFC 5424 levels ('debug', 'info', 'warn', 'error')
+        'logger_level' => Logger::INFO, // valid entries are RFC 5424 levels ('debug', 'info', 'warn', 'error')
         'logfile_location' => storage_path('logs'),
     ],
 

--- a/database/factories/AllianceInfoFactory.php
+++ b/database/factories/AllianceInfoFactory.php
@@ -30,7 +30,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use Seatplus\Eveapi\Models\Alliance\AllianceInfo;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\Seatplus\Eveapi\Models\Alliance\AllianceInfo>
+ * @extends Factory<AllianceInfo>
  */
 class AllianceInfoFactory extends Factory
 {

--- a/database/factories/ApplicationFactory.php
+++ b/database/factories/ApplicationFactory.php
@@ -32,7 +32,7 @@ use Seatplus\Eveapi\Models\Character\CharacterInfo;
 use Seatplus\Eveapi\Models\Corporation\CorporationInfo;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\Seatplus\Eveapi\Models\Application>
+ * @extends Factory<Application>
  */
 class ApplicationFactory extends Factory
 {

--- a/database/factories/AssetFactory.php
+++ b/database/factories/AssetFactory.php
@@ -32,7 +32,7 @@ use Seatplus\Eveapi\Models\Character\CharacterInfo;
 use Seatplus\Eveapi\Models\Universe\Type;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\Seatplus\Eveapi\Models\Assets\Asset>
+ * @extends Factory<Asset>
  */
 class AssetFactory extends Factory
 {

--- a/database/factories/BalanceFactory.php
+++ b/database/factories/BalanceFactory.php
@@ -31,7 +31,7 @@ use Seatplus\Eveapi\Models\Character\CharacterInfo;
 use Seatplus\Eveapi\Models\Wallet\Balance;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\Seatplus\Eveapi\Models\Wallet\Balance>
+ * @extends Factory<Balance>
  */
 class BalanceFactory extends Factory
 {

--- a/database/factories/BatchStatisticFactory.php
+++ b/database/factories/BatchStatisticFactory.php
@@ -30,7 +30,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use Seatplus\Eveapi\Models\BatchStatistic;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\Seatplus\Eveapi\Models\BatchStatistic>
+ * @extends Factory<BatchStatistic>
  */
 class BatchStatisticFactory extends Factory
 {

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -30,7 +30,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use Seatplus\Eveapi\Models\Universe\Category;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\Seatplus\Eveapi\Models\Universe\Category>
+ * @extends Factory<Category>
  */
 class CategoryFactory extends Factory
 {

--- a/database/factories/CharacterAffiliationFactory.php
+++ b/database/factories/CharacterAffiliationFactory.php
@@ -32,7 +32,7 @@ use Seatplus\Eveapi\Models\Character\CharacterAffiliation;
 use Seatplus\Eveapi\Models\Corporation\CorporationInfo;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\Seatplus\Eveapi\Models\Character\CharacterAffiliation>
+ * @extends Factory<CharacterAffiliation>
  */
 class CharacterAffiliationFactory extends Factory
 {

--- a/database/factories/CharacterInfoFactory.php
+++ b/database/factories/CharacterInfoFactory.php
@@ -34,7 +34,7 @@ use Seatplus\Eveapi\Models\Character\CharacterRole;
 use Seatplus\Eveapi\Models\RefreshToken;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\Seatplus\Eveapi\Models\Character\CharacterInfo>
+ * @extends Factory<CharacterInfo>
  */
 class CharacterInfoFactory extends Factory
 {

--- a/database/factories/CharacterRoleFactory.php
+++ b/database/factories/CharacterRoleFactory.php
@@ -30,7 +30,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use Seatplus\Eveapi\Models\Character\CharacterRole;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\Seatplus\Eveapi\Models\Character\CharacterRole>
+ * @extends Factory<CharacterRole>
  */
 class CharacterRoleFactory extends Factory
 {

--- a/database/factories/ConstellationFactory.php
+++ b/database/factories/ConstellationFactory.php
@@ -31,7 +31,7 @@ use Seatplus\Eveapi\Models\Universe\Constellation;
 use Seatplus\Eveapi\Models\Universe\Region;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\Seatplus\Eveapi\Models\Universe\Constellation>
+ * @extends Factory<Constellation>
  */
 class ConstellationFactory extends Factory
 {

--- a/database/factories/ContactFactory.php
+++ b/database/factories/ContactFactory.php
@@ -33,7 +33,7 @@ use Seatplus\Eveapi\Models\Contacts\Contact;
 use Seatplus\Eveapi\Models\Corporation\CorporationInfo;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\Seatplus\Eveapi\Models\Contacts\Contact>
+ * @extends Factory<Contact>
  */
 class ContactFactory extends Factory
 {

--- a/database/factories/ContractFactory.php
+++ b/database/factories/ContractFactory.php
@@ -32,7 +32,7 @@ use Seatplus\Eveapi\Models\Corporation\CorporationInfo;
 use Seatplus\Eveapi\Models\Universe\Location;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\Seatplus\Eveapi\Models\Contracts\Contract>
+ * @extends Factory<Contract>
  */
 class ContractFactory extends Factory
 {

--- a/database/factories/ContractItemFactory.php
+++ b/database/factories/ContractItemFactory.php
@@ -31,7 +31,7 @@ use Seatplus\Eveapi\Models\Contracts\ContractItem;
 use Seatplus\Eveapi\Models\Universe\Type;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\Seatplus\Eveapi\Models\Contracts\ContractItem>
+ * @extends Factory<ContractItem>
  */
 class ContractItemFactory extends Factory
 {

--- a/database/factories/CorporationDivisionFactory.php
+++ b/database/factories/CorporationDivisionFactory.php
@@ -30,7 +30,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use Seatplus\Eveapi\Models\Corporation\CorporationDivision;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\Seatplus\Eveapi\Models\Corporation\CorporationDivision>
+ * @extends Factory<CorporationDivision>
  */
 class CorporationDivisionFactory extends Factory
 {

--- a/database/factories/CorporationHistoryFactory.php
+++ b/database/factories/CorporationHistoryFactory.php
@@ -30,7 +30,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use Seatplus\Eveapi\Models\Character\CorporationHistory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\Seatplus\Eveapi\Models\Character\CorporationHistory>
+ * @extends Factory<CorporationHistory>
  */
 class CorporationHistoryFactory extends Factory
 {

--- a/database/factories/CorporationInfoFactory.php
+++ b/database/factories/CorporationInfoFactory.php
@@ -31,7 +31,7 @@ use Seatplus\Eveapi\Models\Alliance\AllianceInfo;
 use Seatplus\Eveapi\Models\Corporation\CorporationInfo;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\Seatplus\Eveapi\Models\Corporation\CorporationInfo>
+ * @extends Factory<CorporationInfo>
  */
 class CorporationInfoFactory extends Factory
 {

--- a/database/factories/CorporationMemberTrackingFactory.php
+++ b/database/factories/CorporationMemberTrackingFactory.php
@@ -32,7 +32,7 @@ use Seatplus\Eveapi\Models\Corporation\CorporationInfo;
 use Seatplus\Eveapi\Models\Corporation\CorporationMemberTracking;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\Seatplus\Eveapi\Models\Corporation\CorporationMemberTracking>
+ * @extends Factory<CorporationMemberTracking>
  */
 class CorporationMemberTrackingFactory extends Factory
 {

--- a/database/factories/GlobalSettingsFactory.php
+++ b/database/factories/GlobalSettingsFactory.php
@@ -30,7 +30,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use Seatplus\Eveapi\Models\Settings\GlobalSettings;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\Seatplus\Eveapi\Models\Settings\GlobalSettings>
+ * @extends Factory<GlobalSettings>
  */
 class GlobalSettingsFactory extends Factory
 {

--- a/database/factories/GroupFactory.php
+++ b/database/factories/GroupFactory.php
@@ -30,7 +30,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use Seatplus\Eveapi\Models\Universe\Group;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\Seatplus\Eveapi\Models\Universe\Group>
+ * @extends Factory<Group>
  */
 class GroupFactory extends Factory
 {

--- a/database/factories/KillmailFactory.php
+++ b/database/factories/KillmailFactory.php
@@ -34,7 +34,7 @@ use Seatplus\Eveapi\Models\Universe\System;
 use Seatplus\Eveapi\Models\Universe\Type;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\Seatplus\Eveapi\Models\Killmails\Killmail>
+ * @extends Factory<Killmail>
  */
 class KillmailFactory extends Factory
 {

--- a/database/factories/LabelFactory.php
+++ b/database/factories/LabelFactory.php
@@ -30,7 +30,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use Seatplus\Eveapi\Models\Contacts\Label;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\Seatplus\Eveapi\Models\Contacts\Label>
+ * @extends Factory<Label>
  */
 class LabelFactory extends Factory
 {

--- a/database/factories/LocationFactory.php
+++ b/database/factories/LocationFactory.php
@@ -31,7 +31,7 @@ use Seatplus\Eveapi\Models\Universe\Location;
 use Seatplus\Eveapi\Models\Universe\Station;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\Seatplus\Eveapi\Models\Universe\Location>
+ * @extends Factory<Location>
  */
 class LocationFactory extends Factory
 {

--- a/database/factories/MailFactory.php
+++ b/database/factories/MailFactory.php
@@ -31,7 +31,7 @@ use Seatplus\Eveapi\Models\Character\CharacterInfo;
 use Seatplus\Eveapi\Models\Mail\Mail;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\Seatplus\Eveapi\Models\Mail\Mail>
+ * @extends Factory<Mail>
  */
 class MailFactory extends Factory
 {

--- a/database/factories/MailRecipientsFactory.php
+++ b/database/factories/MailRecipientsFactory.php
@@ -32,7 +32,7 @@ use Seatplus\Eveapi\Models\Mail\Mail;
 use Seatplus\Eveapi\Models\Mail\MailRecipients;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\Seatplus\Eveapi\Models\Mail\MailRecipients>
+ * @extends Factory<MailRecipients>
  */
 class MailRecipientsFactory extends Factory
 {

--- a/database/factories/RefreshTokenFactory.php
+++ b/database/factories/RefreshTokenFactory.php
@@ -31,7 +31,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use Seatplus\Eveapi\Models\RefreshToken;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\Seatplus\Eveapi\Models\RefreshToken>
+ * @extends Factory<RefreshToken>
  */
 class RefreshTokenFactory extends Factory
 {

--- a/database/factories/RegionFactory.php
+++ b/database/factories/RegionFactory.php
@@ -30,7 +30,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use Seatplus\Eveapi\Models\Universe\Region;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\Seatplus\Eveapi\Models\Universe\Region>
+ * @extends Factory<Region>
  */
 class RegionFactory extends Factory
 {

--- a/database/factories/SkillFactory.php
+++ b/database/factories/SkillFactory.php
@@ -32,7 +32,7 @@ use Seatplus\Eveapi\Models\Skills\Skill;
 use Seatplus\Eveapi\Models\Universe\Type;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\Seatplus\Eveapi\Models\Skills\Skill>
+ * @extends Factory<Skill>
  */
 class SkillFactory extends Factory
 {

--- a/database/factories/SkillQueueFactory.php
+++ b/database/factories/SkillQueueFactory.php
@@ -32,7 +32,7 @@ use Seatplus\Eveapi\Models\Skills\SkillQueue;
 use Seatplus\Eveapi\Models\Universe\Type;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\Seatplus\Eveapi\Models\Skills\SkillQueue>
+ * @extends Factory<SkillQueue>
  */
 class SkillQueueFactory extends Factory
 {

--- a/database/factories/SsoScopesFactory.php
+++ b/database/factories/SsoScopesFactory.php
@@ -32,7 +32,7 @@ use Seatplus\Eveapi\Models\Corporation\CorporationInfo;
 use Seatplus\Eveapi\Models\SsoScopes;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\Seatplus\Eveapi\Models\SsoScopes>
+ * @extends Factory<SsoScopes>
  */
 class SsoScopesFactory extends Factory
 {

--- a/database/factories/StationFactory.php
+++ b/database/factories/StationFactory.php
@@ -31,7 +31,7 @@ use Seatplus\Eveapi\Models\Universe\Station;
 use Seatplus\Eveapi\Models\Universe\System;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\Seatplus\Eveapi\Models\Universe\Station>
+ * @extends Factory<Station>
  */
 class StationFactory extends Factory
 {

--- a/database/factories/StructureFactory.php
+++ b/database/factories/StructureFactory.php
@@ -31,7 +31,7 @@ use Seatplus\Eveapi\Models\Universe\Structure;
 use Seatplus\Eveapi\Models\Universe\System;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\Seatplus\Eveapi\Models\Universe\Structure>
+ * @extends Factory<Structure>
  */
 class StructureFactory extends Factory
 {

--- a/database/factories/SystemFactory.php
+++ b/database/factories/SystemFactory.php
@@ -31,7 +31,7 @@ use Seatplus\Eveapi\Models\Universe\Constellation;
 use Seatplus\Eveapi\Models\Universe\System;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\Seatplus\Eveapi\Models\Universe\System>
+ * @extends Factory<System>
  */
 class SystemFactory extends Factory
 {

--- a/database/factories/TypeFactory.php
+++ b/database/factories/TypeFactory.php
@@ -30,7 +30,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use Seatplus\Eveapi\Models\Universe\Type;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\Seatplus\Eveapi\Models\Universe\Type>
+ * @extends Factory<Type>
  */
 class TypeFactory extends Factory
 {

--- a/database/factories/WalletJournalFactory.php
+++ b/database/factories/WalletJournalFactory.php
@@ -31,7 +31,7 @@ use Seatplus\Eveapi\Models\Character\CharacterInfo;
 use Seatplus\Eveapi\Models\Wallet\WalletJournal;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\Seatplus\Eveapi\Models\Wallet\WalletJournal>
+ * @extends Factory<WalletJournal>
  */
 class WalletJournalFactory extends Factory
 {

--- a/database/factories/WalletTransactionFactory.php
+++ b/database/factories/WalletTransactionFactory.php
@@ -31,7 +31,7 @@ use Seatplus\Eveapi\Models\Character\CharacterInfo;
 use Seatplus\Eveapi\Models\Wallet\WalletTransaction;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\Seatplus\Eveapi\Models\Wallet\WalletTransaction>
+ * @extends Factory<WalletTransaction>
  */
 class WalletTransactionFactory extends Factory
 {

--- a/database/migrations/2023_02_07_070017_seed_schedule_tables_with_default_expressions.php
+++ b/database/migrations/2023_02_07_070017_seed_schedule_tables_with_default_expressions.php
@@ -1,6 +1,9 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
+use Seatplus\Eveapi\Jobs\Seatplus\MaintenanceJob;
+use Seatplus\Eveapi\Jobs\Seatplus\UpdateCharacter;
+use Seatplus\Eveapi\Jobs\Seatplus\UpdateCorporation;
 use Seatplus\Eveapi\Models\Schedules;
 
 return new class extends Migration
@@ -10,11 +13,11 @@ return new class extends Migration
 
         $jobs = [
             // schedule UpdateCharacter to run every minute
-            \Seatplus\Eveapi\Jobs\Seatplus\UpdateCharacter::class => '* * * * *',
+            UpdateCharacter::class => '* * * * *',
             // schedule UpdateCorporation to run every minute
-            \Seatplus\Eveapi\Jobs\Seatplus\UpdateCorporation::class => '* * * * *',
+            UpdateCorporation::class => '* * * * *',
             // schedule MaintenanceJob to run every day at 00:00
-            \Seatplus\Eveapi\Jobs\Seatplus\MaintenanceJob::class => '0 0 * * *',
+            MaintenanceJob::class => '0 0 * * *',
         ];
         // if the schedule is not in the database, create it
         foreach ($jobs as $job => $schedule) {

--- a/database/migrations/2025_01_04_120813_migrate_old_database.php
+++ b/database/migrations/2025_01_04_120813_migrate_old_database.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
+use Seatplus\Eveapi\Services\MigrateDb;
 
 return new class extends Migration
 {
@@ -11,6 +12,6 @@ return new class extends Migration
             return;
         }
 
-        new \Seatplus\Eveapi\Services\MigrateDb;
+        new MigrateDb;
     }
 };

--- a/rector.php
+++ b/rector.php
@@ -3,7 +3,9 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
+use RectorLaravel\Set\LaravelLevelSetList;
 
 return RectorConfig::configure()
     ->withSets([
@@ -12,8 +14,8 @@ return RectorConfig::configure()
         // SetList::TYPE_DECLARATION,
         // SetList::CODE_QUALITY,
         // SetList::CODING_STYLE,
-        \RectorLaravel\Set\LaravelLevelSetList::UP_TO_LARAVEL_110,
-        \Rector\Set\ValueObject\LevelSetList::UP_TO_PHP_83,
+        LaravelLevelSetList::UP_TO_LARAVEL_110,
+        LevelSetList::UP_TO_PHP_83,
     ])
     ->withPaths([
         __DIR__.'/config',

--- a/src/Jobs/Alliances/AllianceInfoJob.php
+++ b/src/Jobs/Alliances/AllianceInfoJob.php
@@ -26,6 +26,7 @@
 
 namespace Seatplus\Eveapi\Jobs\Alliances;
 
+use Seatplus\EsiClient\Exceptions\RequestFailedException;
 use Seatplus\Eveapi\DataTransferObjects\Responses\Alliances\AllianceInfoResponse;
 use Seatplus\Eveapi\Esi\HasPathValuesInterface;
 use Seatplus\Eveapi\Jobs\EsiBase;
@@ -74,7 +75,7 @@ class AllianceInfoJob extends EsiBase implements HasPathValuesInterface
     /**
      * Execute the job.
      *
-     * @throws \Seatplus\EsiClient\Exceptions\RequestFailedException
+     * @throws RequestFailedException
      */
     #[\Override]
     public function executeJob(): void

--- a/src/Jobs/Corporation/CorporationMemberTrackingJob.php
+++ b/src/Jobs/Corporation/CorporationMemberTrackingJob.php
@@ -26,6 +26,7 @@
 
 namespace Seatplus\Eveapi\Jobs\Corporation;
 
+use Illuminate\Support\Collection;
 use Seatplus\Eveapi\DataTransferObjects\Responses\Corporation\CorporationMemberTrackingItemResponse;
 use Seatplus\Eveapi\Esi\HasCorporationRoleInterface;
 use Seatplus\Eveapi\Esi\HasPathValuesInterface;
@@ -122,12 +123,12 @@ class CorporationMemberTrackingJob extends EsiBase implements HasCorporationRole
         $this->getShipTypes();
     }
 
-    private function upsertMembers(\Illuminate\Support\Collection $members): void
+    private function upsertMembers(Collection $members): void
     {
         CorporationMemberTracking::upsert($members->toArray(), ['corporation_id', 'character_id']);
     }
 
-    private function removeOldMembers(\Illuminate\Support\Collection $members): void
+    private function removeOldMembers(Collection $members): void
     {
         CorporationMemberTracking::where('corporation_id', $this->corporation_id)
             ->whereNotIn('character_id', $members->pluck('character_id')->all())

--- a/src/Jobs/Wallet/CorporationBalanceJob.php
+++ b/src/Jobs/Wallet/CorporationBalanceJob.php
@@ -27,6 +27,7 @@
 namespace Seatplus\Eveapi\Jobs\Wallet;
 
 use Illuminate\Support\Collection;
+use Seatplus\Eveapi\DataTransferObjects\Responses\Corporation\CorporationWalletItemResponse;
 use Seatplus\Eveapi\Esi\HasCorporationRoleInterface;
 use Seatplus\Eveapi\Esi\HasPathValuesInterface;
 use Seatplus\Eveapi\Esi\HasRequiredScopeInterface;
@@ -34,7 +35,6 @@ use Seatplus\Eveapi\Jobs\EsiBase;
 use Seatplus\Eveapi\Jobs\Middleware\HasRequiredScopeMiddleware;
 use Seatplus\Eveapi\Models\Corporation\CorporationInfo;
 use Seatplus\Eveapi\Models\Wallet\Balance;
-use Seatplus\Eveapi\DataTransferObjects\Responses\Corporation\CorporationWalletItemResponse;
 use Seatplus\Eveapi\Traits\HasCorporationRole;
 use Seatplus\Eveapi\Traits\HasPages;
 use Seatplus\Eveapi\Traits\HasPathValues;

--- a/src/Models/RefreshToken.php
+++ b/src/Models/RefreshToken.php
@@ -40,7 +40,7 @@ use Seatplus\Eveapi\Models\Character\CharacterInfo;
 use Seatplus\Eveapi\Models\Corporation\CorporationInfo;
 
 /**
- * @property \Carbon\Carbon $expires_on
+ * @property Carbon $expires_on
  */
 class RefreshToken extends Model
 {

--- a/src/Observers/CharacterInfoObserver.php
+++ b/src/Observers/CharacterInfoObserver.php
@@ -26,6 +26,7 @@
 
 namespace Seatplus\Eveapi\Observers;
 
+use Seatplus\Eveapi\Exceptions\InvalidContainerDataException;
 use Seatplus\Eveapi\Jobs\Character\CharacterAffiliationJob;
 use Seatplus\Eveapi\Models\Character\CharacterInfo;
 
@@ -36,7 +37,7 @@ class CharacterInfoObserver
      *
      *
      *
-     * @throws \Seatplus\Eveapi\Exceptions\InvalidContainerDataException
+     * @throws InvalidContainerDataException
      */
     public function created(CharacterInfo $character_info): void
     {
@@ -48,7 +49,7 @@ class CharacterInfoObserver
      *
      *
      *
-     * @throws \Seatplus\Eveapi\Exceptions\InvalidContainerDataException
+     * @throws InvalidContainerDataException
      */
     public function updating(CharacterInfo $character_info): void
     {

--- a/src/Traits/HasRequiredScopes.php
+++ b/src/Traits/HasRequiredScopes.php
@@ -58,7 +58,7 @@ trait HasRequiredScopes
                 'character_id' => RefreshToken::firstWhere('character_id', $value),
                 'corporation_id' => $this->getCorporateRefreshToken($value),
                 'alliance_id' => $this->getAllianceRefreshToken($value),
-                default => throw new \Exception("Unexpected key: {$key}")
+                default => throw new Exception("Unexpected key: {$key}")
             });
 
         // throw error if length of collection is not 1

--- a/tests/Integration/CharacterAffiliationLifeCycleTest.php
+++ b/tests/Integration/CharacterAffiliationLifeCycleTest.php
@@ -76,7 +76,7 @@ it('applies binary search and chaches it if one id is invalid', function () {
     $ids = [123456789, $mock_data->character_id];
 
     // Prepare the mock responses
-    $exception_mock = \Mockery::mock(\Exception::class);
+    $exception_mock = Mockery::mock(Exception::class);
     $exception_mock->shouldReceive('getResponse->getReasonPhrase')->andReturn('Invalid character ID');
     // first create the exception
     $exception = new RequestFailedException($exception_mock, new EsiResponse(json_encode([]), [], 'now', 200));

--- a/tests/Integration/ContactLifecycleTest.php
+++ b/tests/Integration/ContactLifecycleTest.php
@@ -5,6 +5,7 @@ use Seatplus\Eveapi\Jobs\Contacts\AllianceContactJob;
 use Seatplus\Eveapi\Jobs\Contacts\CharacterContactJob;
 use Seatplus\Eveapi\Jobs\Contacts\CorporationContactJob;
 use Seatplus\Eveapi\Models\Contacts\Contact;
+use Seatplus\Eveapi\Services\Jobs\CacheCharacterAffiliationIdsService;
 
 beforeEach(function () {
     // Prevent any auto dispatching of jobs
@@ -20,7 +21,7 @@ test('run character contact', function () {
 
     $job->handle();
 
-    $cached_ids = \Seatplus\Eveapi\Services\Jobs\CacheCharacterAffiliationIdsService::make()->retrieve();
+    $cached_ids = CacheCharacterAffiliationIdsService::make()->retrieve();
 
     foreach ($mock_data as $data) {
         // Assert that character asset created
@@ -44,7 +45,7 @@ test('run corporation contact', function () {
 
     $job->handle();
 
-    $cached_ids = \Seatplus\Eveapi\Services\Jobs\CacheCharacterAffiliationIdsService::make()->retrieve();
+    $cached_ids = CacheCharacterAffiliationIdsService::make()->retrieve();
 
     foreach ($mock_data as $data) {
         // Assert that character asset created

--- a/tests/Integration/MailIntegrationTest.php
+++ b/tests/Integration/MailIntegrationTest.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Queue;
+use Mockery\MockInterface;
 use Seatplus\EsiClient\DataTransferObjects\EsiResponse;
 use Seatplus\Eveapi\Jobs\Mail\MailBodyJob;
 use Seatplus\Eveapi\Jobs\Mail\MailHeaderJob;
@@ -41,7 +42,7 @@ it('runs mail body job', function () {
 
 it('adds MailBodyJob to batch if batched', function () {
 
-    $job = mock(MailHeaderJob::class, function (\Mockery\MockInterface $mock) {
+    $job = mock(MailHeaderJob::class, function (MockInterface $mock) {
         $mock->method = 'get';
         $mock->endpoint = '/characters/{character_id}/mail/';
         $mock->version = 'v1';

--- a/tests/Integration/SkillLifeCycleTest.php
+++ b/tests/Integration/SkillLifeCycleTest.php
@@ -1,13 +1,15 @@
 <?php
 
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Queue;
+use Seatplus\EsiClient\DataTransferObjects\EsiResponse;
 use Seatplus\Eveapi\Jobs\Skills\SkillsJob;
 use Seatplus\Eveapi\Jobs\Universe\ResolveUniverseTypeByIdJob;
 use Seatplus\Eveapi\Models\Skills\Skill;
 use Seatplus\Eveapi\Models\Universe\Type;
 
-uses(\Illuminate\Foundation\Testing\LazilyRefreshDatabase::class);
+uses(LazilyRefreshDatabase::class);
 
 beforeEach(function () {
     // Prevent any auto dispatching of jobs
@@ -50,10 +52,10 @@ it('Dispatch Type job if skill is missing', function () {
 });
 
 it('does not update skills and character info if response is cached', function () {
-    $response = \Mockery::mock(\Seatplus\EsiClient\DataTransferObjects\EsiResponse::class);
+    $response = Mockery::mock(EsiResponse::class);
     $response->shouldReceive('isCachedLoad')->andReturn(true);
 
-    $job = \Mockery::mock(\Seatplus\Eveapi\Jobs\Skills\SkillsJob::class)->makePartial();
+    $job = Mockery::mock(SkillsJob::class)->makePartial();
     $job->shouldReceive('retrieve')->andReturn($response);
 
     $job->executeJob();

--- a/tests/Integration/SkillQueueLifeCycleTest.php
+++ b/tests/Integration/SkillQueueLifeCycleTest.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Queue;
+use Seatplus\EsiClient\DataTransferObjects\EsiResponse;
 use Seatplus\Eveapi\Jobs\Skills\SkillQueueJob;
 use Seatplus\Eveapi\Jobs\Universe\ResolveUniverseTypeByIdJob;
 use Seatplus\Eveapi\Models\Skills\SkillQueue;
@@ -62,10 +63,10 @@ it('deletes old queue items', function () {
 });
 
 it('does not update skill queue if response is cached', function () {
-    $response = mock(\Seatplus\EsiClient\DataTransferObjects\EsiResponse::class);
+    $response = mock(EsiResponse::class);
     $response->shouldReceive('isCachedLoad')->andReturn(true);
 
-    $job = mock(\Seatplus\Eveapi\Jobs\Skills\SkillQueueJob::class)->makePartial();
+    $job = mock(SkillQueueJob::class)->makePartial();
     $job->shouldReceive('retrieve')->andReturn($response);
 
     $job->executeJob();

--- a/tests/Jobs/Assets/CharacterAssetTest.php
+++ b/tests/Jobs/Assets/CharacterAssetTest.php
@@ -5,6 +5,8 @@ use Seatplus\Eveapi\Jobs\Assets\CharacterAssetJob;
 use Seatplus\Eveapi\Jobs\Universe\ResolveLocationJob;
 use Seatplus\Eveapi\Jobs\Universe\ResolveUniverseTypeByIdJob;
 use Seatplus\Eveapi\Models\Assets\Asset;
+use Seatplus\Eveapi\Models\Universe\Location;
+use Seatplus\Eveapi\Models\Universe\Type;
 
 beforeEach(function () {
     Queue::fake();
@@ -124,7 +126,7 @@ it('dispatches unknown types job', function () {
 });
 
 it('does not dispatch ResolveUniverseTypeByIdJob if type is known', function () {
-    $type = \Seatplus\Eveapi\Models\Universe\Type::factory()->create();
+    $type = Type::factory()->create();
 
     $assets = Asset::factory()->count(5)->create([
         'assetable_id' => testCharacter()->character_id,
@@ -140,7 +142,7 @@ it('does not dispatch ResolveUniverseTypeByIdJob if type is known', function () 
 });
 
 it('does not dispatch ResolveLocationJob if location is known', function () {
-    $location = \Seatplus\Eveapi\Models\Universe\Location::factory()->create();
+    $location = Location::factory()->create();
 
     $assets = Asset::factory()->count(5)->create([
         'assetable_id' => testCharacter()->character_id,

--- a/tests/Jobs/Contracts/ContractItemJobTest.php
+++ b/tests/Jobs/Contracts/ContractItemJobTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Queue;
 use Seatplus\Eveapi\Jobs\Contracts\CharacterContractItemsJob;
 use Seatplus\Eveapi\Jobs\Universe\ResolveUniverseTypeByIdJob;
@@ -27,7 +28,7 @@ it('dispatches resolve universe type job if type is unknown', function () {
 
     $mock_data = ContractItem::factory()->withoutType()->count(5)->make();
 
-    $contract = \Illuminate\Support\Facades\Event::fakeFor(fn () => Contract::factory()->create([
+    $contract = Event::fakeFor(fn () => Contract::factory()->create([
         'contract_id' => $mock_data->first()->contract_id,
     ]));
 

--- a/tests/Jobs/Corporation/CorporationInfoJobTest.php
+++ b/tests/Jobs/Corporation/CorporationInfoJobTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Bus;
+use Seatplus\EsiClient\DataTransferObjects\EsiResponse;
 use Seatplus\Eveapi\Jobs\Corporation\CorporationInfoJob;
 use Seatplus\Eveapi\Models\Corporation\CorporationInfo;
 
@@ -28,7 +29,7 @@ test('retrieve test', function () {
 
 test('returns early if cached', function () {
 
-    $response = mock(\Seatplus\EsiClient\DataTransferObjects\EsiResponse::class);
+    $response = mock(EsiResponse::class);
     $response->shouldReceive('isCachedLoad')->once()->andReturn(true);
 
     $job = mock(CorporationInfoJob::class)->makePartial();

--- a/tests/Jobs/Seatplus/CharacterBatchJobTest.php
+++ b/tests/Jobs/Seatplus/CharacterBatchJobTest.php
@@ -1,6 +1,8 @@
 <?php
 
+use Carbon\Carbon;
 use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Queue;
 use Seatplus\Eveapi\Jobs\Assets\CharacterAssetJob;
 use Seatplus\Eveapi\Jobs\Assets\CharacterAssetsNameJob;
 use Seatplus\Eveapi\Jobs\Assets\EnrichAssetTypeGroupCategoryJob;
@@ -23,6 +25,8 @@ use Seatplus\Eveapi\Jobs\Wallet\CharacterBalanceJob;
 use Seatplus\Eveapi\Jobs\Wallet\CharacterWalletJournalJob;
 use Seatplus\Eveapi\Jobs\Wallet\CharacterWalletTransactionJob;
 use Seatplus\Eveapi\Models\BatchStatistic;
+use Seatplus\Eveapi\Models\BatchUpdate;
+use Seatplus\Eveapi\Models\Character\CharacterInfo;
 use Seatplus\Eveapi\Models\RefreshToken;
 
 it('creates BatchUpdate entries', function () {
@@ -32,13 +36,13 @@ it('creates BatchUpdate entries', function () {
 
     (new CharacterBatchJob(testCharacter()->character_id))->handle();
 
-    expect(\Seatplus\Eveapi\Models\BatchUpdate::all())->toHaveCount(RefreshToken::count())
-        ->and(\Seatplus\Eveapi\Models\BatchUpdate::first())
+    expect(BatchUpdate::all())->toHaveCount(RefreshToken::count())
+        ->and(BatchUpdate::first())
         ->batchable_id->toBe(testCharacter()->character_id)
-        ->batchable_type->toBe(\Seatplus\Eveapi\Models\Character\CharacterInfo::class)
-        ->batchable->toBeInstanceOf(\Seatplus\Eveapi\Models\Character\CharacterInfo::class)
+        ->batchable_type->toBe(CharacterInfo::class)
+        ->batchable->toBeInstanceOf(CharacterInfo::class)
         ->finished_at->toBeNull()
-        ->started_at->toBeInstanceOf(\Carbon\Carbon::class);
+        ->started_at->toBeInstanceOf(Carbon::class);
 });
 
 it('contains public jobs in batch', function ($public_job) {
@@ -54,7 +58,7 @@ it('contains public jobs in batch', function ($public_job) {
 ]);
 
 it('contains jobs if refresh_token has scope', function (string $scope, array $classes) {
-    \Illuminate\Support\Facades\Queue::fake();
+    Queue::fake();
     updateRefreshTokenScopes($this->test_character->refresh_token, [$scope])->save();
 
     Bus::fake();

--- a/tests/Jobs/Seatplus/CorporationUpdateTest.php
+++ b/tests/Jobs/Seatplus/CorporationUpdateTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Bus\PendingBatch;
 use Illuminate\Support\Facades\Bus;
 use Seatplus\Eveapi\Jobs\Corporation\CorporationDivisionsJob;
 use Seatplus\Eveapi\Jobs\Corporation\CorporationMemberTrackingJob;
@@ -25,7 +26,7 @@ test('it dispatches jobs if token with role, scope and permission is present', f
     foreach ($job_classes as $job_class) {
         // if class is of type array
         if (is_array($job_class)) {
-            Bus::assertBatched(function (Illuminate\Bus\PendingBatch $batch) use ($job_class) {
+            Bus::assertBatched(function (PendingBatch $batch) use ($job_class) {
                 // get array inside the jobs array
                 $jobs = $batch->jobs->first(fn ($job) => is_array($job));
                 $classes = $job_class;

--- a/tests/Jobs/Seatplus/MaintenanceJobTest.php
+++ b/tests/Jobs/Seatplus/MaintenanceJobTest.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Queue;
 use Seatplus\Eveapi\Jobs\Assets\EnrichAssetTypeGroupCategoryJob;
 use Seatplus\Eveapi\Jobs\Character\CharacterInfoJob;
 use Seatplus\Eveapi\Jobs\Hydrate\Maintenance\GetMissingBodysFromMails;
@@ -503,7 +504,7 @@ it('dispatches resolve universe type by id job for missing types of skillqueue',
 });
 
 it('dispatches mail body job for missing mail bodies', function () {
-    \Illuminate\Support\Facades\Queue::fake();
+    Queue::fake();
     $refresh_token = updateRefreshTokenScopes($this->test_character->refresh_token, ['esi-mail.read_mail.v1']);
     $refresh_token->save();
 

--- a/tests/Jobs/Universe/ResolveLocationJobTest.php
+++ b/tests/Jobs/Universe/ResolveLocationJobTest.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Queue;
 use Seatplus\Eveapi\Jobs\Universe\ResolveLocationJob;
+use Seatplus\Eveapi\Models\Universe\Location;
 
 beforeEach(function () {
     Queue::fake();
@@ -23,7 +24,7 @@ it('runs ResolveLocationService', function () {
 
     // Assert
     // assert that mock was called
-    expect(\Seatplus\Eveapi\Models\Universe\Location::all())
+    expect(Location::all())
         ->toHaveCount(0);
 });
 

--- a/tests/Jobs/Universe/ResolveUniverseGroupByIdJobTest.php
+++ b/tests/Jobs/Universe/ResolveUniverseGroupByIdJobTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Event;
+use Seatplus\Eveapi\Jobs\Universe\ResolveUniverseGroupByIdJob;
 use Seatplus\Eveapi\Models\Universe\Group;
 
 it('creates group', function () {
@@ -11,7 +12,7 @@ it('creates group', function () {
 
     expect(Group::first())->toBeNull();
 
-    Event::fakeFor(fn () => (new \Seatplus\Eveapi\Jobs\Universe\ResolveUniverseGroupByIdJob($mock_data->group_id))->handle());
+    Event::fakeFor(fn () => (new ResolveUniverseGroupByIdJob($mock_data->group_id))->handle());
 
     expect(Group::first())
         ->first()->category_id->toBe($mock_data->category_id);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -16,9 +16,12 @@
 use Faker\Factory;
 use Firebase\JWT\JWT;
 use Seatplus\EsiClient\DataTransferObjects\EsiResponse;
+use Seatplus\Eveapi\Models\Character\CharacterInfo;
+use Seatplus\Eveapi\Models\RefreshToken;
 use Seatplus\Eveapi\Services\Facade\RetrieveEsiData;
+use Seatplus\Eveapi\Tests\TestCase;
 
-uses(\Seatplus\Eveapi\Tests\TestCase::class)->in('Unit', 'Integration', 'Jobs');
+uses(TestCase::class)->in('Unit', 'Integration', 'Jobs');
 // uses(\Illuminate\Foundation\Testing\LazilyRefreshDatabase::class)->in('Unit', 'Integration', 'Jobs');
 
 /*
@@ -68,10 +71,10 @@ function noRetrieveEsiDataAction()
 
 function testCharacter()
 {
-    return \Seatplus\Eveapi\Models\Character\CharacterInfo::first();
+    return CharacterInfo::first();
 }
 
-function updateRefreshTokenScopes(Seatplus\Eveapi\Models\RefreshToken $refreshToken, array $scopes): Seatplus\Eveapi\Models\RefreshToken
+function updateRefreshTokenScopes(RefreshToken $refreshToken, array $scopes): RefreshToken
 {
     $jwt = $refreshToken->getRawOriginal('token');
     $jwt_payload_base64_encoded = explode('.', (string) $jwt)[1];

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ namespace Seatplus\Eveapi\Tests;
 
 use Illuminate\Config\Repository;
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Queue;
@@ -39,7 +40,7 @@ abstract class TestCase extends OrchestraTestCase
     /**
      * Get application providers.
      *
-     * @param  \Illuminate\Foundation\Application  $app
+     * @param  Application  $app
      * @return array
      */
     #[\Override]
@@ -54,7 +55,7 @@ abstract class TestCase extends OrchestraTestCase
     /**
      * Define environment setup.
      *
-     * @param  \Illuminate\Foundation\Application  $app
+     * @param  Application  $app
      * @return void
      */
     protected function defineEnvironment($app)

--- a/tests/Unit/Commands/CheckJobsCommandTest.php
+++ b/tests/Unit/Commands/CheckJobsCommandTest.php
@@ -1,15 +1,18 @@
 <?php
 
+use Seatplus\Eveapi\Commands\CheckJobsCommand;
+use Seatplus\Eveapi\Services\JobChecker;
+
 it('writes error, warning and success header', function (array $job_checker_result) {
 
-    $job_checker = mock(\Seatplus\Eveapi\Services\JobChecker::class, function ($mock) use ($job_checker_result) {
+    $job_checker = mock(JobChecker::class, function ($mock) use ($job_checker_result) {
         $mock->shouldReceive('checkJob')
             ->andReturn(collect([
                 $job_checker_result,
             ]));
     });
 
-    $command = new \Seatplus\Eveapi\Commands\CheckJobsCommand($job_checker);
+    $command = new CheckJobsCommand($job_checker);
 
     $command->handle();
 
@@ -32,7 +35,7 @@ it('writes error, warning and success header', function (array $job_checker_resu
 
 it('throws exception if status is unknown', function () {
 
-    $job_checker = mock(\Seatplus\Eveapi\Services\JobChecker::class, function ($mock) {
+    $job_checker = mock(JobChecker::class, function ($mock) {
         $mock->shouldReceive('checkJob')
             ->andReturn(collect([
                 [
@@ -42,9 +45,9 @@ it('throws exception if status is unknown', function () {
             ]));
     });
 
-    $command = new \Seatplus\Eveapi\Commands\CheckJobsCommand($job_checker);
+    $command = new CheckJobsCommand($job_checker);
 
     $command->handle();
 
 })
-    ->throws(\Exception::class, 'Unknown status');
+    ->throws(Exception::class, 'Unknown status');

--- a/tests/Unit/Commands/ClearCacheTest.php
+++ b/tests/Unit/Commands/ClearCacheTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Facades\Redis;
+
 it('clears all caches when force option is provided', function () {
     $this->artisan('seatplus:cache:clear', ['--force' => true])
         ->expectsOutput('SeAT plus Cache Clearing Tool')
@@ -30,7 +32,7 @@ it('clears caches when confirmation is given', function () {
 });
 
 it('handles exception when Redis cache clearing fails', function () {
-    \Illuminate\Support\Facades\Redis::shouldReceive('flushall')->andThrow(new Exception('Redis error'));
+    Redis::shouldReceive('flushall')->andThrow(new Exception('Redis error'));
 
     $this->artisan('seatplus:cache:clear', ['--force' => true])
         ->expectsOutput('SeAT plus Cache Clearing Tool')

--- a/tests/Unit/EveapiServiceProviderTest.php
+++ b/tests/Unit/EveapiServiceProviderTest.php
@@ -1,41 +1,51 @@
 <?php
 
+use Illuminate\Bus\Dispatcher;
 use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Contracts\Queue\Job;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Http\Request;
+use Illuminate\Queue\CallQueuedHandler;
+use Illuminate\Queue\Middleware\RateLimitedWithRedis;
+use Illuminate\Support\Facades\DB;
+use Laravel\Horizon\Horizon;
+use Seatplus\Auth\Models\User;
+use Seatplus\Eveapi\EveapiServiceProvider;
 
 it('tests horizon auth with user', function () {
 
-    $serviceProvider = new \Seatplus\Eveapi\EveapiServiceProvider(app());
+    $serviceProvider = new EveapiServiceProvider(app());
     $serviceProvider->configureHorizon();
 
-    $requestWithUser = new \Illuminate\Http\Request;
+    $requestWithUser = new Request;
     $requestWithUser->setUserResolver(function () {
-        $user = mock(\Seatplus\Auth\Models\User::class, function ($mock) {
+        $user = mock(User::class, function ($mock) {
             $mock->shouldReceive('can')->with('queue_manager')->andReturn(true);
         });
 
         return $user;
     });
 
-    expect(\Laravel\Horizon\Horizon::check($requestWithUser))->toBeTrue();
+    expect(Horizon::check($requestWithUser))->toBeTrue();
 });
 
 it('tests horizon auth without user', function () {
 
-    $serviceProvider = new \Seatplus\Eveapi\EveapiServiceProvider(app());
+    $serviceProvider = new EveapiServiceProvider(app());
     $serviceProvider->configureHorizon();
 
-    $requestWithoutUser = new \Illuminate\Http\Request;
+    $requestWithoutUser = new Request;
 
-    expect(\Laravel\Horizon\Horizon::check($requestWithoutUser))->toBeFalse();
+    expect(Horizon::check($requestWithoutUser))->toBeFalse();
 });
 
 it('returns null when exception is caught', function () {
 
     // arrange
 
-    \Illuminate\Support\Facades\DB::shouldReceive('connection')->andThrow(new Exception('Database connection error'));
+    DB::shouldReceive('connection')->andThrow(new Exception('Database connection error'));
 
-    $serviceProvider = new \Seatplus\Eveapi\EveapiServiceProvider(app());
+    $serviceProvider = new EveapiServiceProvider(app());
     $serviceProvider->boot();
 
     // assert
@@ -69,9 +79,9 @@ it('has limits for character_batch if queue is not high', function () {
 function assertJobRanSuccessfully($testJob)
 {
     $testJob::$handled = false;
-    $instance = new \Illuminate\Queue\CallQueuedHandler(new \Illuminate\Bus\Dispatcher(app()), app());
+    $instance = new CallQueuedHandler(new Dispatcher(app()), app());
 
-    $job = mock(\Illuminate\Contracts\Queue\Job::class, function ($mock) {
+    $job = mock(Job::class, function ($mock) {
         $mock->shouldReceive('hasFailed')->once()->andReturn(false);
         $mock->shouldReceive('isReleased')->andReturn(false);
         $mock->shouldReceive('isDeletedOrReleased')->once()->andReturn(false);
@@ -88,9 +98,9 @@ function assertJobRanSuccessfully($testJob)
 function assertJobWasReleased($testJob)
 {
     $testJob::$handled = false;
-    $instance = new \Illuminate\Queue\CallQueuedHandler(new \Illuminate\Bus\Dispatcher(app()), app());
+    $instance = new CallQueuedHandler(new Dispatcher(app()), app());
 
-    $job = mock(\Illuminate\Contracts\Queue\Job::class, function ($mock) {
+    $job = mock(Job::class, function ($mock) {
         $mock->shouldReceive('hasFailed')->once()->andReturn(false);
         $mock->shouldReceive('release');
         $mock->shouldReceive('isReleased')->andReturn(true);
@@ -106,7 +116,7 @@ function assertJobWasReleased($testJob)
 
 class RateLimitedTestJob
 {
-    use \Illuminate\Foundation\Queue\Queueable, \Illuminate\Queue\InteractsWithQueue;
+    use \Illuminate\Queue\InteractsWithQueue, Queueable;
 
     public static $handled = false;
 
@@ -119,6 +129,6 @@ class RateLimitedTestJob
 
     public function middleware()
     {
-        return [new \Illuminate\Queue\Middleware\RateLimitedWithRedis('character_batch')];
+        return [new RateLimitedWithRedis('character_batch')];
     }
 }

--- a/tests/Unit/JobMiddleware/HasRequiredScopeMiddlewareTest.php
+++ b/tests/Unit/JobMiddleware/HasRequiredScopeMiddlewareTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Seatplus\Eveapi\Esi\HasRequiredScopeInterface;
 use Seatplus\Eveapi\Jobs\EsiBase;
 use Seatplus\Eveapi\Jobs\Middleware\HasRequiredScopeMiddleware;
 use Seatplus\Eveapi\Models\RefreshToken;
@@ -47,7 +48,7 @@ function prepareJobMiddleware(bool $should_fail = true)
 {
     $middleware = new HasRequiredScopeMiddleware;
 
-    $job = Mockery::mock(EsiBase::class, \Seatplus\Eveapi\Esi\HasRequiredScopeInterface::class);
+    $job = Mockery::mock(EsiBase::class, HasRequiredScopeInterface::class);
 
     if ($should_fail) {
         $job->shouldReceive('fail')->times(1);

--- a/tests/Unit/Jobs/AllianceInfoJobTest.php
+++ b/tests/Unit/Jobs/AllianceInfoJobTest.php
@@ -1,7 +1,10 @@
 <?php
 
+use Seatplus\EsiClient\DataTransferObjects\EsiResponse;
+use Seatplus\Eveapi\Jobs\Alliances\AllianceInfoJob;
+
 it('returns early if batch is cancelled', function () {
-    $job = mock(\Seatplus\Eveapi\Jobs\Alliances\AllianceInfoJob::class, function ($mock) {
+    $job = mock(AllianceInfoJob::class, function ($mock) {
         $mock->shouldReceive('batching')->andReturn(true);
         $mock->shouldReceive('batch->cancelled')->once()->andReturn(true);
     })->makePartial();
@@ -12,8 +15,8 @@ it('returns early if batch is cancelled', function () {
 });
 
 it('checks if the response is cached', function () {
-    $job = mock(\Seatplus\Eveapi\Jobs\Alliances\AllianceInfoJob::class, function ($mock) {
-        $response = mock(\Seatplus\EsiClient\DataTransferObjects\EsiResponse::class, function ($mock) {
+    $job = mock(AllianceInfoJob::class, function ($mock) {
+        $response = mock(EsiResponse::class, function ($mock) {
             $mock->shouldReceive('isCachedLoad')->once()->andReturn(true);
         });
 

--- a/tests/Unit/Jobs/CharacterAssetJobTest.php
+++ b/tests/Unit/Jobs/CharacterAssetJobTest.php
@@ -1,8 +1,12 @@
 <?php
 
+use Seatplus\EsiClient\DataTransferObjects\EsiResponse;
+use Seatplus\Eveapi\Jobs\Assets\CharacterAssetJob;
+use Seatplus\Eveapi\Models\Assets\Asset;
+
 it('checks if the response is cached', function () {
-    $job = mock(\Seatplus\Eveapi\Jobs\Assets\CharacterAssetJob::class, function ($mock) {
-        $response = mock(\Seatplus\EsiClient\DataTransferObjects\EsiResponse::class, function ($mock) {
+    $job = mock(CharacterAssetJob::class, function ($mock) {
+        $response = mock(EsiResponse::class, function ($mock) {
             $mock->shouldReceive('isCachedLoad')->andReturn(true);
         });
 
@@ -11,18 +15,18 @@ it('checks if the response is cached', function () {
 
     $job->executeJob();
 
-    expect(\Seatplus\Eveapi\Models\Assets\Asset::count())->toBe(0);
+    expect(Asset::count())->toBe(0);
 });
 
 it('increments page', function () {
     Queue::fake();
 
-    $asset = \Seatplus\Eveapi\Models\Assets\Asset::factory()->count(2)->make();
+    $asset = Asset::factory()->count(2)->make();
 
-    $response1 = new \Seatplus\EsiClient\DataTransferObjects\EsiResponse(json_encode($asset->toArray()), ['X-Pages' => 2], 'now', 200);
-    $response2 = new \Seatplus\EsiClient\DataTransferObjects\EsiResponse('{}', ['X-Pages' => 2], 'now', 200);
+    $response1 = new EsiResponse(json_encode($asset->toArray()), ['X-Pages' => 2], 'now', 200);
+    $response2 = new EsiResponse('{}', ['X-Pages' => 2], 'now', 200);
 
-    $job = mock(\Seatplus\Eveapi\Jobs\Assets\CharacterAssetJob::class)->makePartial();
+    $job = mock(CharacterAssetJob::class)->makePartial();
     $job->__construct(123);
     $job->shouldReceive('retrieve')->twice()->andReturns($response1, $response2);
 

--- a/tests/Unit/Jobs/CharacterAssetsNameJobTest.php
+++ b/tests/Unit/Jobs/CharacterAssetsNameJobTest.php
@@ -1,12 +1,15 @@
 <?php
 
+use Seatplus\Eveapi\Jobs\Assets\CharacterAssetsNameJob;
+use Seatplus\Eveapi\Models\Assets\Asset;
+
 it('returns early if batch is cancelled', function () {
-    $job = mock(\Seatplus\Eveapi\Jobs\Assets\CharacterAssetsNameJob::class)->makePartial();
+    $job = mock(CharacterAssetsNameJob::class)->makePartial();
 
     $job->shouldReceive('batching')->once()->andReturn(true);
     $job->shouldReceive('batch->cancelled')->once()->andReturn(true);
 
     $job->executeJob();
 
-    expect(\Seatplus\Eveapi\Models\Assets\Asset::count())->toBe(0);
+    expect(Asset::count())->toBe(0);
 });

--- a/tests/Unit/Jobs/CharacterBatchJobTest.php
+++ b/tests/Unit/Jobs/CharacterBatchJobTest.php
@@ -1,9 +1,11 @@
 <?php
 
-use Illuminate\Bus\Batch;
+use Illuminate\Support\Facades\Event;
+use Seatplus\Eveapi\Jobs\Contacts\AllianceContactJob;
 use Seatplus\Eveapi\Jobs\Seatplus\Batch\CharacterBatchJob;
 use Seatplus\Eveapi\Models\BatchStatistic;
 use Seatplus\Eveapi\Models\BatchUpdate;
+use Seatplus\Eveapi\Models\Character\CharacterInfo;
 
 it('discards update if still pending', function () {
     $batch_update = new BatchUpdate;
@@ -25,14 +27,14 @@ it('finally creates BatchStatistices', function () {
     // create an very old BatchUpdate
     BatchUpdate::create([
         'batchable_id' => testCharacter()->character_id,
-        'batchable_type' => \Seatplus\Eveapi\Models\Character\CharacterInfo::class,
+        'batchable_type' => CharacterInfo::class,
         'started_at' => now()->subDays(2),
         'finished_at' => now()->subDays(1),
     ]);
 
     $job = new CharacterBatchJob(testCharacter()->character_id, batch_jobs: [fn () => 'test']);
 
-    \Illuminate\Support\Facades\Bus::fake();
+    Illuminate\Support\Facades\Bus::fake();
 
     // Act
     $job->handle();
@@ -57,13 +59,13 @@ it('does not add AllianceContactsJob if no alliance_id is present', function () 
 
     // make sure refresh token has esi-alliances.read_contacts.v1 scope
     $refresh_token = updateRefreshTokenScopes(testCharacter()->refresh_token, ['esi-alliances.read_contacts.v1']);
-    \Illuminate\Support\Facades\Event::fakeFor(fn () => $refresh_token->save());
+    Event::fakeFor(fn () => $refresh_token->save());
 
     // delete alliance_id from character info
     $character_affiliation = testCharacter()->character_affiliation;
     $character_affiliation->alliance_id = null;
 
-    \Illuminate\Support\Facades\Event::fakeFor(fn () => $character_affiliation->save());
+    Event::fakeFor(fn () => $character_affiliation->save());
 
     // Act
     $job = new CharacterBatchJob($character_affiliation->character_id);
@@ -83,7 +85,7 @@ it('does not add AllianceContactsJob if no alliance_id is present', function () 
     $batch_jobs = Arr::flatten($batch_jobs);
 
     foreach ($batch_jobs as $batch_job) {
-        expect($batch_job)->not->toBeInstanceOf(\Seatplus\Eveapi\Jobs\Contacts\AllianceContactJob::class);
+        expect($batch_job)->not->toBeInstanceOf(AllianceContactJob::class);
     }
 });
 

--- a/tests/Unit/Jobs/CharacterContractsJobTest.php
+++ b/tests/Unit/Jobs/CharacterContractsJobTest.php
@@ -2,6 +2,7 @@
 
 use Seatplus\EsiClient\DataTransferObjects\EsiResponse;
 use Seatplus\Eveapi\Jobs\Contracts\CharacterContractsJob;
+use Seatplus\Eveapi\Models\Contracts\Contract;
 
 test('returns early if cached', function () {
 
@@ -20,7 +21,7 @@ it('increments page', function () {
 
     Queue::fake();
 
-    $contract = \Seatplus\Eveapi\Models\Contracts\Contract::factory()->count(2)->make();
+    $contract = Contract::factory()->count(2)->make();
 
     $response1 = new EsiResponse(json_encode($contract->toArray()), ['X-Pages' => 2], 'now', 200);
     $response2 = new EsiResponse('{}', ['X-Pages' => 2], 'now', 200);
@@ -38,7 +39,7 @@ it('adds follow up jobs to batch if batching', function () {
 
     Queue::fake();
 
-    $contract = \Seatplus\Eveapi\Models\Contracts\Contract::factory()->count(2)->make();
+    $contract = Contract::factory()->count(2)->make();
 
     $response = new EsiResponse(json_encode($contract->toArray()), [], 'now', 200);
 

--- a/tests/Unit/Jobs/CharacterInfoJobTest.php
+++ b/tests/Unit/Jobs/CharacterInfoJobTest.php
@@ -1,8 +1,11 @@
 <?php
 
+use Seatplus\EsiClient\DataTransferObjects\EsiResponse;
+use Seatplus\Eveapi\Jobs\Character\CharacterInfoJob;
+
 it('checks if the response is cached', function () {
-    $job = mock(\Seatplus\Eveapi\Jobs\Character\CharacterInfoJob::class, function ($mock) {
-        $response = mock(\Seatplus\EsiClient\DataTransferObjects\EsiResponse::class, function ($mock) {
+    $job = mock(CharacterInfoJob::class, function ($mock) {
+        $response = mock(EsiResponse::class, function ($mock) {
             $mock->shouldReceive('isCachedLoad')->andReturn(true);
         });
 

--- a/tests/Unit/Jobs/CharacterRoleJobTest.php
+++ b/tests/Unit/Jobs/CharacterRoleJobTest.php
@@ -1,8 +1,11 @@
 <?php
 
+use Seatplus\EsiClient\DataTransferObjects\EsiResponse;
+use Seatplus\Eveapi\Jobs\Character\CharacterRoleJob;
+
 it('checks if the response is cached', function () {
-    $job = mock(\Seatplus\Eveapi\Jobs\Character\CharacterRoleJob::class, function ($mock) {
-        $response = mock(\Seatplus\EsiClient\DataTransferObjects\EsiResponse::class, function ($mock) {
+    $job = mock(CharacterRoleJob::class, function ($mock) {
+        $response = mock(EsiResponse::class, function ($mock) {
             $mock->shouldReceive('isCachedLoad')->andReturn(true);
         });
 

--- a/tests/Unit/Jobs/ContractItemsJobTest.php
+++ b/tests/Unit/Jobs/ContractItemsJobTest.php
@@ -1,8 +1,11 @@
 <?php
 
+use Seatplus\EsiClient\DataTransferObjects\EsiResponse;
+use Seatplus\Eveapi\Jobs\Contracts\ContractItemsJob;
+
 it('has tags', function () {
 
-    $job = mock(\Seatplus\Eveapi\Jobs\Contracts\ContractItemsJob::class)->makePartial();
+    $job = mock(ContractItemsJob::class)->makePartial();
     $job->contract_id = 1;
 
     expect($job->tags())->toBeArray();
@@ -10,7 +13,7 @@ it('has tags', function () {
 
 it('stops executing when batch is cancelled', function () {
 
-    $job = mock(\Seatplus\Eveapi\Jobs\Contracts\ContractItemsJob::class)->makePartial();
+    $job = mock(ContractItemsJob::class)->makePartial();
     $job->contract_id = 1;
 
     $job->shouldReceive('batching')->once()->andReturn(true);
@@ -23,10 +26,10 @@ it('stops executing when batch is cancelled', function () {
 
 it('does stop executing if response is cached', function () {
 
-    $response = mock(\Seatplus\EsiClient\DataTransferObjects\EsiResponse::class);
+    $response = mock(EsiResponse::class);
     $response->shouldReceive('isCachedLoad')->andReturn(true);
 
-    $job = mock(\Seatplus\Eveapi\Jobs\Contracts\ContractItemsJob::class)->makePartial();
+    $job = mock(ContractItemsJob::class)->makePartial();
     $job->shouldReceive('retrieve')->andReturn($response);
 
     $job->executeJob();

--- a/tests/Unit/Jobs/CorporationContactLabelJobTest.php
+++ b/tests/Unit/Jobs/CorporationContactLabelJobTest.php
@@ -1,11 +1,15 @@
 <?php
 
+use Seatplus\EsiClient\DataTransferObjects\EsiResponse;
+use Seatplus\Eveapi\Jobs\Contacts\CorporationContactLabelJob;
+use Seatplus\Eveapi\Models\Contacts\Label;
+
 it('returns early if cached', function () {
 
-    $response = mock(\Seatplus\EsiClient\DataTransferObjects\EsiResponse::class);
+    $response = mock(EsiResponse::class);
     $response->shouldReceive('isCachedLoad')->once()->andReturn(true);
 
-    $job = mock(\Seatplus\Eveapi\Jobs\Contacts\CorporationContactLabelJob::class)->makePartial();
+    $job = mock(CorporationContactLabelJob::class)->makePartial();
     $job->shouldReceive('retrieve')->once()->andReturn($response);
     $job->corporation_id = 123;
 
@@ -18,12 +22,12 @@ it('increments page', function () {
 
     Queue::fake();
 
-    $contact_label = \Seatplus\Eveapi\Models\Contacts\Label::factory()->count(2)->make();
+    $contact_label = Label::factory()->count(2)->make();
 
-    $response1 = new \Seatplus\EsiClient\DataTransferObjects\EsiResponse(json_encode($contact_label->toArray()), ['X-Pages' => 2], 'now', 200);
-    $response2 = new \Seatplus\EsiClient\DataTransferObjects\EsiResponse('{}', ['X-Pages' => 2], 'now', 200);
+    $response1 = new EsiResponse(json_encode($contact_label->toArray()), ['X-Pages' => 2], 'now', 200);
+    $response2 = new EsiResponse('{}', ['X-Pages' => 2], 'now', 200);
 
-    $job = mock(\Seatplus\Eveapi\Jobs\Contacts\CorporationContactLabelJob::class)->makePartial();
+    $job = mock(CorporationContactLabelJob::class)->makePartial();
     $job->__construct(123, 456);
     $job->shouldReceive('retrieve')->twice()->andReturns($response1, $response2);
 

--- a/tests/Unit/Jobs/CorporationDivisionsJobTest.php
+++ b/tests/Unit/Jobs/CorporationDivisionsJobTest.php
@@ -1,9 +1,13 @@
 <?php
 
+use Seatplus\EsiClient\DataTransferObjects\EsiResponse;
+use Seatplus\Eveapi\Jobs\Corporation\CorporationDivisionsJob;
+use Seatplus\Eveapi\Jobs\Middleware\EsiProactiveRateLimitMiddleware;
+use Seatplus\Eveapi\Jobs\Middleware\HasRequiredScopeMiddleware;
 use Seatplus\Eveapi\Models\Corporation\CorporationDivision;
 
 it('has tags', function () {
-    $job = new \Seatplus\Eveapi\Jobs\Corporation\CorporationDivisionsJob(1);
+    $job = new CorporationDivisionsJob(1);
 
     expect($job->tags())->toEqual([
         'corporation',
@@ -13,20 +17,20 @@ it('has tags', function () {
 });
 
 it('has middleware', function () {
-    $job = new \Seatplus\Eveapi\Jobs\Corporation\CorporationDivisionsJob(1);
+    $job = new CorporationDivisionsJob(1);
 
     expect($job->middleware())->toBeArray()
         ->and($job->middleware())->toHaveCount(3)
-        ->and($job->middleware()[0])->toBeInstanceOf(\Seatplus\Eveapi\Jobs\Middleware\HasRequiredScopeMiddleware::class)
-        ->and($job->middleware()[1])->toBeInstanceOf(\Seatplus\Eveapi\Jobs\Middleware\EsiProactiveRateLimitMiddleware::class);
+        ->and($job->middleware()[0])->toBeInstanceOf(HasRequiredScopeMiddleware::class)
+        ->and($job->middleware()[1])->toBeInstanceOf(EsiProactiveRateLimitMiddleware::class);
 });
 
 it('returns early if response is cached', function () {
 
-    $response = mock(\Seatplus\EsiClient\DataTransferObjects\EsiResponse::class);
+    $response = mock(EsiResponse::class);
     $response->shouldReceive('isCachedLoad')->andReturn(true);
 
-    $job = mock(\Seatplus\Eveapi\Jobs\Corporation\CorporationDivisionsJob::class)->makePartial();
+    $job = mock(CorporationDivisionsJob::class)->makePartial();
     $job->shouldReceive('retrieve')->andReturn($response);
 
     $job->executeJob();

--- a/tests/Unit/Jobs/CorporationMemberTrackingJobTest.php
+++ b/tests/Unit/Jobs/CorporationMemberTrackingJobTest.php
@@ -1,14 +1,18 @@
 <?php
 
+use Seatplus\EsiClient\DataTransferObjects\EsiResponse;
+use Seatplus\Eveapi\Jobs\Corporation\CorporationMemberTrackingJob;
+use Seatplus\Eveapi\Models\Corporation\CorporationMemberTracking;
+
 it('returns early if resonse is cached', function () {
 
-    $response = \Mockery::mock(\Seatplus\EsiClient\DataTransferObjects\EsiResponse::class);
+    $response = Mockery::mock(EsiResponse::class);
     $response->shouldReceive('isCachedLoad')->andReturn(true);
 
-    $job = mock(\Seatplus\Eveapi\Jobs\Corporation\CorporationMemberTrackingJob::class)->makePartial();
+    $job = mock(CorporationMemberTrackingJob::class)->makePartial();
     $job->shouldReceive('retrieve')->andReturn($response);
 
     $job->executeJob();
 
-    expect(\Seatplus\Eveapi\Models\Corporation\CorporationMemberTracking::query()->count())->toEqual(0);
+    expect(CorporationMemberTracking::query()->count())->toEqual(0);
 });

--- a/tests/Unit/Jobs/CorporationWalletJournalJobTest.php
+++ b/tests/Unit/Jobs/CorporationWalletJournalJobTest.php
@@ -1,6 +1,9 @@
 <?php
 
+use Mockery\MockInterface;
 use Seatplus\Eveapi\Jobs\Wallet\CorporationWalletJournalJob;
+use Seatplus\Eveapi\Models\Corporation\CorporationInfo;
+use Seatplus\Eveapi\Models\Wallet\Balance;
 
 beforeEach(function () {
     Queue::fake();
@@ -26,15 +29,15 @@ it('returns correct tags', function () {
 describe('handle batching', function () {
 
     beforeEach(function () {
-        \Seatplus\Eveapi\Models\Wallet\Balance::factory()->withDivision()->create([
+        Balance::factory()->withDivision()->create([
             'balanceable_id' => testCharacter()->corporation_id,
-            'balanceable_type' => \Seatplus\Eveapi\Models\Corporation\CorporationInfo::class,
+            'balanceable_type' => CorporationInfo::class,
         ]);
     });
 
     test('cancelled', function () {
 
-        $job = mock(CorporationWalletJournalJob::class, [testCharacter()->corporation_id], function (\Mockery\MockInterface $mock) {
+        $job = mock(CorporationWalletJournalJob::class, [testCharacter()->corporation_id], function (MockInterface $mock) {
             $mock->shouldReceive('batching')->andReturnTrue();
             $mock->shouldReceive('batch->cancelled')->once()->andReturnTrue();
         })->makePartial();
@@ -44,7 +47,7 @@ describe('handle batching', function () {
 
     test('adding to batch', function () {
 
-        $job = mock(CorporationWalletJournalJob::class, [testCharacter()->corporation_id], function (\Mockery\MockInterface $mock) {
+        $job = mock(CorporationWalletJournalJob::class, [testCharacter()->corporation_id], function (MockInterface $mock) {
             $mock->shouldReceive('batching')->andReturnTrue();
             $mock->shouldReceive('batch->cancelled')->once()->andReturnFalse();
             $mock->shouldReceive('batch->add')->once();

--- a/tests/Unit/Jobs/EnrichAssetTypeGroupCategoryJobTest.php
+++ b/tests/Unit/Jobs/EnrichAssetTypeGroupCategoryJobTest.php
@@ -1,11 +1,14 @@
 <?php
 
+use Seatplus\Eveapi\Jobs\Assets\EnrichAssetTypeGroupCategoryJob;
+use Seatplus\Eveapi\Models\Assets\Asset;
+
 it('returns early if batch is cancelled', function () {
-    $job = mock(\Seatplus\Eveapi\Jobs\Assets\EnrichAssetTypeGroupCategoryJob::class, function ($mock) {
+    $job = mock(EnrichAssetTypeGroupCategoryJob::class, function ($mock) {
         $mock->shouldReceive('batch->cancelled')->andReturn(true);
     })->makePartial();
 
     $job->handle();
 
-    expect(\Seatplus\Eveapi\Models\Assets\Asset::count())->toBe(0);
+    expect(Asset::count())->toBe(0);
 });

--- a/tests/Unit/Jobs/EsiBaseTest.php
+++ b/tests/Unit/Jobs/EsiBaseTest.php
@@ -1,15 +1,18 @@
 <?php
 
+use Mockery\MockInterface;
+use Seatplus\Eveapi\Jobs\EsiBase;
+
 it('has backoff array', function () {
-    $job = mock(\Seatplus\Eveapi\Jobs\EsiBase::class)->makePartial();
+    $job = mock(EsiBase::class)->makePartial();
 
     expect($job->backoff())->toBeArray();
 });
 
 it('reports exception', function () {
-    $job = mock(\Seatplus\Eveapi\Jobs\EsiBase::class, function (\Mockery\MockInterface $mock) {
+    $job = mock(EsiBase::class, function (MockInterface $mock) {
         $mock->shouldReceive('executeJob')
-            ->andThrow(new \Exception('test'));
+            ->andThrow(new Exception('test'));
 
     })->makePartial();
 
@@ -17,4 +20,4 @@ it('reports exception', function () {
     $job->handle();
 
 })
-    ->throws(\Exception::class, 'test');
+    ->throws(Exception::class, 'test');

--- a/tests/Unit/Jobs/GetMissingLocationsTest.php
+++ b/tests/Unit/Jobs/GetMissingLocationsTest.php
@@ -1,11 +1,12 @@
 <?php
 
+use Illuminate\Support\Facades\Event;
 use Seatplus\Eveapi\Jobs\Hydrate\Maintenance\GetMissingLocations;
 use Seatplus\Eveapi\Models\Universe\Location;
 
 it('adds resolve location job to batch', function () {
 
-    \Illuminate\Support\Facades\Event::fakeFor(fn () => Location::factory()->create());
+    Event::fakeFor(fn () => Location::factory()->create());
 
     $job = mock(GetMissingLocations::class)->makePartial();
     $job->shouldReceive('batch->cancelled')->andReturn(false);

--- a/tests/Unit/Jobs/HydrateTest.php
+++ b/tests/Unit/Jobs/HydrateTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\Event;
 use Seatplus\Eveapi\Jobs\Hydrate\Maintenance\GetMissingBodysFromMails;
 use Seatplus\Eveapi\Jobs\Hydrate\Maintenance\GetMissingCategorys;
 use Seatplus\Eveapi\Jobs\Hydrate\Maintenance\GetMissingCharacterInfosFromCorporationMemberTracking;
@@ -18,6 +19,7 @@ use Seatplus\Eveapi\Jobs\Hydrate\Maintenance\GetMissingTypesFromLocations;
 use Seatplus\Eveapi\Jobs\Hydrate\Maintenance\GetMissingTypesFromSkillQueue;
 use Seatplus\Eveapi\Jobs\Hydrate\Maintenance\GetMissingTypesFromSkills;
 use Seatplus\Eveapi\Jobs\Hydrate\Maintenance\GetMissingTypesFromWalletTransaction;
+use Seatplus\Eveapi\Models\Mail\Mail;
 
 it('returns early if batch is cancelled', function (string $job) {
     $job = mock($job)->makePartial();
@@ -52,8 +54,8 @@ it('returns early if batch is cancelled', function (string $job) {
 
 it('returns null if no refresh token is found', function () {
 
-    \Illuminate\Support\Facades\Event::fakeFor(function () {
-        \Seatplus\Eveapi\Models\Mail\Mail::factory()->create();
+    Event::fakeFor(function () {
+        Mail::factory()->create();
     });
 
     $job = mock(GetMissingBodysFromMails::class)->makePartial();

--- a/tests/Unit/Jobs/KillmailJobTest.php
+++ b/tests/Unit/Jobs/KillmailJobTest.php
@@ -1,8 +1,10 @@
 <?php
 
+use Illuminate\Support\Facades\Event;
 use Seatplus\EsiClient\DataTransferObjects\EsiResponse;
 use Seatplus\Eveapi\Jobs\Killmails\KillmailJob;
 use Seatplus\Eveapi\Models\Killmails\Killmail;
+use Seatplus\Eveapi\Models\Universe\System;
 
 it('returns early if cache is hit', function () {
 
@@ -23,9 +25,9 @@ it('returns early if cache is hit', function () {
 
 it('does not further execute if killmail is complete', function () {
 
-    \Illuminate\Support\Facades\Queue::fake();
+    Illuminate\Support\Facades\Queue::fake();
 
-    $killmail = \Illuminate\Support\Facades\Event::fakeFor(fn () => Killmail::factory()->create([
+    $killmail = Event::fakeFor(fn () => Killmail::factory()->create([
         'complete' => true,
         'solar_system_id' => 12345,
     ]));
@@ -53,13 +55,13 @@ it('does not further execute if killmail is complete', function () {
     $job->executeJob();
 
     Queue::assertNothingPushed();
-    expect(\Seatplus\Eveapi\Models\Universe\System::count())->toEqual(0);
+    expect(System::count())->toEqual(0);
 });
 
 it('adds to batch', function () {
     Queue::fake();
 
-    $killmail = \Illuminate\Support\Facades\Event::fakeFor(fn () => Killmail::factory()->make([
+    $killmail = Event::fakeFor(fn () => Killmail::factory()->make([
         'complete' => false,
         'ship_type_id' => 12345,
         'solar_system_id' => 12345,

--- a/tests/Unit/Jobs/MailBodyJobTest.php
+++ b/tests/Unit/Jobs/MailBodyJobTest.php
@@ -2,6 +2,7 @@
 
 use Seatplus\EsiClient\DataTransferObjects\EsiResponse;
 use Seatplus\Eveapi\Jobs\Mail\MailBodyJob;
+use Seatplus\Eveapi\Models\Mail\Mail;
 
 it('returns early if cache is hit', function () {
 
@@ -14,5 +15,5 @@ it('returns early if cache is hit', function () {
 
     $job->executeJob();
 
-    expect(\Seatplus\Eveapi\Models\Mail\Mail::all())->toHaveCount(0);
+    expect(Mail::all())->toHaveCount(0);
 });

--- a/tests/Unit/Jobs/MailHeaderJobTest.php
+++ b/tests/Unit/Jobs/MailHeaderJobTest.php
@@ -1,7 +1,11 @@
 <?php
 
+use Seatplus\EsiClient\DataTransferObjects\EsiResponse;
+use Seatplus\Eveapi\Jobs\Mail\MailHeaderJob;
+use Seatplus\Eveapi\Models\Mail\Mail;
+
 it('has tags', function () {
-    $job = new \Seatplus\Eveapi\Jobs\Mail\MailHeaderJob(1);
+    $job = new MailHeaderJob(1);
 
     expect($job->tags())->toHaveCount(3)
         ->and($job->tags())->toContain('mail')
@@ -10,13 +14,13 @@ it('has tags', function () {
 });
 
 it('returns early if response is cached', function () {
-    $response = mock(\Seatplus\EsiClient\DataTransferObjects\EsiResponse::class);
+    $response = mock(EsiResponse::class);
     $response->shouldReceive('isCachedLoad')->andReturn(true);
 
-    $job = mock(\Seatplus\Eveapi\Jobs\Mail\MailHeaderJob::class)->makePartial();
+    $job = mock(MailHeaderJob::class)->makePartial();
     $job->shouldReceive('retrieve')->andReturn($response);
 
     $job->executeJob();
 
-    expect(\Seatplus\Eveapi\Models\Mail\Mail::all())->toHaveCount(0);
+    expect(Mail::all())->toHaveCount(0);
 });

--- a/tests/Unit/Jobs/MaintenanceJobTest.php
+++ b/tests/Unit/Jobs/MaintenanceJobTest.php
@@ -1,7 +1,9 @@
 <?php
 
+use Seatplus\Eveapi\Jobs\Seatplus\MaintenanceJob;
+
 it('has correct tags', function () {
-    $job = new \Seatplus\Eveapi\Jobs\Seatplus\MaintenanceJob;
+    $job = new MaintenanceJob;
 
     expect($job->tags())->toBeArray()
         ->and($job->tags())->toBe(['Maintenance']);

--- a/tests/Unit/Jobs/SkillQueueJobTest.php
+++ b/tests/Unit/Jobs/SkillQueueJobTest.php
@@ -1,7 +1,9 @@
 <?php
 
+use Seatplus\Eveapi\Jobs\Skills\SkillQueueJob;
+
 it('has tags', function () {
-    $job = new \Seatplus\Eveapi\Jobs\Skills\SkillQueueJob(1);
+    $job = new SkillQueueJob(1);
 
     expect($job->tags())->toBe([
         'skill queue',

--- a/tests/Unit/Jobs/SkillsJobTest.php
+++ b/tests/Unit/Jobs/SkillsJobTest.php
@@ -1,7 +1,9 @@
 <?php
 
+use Seatplus\Eveapi\Jobs\Skills\SkillsJob;
+
 it('has tags', function () {
-    $job = new \Seatplus\Eveapi\Jobs\Skills\SkillsJob(1);
+    $job = new SkillsJob(1);
 
     expect($job->tags())->toBe([
         'skills',

--- a/tests/Unit/Jobs/WalletJournalBaseTest.php
+++ b/tests/Unit/Jobs/WalletJournalBaseTest.php
@@ -1,15 +1,16 @@
 <?php
 
+use Mockery\MockInterface;
 use Seatplus\EsiClient\DataTransferObjects\EsiResponse;
 use Seatplus\Eveapi\Jobs\Wallet\WalletJournalBase;
 
 it('does not execute job if response is cached', function () {
-    $job = mock(WalletJournalBase::class, function (\Mockery\MockInterface $mock) {
+    $job = mock(WalletJournalBase::class, function (MockInterface $mock) {
         $mock->shouldReceive('getPathValues')->once()->andReturn([
             'character_id' => 12345,
         ]);
 
-        $response = mock(EsiResponse::class, function (\Mockery\MockInterface $mock) {
+        $response = mock(EsiResponse::class, function (MockInterface $mock) {
             $mock->shouldReceive('isCachedLoad')->once()->andReturnTrue();
         });
 
@@ -26,12 +27,12 @@ it('does not execute job if response is cached', function () {
 
 it('handles multiple pages correctly', function () {
 
-    $job = mock(WalletJournalBase::class, function (\Mockery\MockInterface $mock) {
+    $job = mock(WalletJournalBase::class, function (MockInterface $mock) {
         $mock->shouldReceive('getPathValues')->once()->andReturn([
             'character_id' => 12345,
         ]);
 
-        $response = mock(EsiResponse::class, function (\Mockery\MockInterface $mock) {
+        $response = mock(EsiResponse::class, function (MockInterface $mock) {
             $mock->shouldReceive('isCachedLoad')->andReturnFalse();
             $mock->pages = 2;
             $mock->data = (object) [];
@@ -48,12 +49,12 @@ it('handles multiple pages correctly', function () {
 });
 
 it('handles contextable type', function ($context_id_type) {
-    $job = mock(WalletJournalBase::class, function (\Mockery\MockInterface $mock) use ($context_id_type) {
+    $job = mock(WalletJournalBase::class, function (MockInterface $mock) use ($context_id_type) {
         $mock->shouldReceive('getPathValues')->once()->andReturn([
             'corporation_id' => 12345,
         ]);
 
-        $response = mock(EsiResponse::class, function (\Mockery\MockInterface $mock) use ($context_id_type) {
+        $response = mock(EsiResponse::class, function (MockInterface $mock) use ($context_id_type) {
             $mock->shouldReceive('isCachedLoad')->andReturnFalse();
             $mock->pages = 1;
             $mock->data = (object) [

--- a/tests/Unit/Jobs/WalletTransactionBaseTest.php
+++ b/tests/Unit/Jobs/WalletTransactionBaseTest.php
@@ -1,11 +1,12 @@
 <?php
 
+use Illuminate\Support\Facades\Queue;
 use Mockery\MockInterface;
 use Seatplus\EsiClient\DataTransferObjects\EsiResponse;
 use Seatplus\Eveapi\Jobs\Wallet\WalletTransactionBase;
 use Seatplus\Eveapi\Models\Wallet\WalletTransaction;
 
-beforeEach(fn () => \Illuminate\Support\Facades\Queue::fake());
+beforeEach(fn () => Queue::fake());
 
 it('sets from_id to latest transaction id minus one when latest transaction exists', function () {
 

--- a/tests/Unit/Listeners/DispatchGetConstellationByIdTest.php
+++ b/tests/Unit/Listeners/DispatchGetConstellationByIdTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Mockery\MockInterface;
 use Seatplus\Eveapi\Events\UniverseSystemCreated;
 use Seatplus\Eveapi\Jobs\Universe\ResolveUniverseConstellationByConstellationIdJob;
 use Seatplus\Eveapi\Listeners\DispatchGetConstellationById;
@@ -25,7 +26,7 @@ it('dispatches job when constellation is null', function () {
 });
 
 it('does not dispatch job when constellation is not null', function () {
-    $event = mock(UniverseSystemCreated::class, function (\Mockery\MockInterface $mock) {
+    $event = mock(UniverseSystemCreated::class, function (MockInterface $mock) {
 
         $mock->system = System::factory()->make();
     })->makePartial();

--- a/tests/Unit/Models/ApplicationLogModelTest.php
+++ b/tests/Unit/Models/ApplicationLogModelTest.php
@@ -1,9 +1,10 @@
 <?php
 
+use Seatplus\Eveapi\Models\Application;
 use Seatplus\Eveapi\Models\Character\CharacterInfo;
 
 it('has causer morph relationshio', function () {
-    $application = \Seatplus\Eveapi\Models\Application::factory()->create();
+    $application = Application::factory()->create();
 
     $log = $application->log_entries()->create([
         'causer_type' => CharacterInfo::class,
@@ -13,5 +14,5 @@ it('has causer morph relationshio', function () {
     ]);
 
     expect($log)->causer->toBeInstanceOf(CharacterInfo::class)
-        ->and($log->application)->toBeInstanceOf(\Seatplus\Eveapi\Models\Application::class);
+        ->and($log->application)->toBeInstanceOf(Application::class);
 });

--- a/tests/Unit/Models/BatchUpdateTest.php
+++ b/tests/Unit/Models/BatchUpdateTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Carbon\Carbon;
 use Seatplus\Eveapi\Models\BatchUpdate;
 use Seatplus\Eveapi\Models\Character\CharacterInfo;
 
@@ -42,8 +43,8 @@ it('has isPending attribute and scope', function ($batch) {
 
     expect($batch)
         ->is_pending->toBeFalse()
-        ->started_at->toBeInstanceOf(\Carbon\Carbon::class)
-        ->finished_at->toBeInstanceOf(\Carbon\Carbon::class);
+        ->started_at->toBeInstanceOf(Carbon::class)
+        ->finished_at->toBeInstanceOf(Carbon::class);
 
     // check the scope, should be 0
     $query_result = BatchUpdate::query()->pending()->get();

--- a/tests/Unit/Models/KillmailItemModelTest.php
+++ b/tests/Unit/Models/KillmailItemModelTest.php
@@ -1,7 +1,9 @@
 <?php
 
+use Seatplus\Eveapi\Models\Killmails\KillmailItem;
+
 it('has a has_content attribute', function () {
-    $killmail_item = \Seatplus\Eveapi\Models\Killmails\KillmailItem::query()->create([
+    $killmail_item = KillmailItem::query()->create([
         'location_id' => 123,
         'location_flag' => 'everything_else',
         'quantity' => 1,
@@ -11,7 +13,7 @@ it('has a has_content attribute', function () {
     expect($killmail_item->has_content)->toBeFalse();
 
     // create content
-    \Seatplus\Eveapi\Models\Killmails\KillmailItem::query()->create([
+    KillmailItem::query()->create([
         'location_id' => $killmail_item->id,
         'location_flag' => 'everything_else',
         'quantity' => 1,
@@ -22,7 +24,7 @@ it('has a has_content attribute', function () {
 });
 
 it('has a content relationship', function () {
-    $killmail_item = \Seatplus\Eveapi\Models\Killmails\KillmailItem::query()->create([
+    $killmail_item = KillmailItem::query()->create([
         'location_id' => 123,
         'location_flag' => 'everything_else',
         'quantity' => 1,
@@ -32,7 +34,7 @@ it('has a content relationship', function () {
     expect($killmail_item->content)->toBeEmpty();
 
     // create content
-    \Seatplus\Eveapi\Models\Killmails\KillmailItem::query()->create([
+    KillmailItem::query()->create([
         'location_id' => $killmail_item->id,
         'location_flag' => 'everything_else',
         'quantity' => 1,
@@ -43,7 +45,7 @@ it('has a content relationship', function () {
 });
 
 it('deletes content', function () {
-    $killmail_item = \Seatplus\Eveapi\Models\Killmails\KillmailItem::query()->create([
+    $killmail_item = KillmailItem::query()->create([
         'location_id' => 123,
         'location_flag' => 'everything_else',
         'quantity' => 1,
@@ -51,7 +53,7 @@ it('deletes content', function () {
     ]);
 
     // create content
-    $content = \Seatplus\Eveapi\Models\Killmails\KillmailItem::query()->create([
+    $content = KillmailItem::query()->create([
         'location_id' => $killmail_item->id,
         'location_flag' => 'everything_else',
         'quantity' => 1,
@@ -62,5 +64,5 @@ it('deletes content', function () {
 
     $killmail_item->delete();
 
-    expect(\Seatplus\Eveapi\Models\Killmails\KillmailItem::count())->toBe(0);
+    expect(KillmailItem::count())->toBe(0);
 });

--- a/tests/Unit/Models/LabelModelTest.php
+++ b/tests/Unit/Models/LabelModelTest.php
@@ -1,11 +1,15 @@
 <?php
 
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Seatplus\Eveapi\Models\Character\CharacterInfo;
+use Seatplus\Eveapi\Models\Contacts\Label;
+
 it('has labelable relationship', function () {
-    $label = \Seatplus\Eveapi\Models\Contacts\Label::factory()->create([
+    $label = Label::factory()->create([
         'labelable_id' => testCharacter()->character_id,
-        'labelable_type' => \Seatplus\Eveapi\Models\Character\CharacterInfo::class,
+        'labelable_type' => CharacterInfo::class,
     ]);
 
-    expect($label->labelable())->toBeInstanceOf(\Illuminate\Database\Eloquent\Relations\MorphTo::class)
+    expect($label->labelable())->toBeInstanceOf(MorphTo::class)
         ->and($label->labelable->character_id)->toEqual(testCharacter()->character_id);
 });

--- a/tests/Unit/Models/LocationModelTest.php
+++ b/tests/Unit/Models/LocationModelTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Seatplus\Eveapi\Models\Assets\Asset;
 use Seatplus\Eveapi\Models\Universe\Location;
 use Seatplus\Eveapi\Models\Universe\Station;
 use Seatplus\Eveapi\Models\Universe\System;
@@ -54,7 +55,7 @@ it('has assets relationship', function () {
         'locatable_type' => Station::class,
     ]);
 
-    \Seatplus\Eveapi\Models\Assets\Asset::factory()->create([
+    Asset::factory()->create([
         'location_id' => $location->location_id,
     ]);
 

--- a/tests/Unit/Models/LocationRefreshTokenModelTest.php
+++ b/tests/Unit/Models/LocationRefreshTokenModelTest.php
@@ -1,10 +1,11 @@
 <?php
 
+use Illuminate\Support\Facades\Event;
 use Seatplus\Eveapi\Models\LocationRefreshToken;
 use Seatplus\Eveapi\Models\Universe\Location;
 
 beforeEach(function () {
-    \Illuminate\Support\Facades\Event::fake();
+    Event::fake();
 });
 
 it('belongs to a location', function () {

--- a/tests/Unit/Models/RefreshTokenModelTest.php
+++ b/tests/Unit/Models/RefreshTokenModelTest.php
@@ -1,7 +1,9 @@
 <?php
 
+use Carbon\Carbon;
 use Seatplus\Eveapi\Models\Character\CharacterInfo;
 use Seatplus\Eveapi\Models\Corporation\CorporationInfo;
+use Seatplus\Eveapi\Models\RefreshToken;
 
 it('has character relationship', function () {
     expect($this->test_character->refresh_token->character)->toBeInstanceOf(CharacterInfo::class);
@@ -12,15 +14,15 @@ it('has corporation relationship', function () {
 });
 
 it('only returns token if it is not already considered expired', function () {
-    $refresh_token = \Seatplus\Eveapi\Models\RefreshToken::factory()->make();
+    $refresh_token = RefreshToken::factory()->make();
 
     expect($refresh_token)
-        ->expires_on->timestamp->toBeGreaterThan(\Illuminate\Support\Carbon::now()->timestamp)
+        ->expires_on->timestamp->toBeGreaterThan(Illuminate\Support\Carbon::now()->timestamp)
         ->token->toBeString();
 
-    $refresh_token->expires_on = \Carbon\Carbon::now()->subMinutes(2);
+    $refresh_token->expires_on = Carbon::now()->subMinutes(2);
 
     expect($refresh_token)
-        ->expires_on->timestamp->toBeLessThan(\Illuminate\Support\Carbon::now()->timestamp)
+        ->expires_on->timestamp->toBeLessThan(Illuminate\Support\Carbon::now()->timestamp)
         ->token->toBeNull();
 });

--- a/tests/Unit/Models/UniverseStationModelTest.php
+++ b/tests/Unit/Models/UniverseStationModelTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Seatplus\Eveapi\Models\Universe\Location;
 use Seatplus\Eveapi\Models\Universe\Station;
 use Seatplus\Eveapi\Models\Universe\System;
 
@@ -15,7 +16,7 @@ it('has location relation', function () {
     $station = Station::factory()->create([
         'system_id' => $system->system_id,
     ]);
-    \Seatplus\Eveapi\Models\Universe\Location::factory()->create([
+    Location::factory()->create([
         'locatable_id' => $station->station_id,
         'locatable_type' => Station::class,
     ]);
@@ -24,5 +25,5 @@ it('has location relation', function () {
     $location = $station->location;
 
     // Assert
-    expect($location)->toBeInstanceOf(\Seatplus\Eveapi\Models\Universe\Location::class);
+    expect($location)->toBeInstanceOf(Location::class);
 });

--- a/tests/Unit/RetrieveFromEsiBaseTest.php
+++ b/tests/Unit/RetrieveFromEsiBaseTest.php
@@ -1,18 +1,24 @@
 <?php
 
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\ServerException;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
 use Seatplus\EsiClient\DataTransferObjects\EsiResponse;
 use Seatplus\EsiClient\Exceptions\RequestFailedException;
+use Seatplus\Eveapi\Jobs\Assets\CharacterAssetJob;
+use Seatplus\Eveapi\Services\Facade\RetrieveEsiData;
 
 it('fails when server exception is handled', function () {
 
     $exception = new RequestFailedException(
-        new \GuzzleHttp\Exception\ServerException('failed', new \GuzzleHttp\Psr7\Request('get', 'now'), new \GuzzleHttp\Psr7\Response(404)),
+        new ServerException('failed', new Request('get', 'now'), new Response(404)),
         new EsiResponse(json_encode([]), [], 'now', 200)
     );
 
-    \Seatplus\Eveapi\Services\Facade\RetrieveEsiData::shouldReceive('execute')->andThrow($exception);
+    RetrieveEsiData::shouldReceive('execute')->andThrow($exception);
 
-    $job = new \Seatplus\Eveapi\Jobs\Assets\CharacterAssetJob(123);
+    $job = new CharacterAssetJob(123);
     $job->executeJob();
 
     expect(true)->toBeTrue();
@@ -21,13 +27,13 @@ it('fails when server exception is handled', function () {
 it('fails when client exception is handled', function () {
 
     $exception = new RequestFailedException(
-        new \GuzzleHttp\Exception\ClientException('failed', new \GuzzleHttp\Psr7\Request('get', 'now'), new \GuzzleHttp\Psr7\Response(404)),
+        new ClientException('failed', new Request('get', 'now'), new Response(404)),
         new EsiResponse(json_encode([]), [], 'now', 200)
     );
 
-    \Seatplus\Eveapi\Services\Facade\RetrieveEsiData::shouldReceive('execute')->andThrow($exception);
+    RetrieveEsiData::shouldReceive('execute')->andThrow($exception);
 
-    $job = new \Seatplus\Eveapi\Jobs\Assets\CharacterAssetJob(123);
+    $job = new CharacterAssetJob(123);
     $job->executeJob();
 
     expect(true)->toBeTrue();

--- a/tests/Unit/Services/Character/RefreshCharacterAffiliationsServiceTest.php
+++ b/tests/Unit/Services/Character/RefreshCharacterAffiliationsServiceTest.php
@@ -1,15 +1,18 @@
 <?php
 
 use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Redis;
 use Seatplus\Eveapi\Jobs\Character\CharacterAffiliationJob;
 use Seatplus\Eveapi\Models\Character\CharacterAffiliation;
+use Seatplus\Eveapi\Models\Character\CharacterInfo;
 use Seatplus\Eveapi\Services\Character\RefreshCharacterAffiliationsService;
+use Seatplus\Eveapi\Services\Jobs\CacheCharacterAffiliationIdsService;
 
 beforeEach(function () {
     Queue::fake();
 
     CharacterAffiliation::query()->whereNotIn('character_id', [testCharacter()->character_id])->delete();
-    \Seatplus\Eveapi\Models\Character\CharacterInfo::query()->whereNotIn('character_id', [testCharacter()->character_id])->delete();
+    CharacterInfo::query()->whereNotIn('character_id', [testCharacter()->character_id])->delete();
 
     // check that only one CharacterAffiliation exists and that it is the test character
     expect(CharacterAffiliation::count())->toBe(1)
@@ -44,10 +47,10 @@ describe('dispatches CharacterAffiliationJob for ', function () {
         // arrange
 
         // clear the redis cache
-        \Illuminate\Support\Facades\Redis::flushall();
+        Redis::flushall();
 
         // cache the character id
-        \Seatplus\Eveapi\Services\Jobs\CacheCharacterAffiliationIdsService::make()
+        CacheCharacterAffiliationIdsService::make()
             ->queue(testCharacter()->character_id);
 
         // act

--- a/tests/Unit/Services/EsiPathServiceTest.php
+++ b/tests/Unit/Services/EsiPathServiceTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Http;
+use Seatplus\Eveapi\Services\EsiPathService;
 
 it('can get esi paths', function () {
 
@@ -18,7 +19,7 @@ it('can get esi paths', function () {
         ]),
     ]);
 
-    $esi_path_service = new \Seatplus\Eveapi\Services\EsiPathService;
+    $esi_path_service = new EsiPathService;
 
     expect($esi_path_service->getEsiPaths())->toBeArray();
 });

--- a/tests/Unit/Services/FindCorporationRefreshTokenTest.php
+++ b/tests/Unit/Services/FindCorporationRefreshTokenTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Seatplus\Eveapi\Services\FindCorporationRefreshToken;
+
 it('returns no RefreshToken if character has no role', function () {
 
     // Arrange
@@ -10,7 +12,7 @@ it('returns no RefreshToken if character has no role', function () {
     updateRefreshTokenScopes(testCharacter()->refresh_token, [$scope])->save();
 
     // Act
-    $find_corporation_refresh_token = new \Seatplus\Eveapi\Services\FindCorporationRefreshToken;
+    $find_corporation_refresh_token = new FindCorporationRefreshToken;
 
     $refresh_token = $find_corporation_refresh_token($corporation_id, $scope, $role);
 

--- a/tests/Unit/Services/GetUpToDateRefreshTokenServiceTest.php
+++ b/tests/Unit/Services/GetUpToDateRefreshTokenServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Facades\Event;
+use Mockery\MockInterface;
 use Seatplus\EsiClient\DataTransferObjects\EsiResponse;
 use Seatplus\EsiClient\Exceptions\RequestFailedException;
 use Seatplus\Eveapi\Models\RefreshToken;
@@ -7,7 +9,7 @@ use Seatplus\Eveapi\Services\Esi\GetUpToDateRefreshTokenService;
 use Seatplus\Eveapi\Services\Esi\UpdateRefreshTokenService;
 
 beforeEach(function () {
-    \Illuminate\Support\Facades\Event::fake();
+    Event::fake();
 });
 
 it('retrieves up to date refresh token successfully', function () {
@@ -29,7 +31,7 @@ it('updates refresh token if expiry is near', function () {
         'expires_on' => now()->addSeconds(30),
     ]);
 
-    $updateRefreshTokenService = mock(UpdateRefreshTokenService::class, function (\Mockery\MockInterface $mock) use ($refreshToken) {
+    $updateRefreshTokenService = mock(UpdateRefreshTokenService::class, function (MockInterface $mock) use ($refreshToken) {
 
         $new_token = RefreshToken::factory()->make([
             'character_id' => $refreshToken->character_id,
@@ -50,7 +52,7 @@ it('updates refresh token if expiry is near', function () {
 
 it('throws request failed exception', function () {
 
-    $refreshToken = mock(RefreshToken::class, function (\Mockery\MockInterface $mock) {
+    $refreshToken = mock(RefreshToken::class, function (MockInterface $mock) {
 
         $mock->makePartial()
             ->shouldReceive('refresh')

--- a/tests/Unit/Services/JobCheckerTest.php
+++ b/tests/Unit/Services/JobCheckerTest.php
@@ -1,7 +1,13 @@
 <?php
 
+use Illuminate\Queue\Middleware\ThrottlesExceptionsWithRedis;
 use Mockery\MockInterface;
+use Seatplus\Eveapi\Esi\HasCorporationRoleInterface;
+use Seatplus\Eveapi\Esi\HasPathValuesInterface;
+use Seatplus\Eveapi\Esi\HasRequiredScopeInterface;
+use Seatplus\Eveapi\Jobs\Character\CharacterAffiliationJob;
 use Seatplus\Eveapi\Jobs\EsiBase;
+use Seatplus\Eveapi\Jobs\Middleware\EsiProactiveRateLimitMiddleware;
 use Seatplus\Eveapi\Services\EsiPathService;
 use Seatplus\Eveapi\Services\FileGetContentsAction;
 use Seatplus\Eveapi\Services\JobChecker;
@@ -128,7 +134,7 @@ describe('required scope checker', function () {
             ],
         ]);
 
-        $job = mock(EsiBase::class, \Seatplus\Eveapi\Esi\HasRequiredScopeInterface::class, function (MockInterface $mock) {
+        $job = mock(EsiBase::class, HasRequiredScopeInterface::class, function (MockInterface $mock) {
             $mock->shouldReceive('getVersion')->andReturn('v2');
             $mock->shouldReceive('getEndpoint')->andReturn('/endpoint');
             $mock->shouldReceive('getMethod')->andReturn('get');
@@ -194,7 +200,7 @@ describe('required scope checker', function () {
             ],
         ]);
 
-        $job = mock(EsiBase::class, \Seatplus\Eveapi\Esi\HasRequiredScopeInterface::class, function (MockInterface $mock) {
+        $job = mock(EsiBase::class, HasRequiredScopeInterface::class, function (MockInterface $mock) {
             $mock->shouldReceive('getVersion')->andReturn('v2');
             $mock->shouldReceive('getEndpoint')->andReturn('/endpoint');
             $mock->shouldReceive('getMethod')->andReturn('get');
@@ -228,7 +234,7 @@ describe('required scope checker', function () {
             ],
         ]);
 
-        $job = mock(EsiBase::class, \Seatplus\Eveapi\Esi\HasRequiredScopeInterface::class, function (MockInterface $mock) {
+        $job = mock(EsiBase::class, HasRequiredScopeInterface::class, function (MockInterface $mock) {
             $mock->shouldReceive('getVersion')->andReturn('v2');
             $mock->shouldReceive('getEndpoint')->andReturn('/endpoint');
             $mock->shouldReceive('getMethod')->andReturn('get');
@@ -308,7 +314,7 @@ describe('Path Check', function () {
 
     it('returns error if no path values are set but have HasPathValuesInterface implemented', function () {
 
-        $job = mock(EsiBase::class, \Seatplus\Eveapi\Esi\HasPathValuesInterface::class, function (MockInterface $mock) {
+        $job = mock(EsiBase::class, HasPathValuesInterface::class, function (MockInterface $mock) {
             $mock->shouldReceive('getVersion')->andReturn('v2');
             $mock->shouldReceive('getEndpoint')->andReturn('/endpoint/{id}');
             $mock->shouldReceive('getMethod')->andReturn('get');
@@ -324,7 +330,7 @@ describe('Path Check', function () {
     });
 
     it('returns error if path value is not used in path', function () {
-        $job = mock(EsiBase::class, \Seatplus\Eveapi\Esi\HasPathValuesInterface::class, function (MockInterface $mock) {
+        $job = mock(EsiBase::class, HasPathValuesInterface::class, function (MockInterface $mock) {
             $mock->shouldReceive('getVersion')->andReturn('v2');
             $mock->shouldReceive('getEndpoint')->andReturn('/endpoint/{id}');
             $mock->shouldReceive('getMethod')->andReturn('get');
@@ -340,7 +346,7 @@ describe('Path Check', function () {
     });
 
     it('returns success if path value is used in path', function () {
-        $job = mock(EsiBase::class, \Seatplus\Eveapi\Esi\HasPathValuesInterface::class, function (MockInterface $mock) {
+        $job = mock(EsiBase::class, HasPathValuesInterface::class, function (MockInterface $mock) {
             $mock->shouldReceive('getVersion')->andReturn('v2');
             $mock->shouldReceive('getEndpoint')->andReturn('/endpoint/{id}');
             $mock->shouldReceive('getMethod')->andReturn('get');
@@ -390,13 +396,13 @@ describe('Middleware check', function () {
     });
 
     it('returns error if job implements HasRequiredScopeInterface but middleware is not set', function () {
-        $job = mock(EsiBase::class, \Seatplus\Eveapi\Esi\HasRequiredScopeInterface::class, function (MockInterface $mock) {
+        $job = mock(EsiBase::class, HasRequiredScopeInterface::class, function (MockInterface $mock) {
             $mock->shouldReceive('getVersion')->andReturn('v2');
             $mock->shouldReceive('getEndpoint')->andReturn('/endpoint');
             $mock->shouldReceive('getMethod')->andReturn('get');
             $mock->shouldReceive('middleware')->andReturn([
-                new \Illuminate\Queue\Middleware\ThrottlesExceptionsWithRedis,
-                new \Seatplus\Eveapi\Jobs\Middleware\EsiProactiveRateLimitMiddleware,
+                new ThrottlesExceptionsWithRedis,
+                new EsiProactiveRateLimitMiddleware,
             ]);
         })->makePartial();
 
@@ -414,7 +420,7 @@ describe('Middleware check', function () {
             $mock->shouldReceive('getEndpoint')->andReturn('/endpoint');
             $mock->shouldReceive('getMethod')->andReturn('get');
             $mock->shouldReceive('middleware')->andReturn([
-                new \Illuminate\Queue\Middleware\ThrottlesExceptionsWithRedis,
+                new ThrottlesExceptionsWithRedis,
             ]);
         })->makePartial();
 
@@ -432,8 +438,8 @@ describe('Middleware check', function () {
             $mock->shouldReceive('getEndpoint')->andReturn('/endpoint');
             $mock->shouldReceive('getMethod')->andReturn('get');
             $mock->shouldReceive('middleware')->andReturn([
-                new \Illuminate\Queue\Middleware\ThrottlesExceptionsWithRedis,
-                new \Seatplus\Eveapi\Jobs\Middleware\EsiProactiveRateLimitMiddleware,
+                new ThrottlesExceptionsWithRedis,
+                new EsiProactiveRateLimitMiddleware,
             ]);
         })->makePartial();
 
@@ -499,7 +505,7 @@ describe('Corporation Role Check', function () {
     });
 
     it('returns error if corporation role is required but no corporation role is set', function () {
-        $job = mock(EsiBase::class, \Seatplus\Eveapi\Esi\HasCorporationRoleInterface::class, function (MockInterface $mock) {
+        $job = mock(EsiBase::class, HasCorporationRoleInterface::class, function (MockInterface $mock) {
             $mock->shouldReceive('getVersion')->andReturn('v2');
             $mock->shouldReceive('getEndpoint')->andReturn('/endpoint/safe');
             $mock->shouldReceive('getMethod')->andReturn('get');
@@ -515,7 +521,7 @@ describe('Corporation Role Check', function () {
     });
 
     it('returns error if corporation role is required but corporation role is not set', function () {
-        $job = mock(EsiBase::class, \Seatplus\Eveapi\Esi\HasCorporationRoleInterface::class, function (MockInterface $mock) {
+        $job = mock(EsiBase::class, HasCorporationRoleInterface::class, function (MockInterface $mock) {
             $mock->shouldReceive('getVersion')->andReturn('v2');
             $mock->shouldReceive('getEndpoint')->andReturn('/endpoint/safe');
             $mock->shouldReceive('getMethod')->andReturn('get');
@@ -531,7 +537,7 @@ describe('Corporation Role Check', function () {
     });
 
     it('returns success if corporation role is required and corporation role is set', function () {
-        $job = mock(EsiBase::class, \Seatplus\Eveapi\Esi\HasCorporationRoleInterface::class, function (MockInterface $mock) {
+        $job = mock(EsiBase::class, HasCorporationRoleInterface::class, function (MockInterface $mock) {
             $mock->shouldReceive('getVersion')->andReturn('v2');
             $mock->shouldReceive('getEndpoint')->andReturn('/endpoint/safe');
             $mock->shouldReceive('getMethod')->andReturn('get');
@@ -575,7 +581,7 @@ describe('is checking cache check', function () {
 
     it('returns success when CharacterAffiliationJob is a post request with cached seconds', function () {
 
-        $job = mock(\Seatplus\Eveapi\Jobs\Character\CharacterAffiliationJob::class, function (MockInterface $mock) {
+        $job = mock(CharacterAffiliationJob::class, function (MockInterface $mock) {
             $mock->shouldReceive('getVersion')->andReturn('v2');
             $mock->shouldReceive('getEndpoint')->andReturn('/endpoint/cached');
             $mock->shouldReceive('getMethod')->andReturn('post');
@@ -796,7 +802,7 @@ describe('Rate limit checker', function () {
             $mock->shouldReceive('getEndpoint')->andReturn('/endpoint');
             $mock->shouldReceive('getMethod')->andReturn('get');
             $mock->shouldReceive('middleware')->andReturn([
-                new \Seatplus\Eveapi\Jobs\Middleware\EsiProactiveRateLimitMiddleware,
+                new EsiProactiveRateLimitMiddleware,
             ]);
         })->makePartial();
 

--- a/tests/Unit/Services/MigrateDbTest.php
+++ b/tests/Unit/Services/MigrateDbTest.php
@@ -2,12 +2,15 @@
 
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Schema;
+use Mockery\MockInterface;
 use Seatplus\Eveapi\Models\Assets\Asset;
+use Seatplus\Eveapi\Services\MigrateDb;
 
 beforeEach(function () {
 
-    \Illuminate\Support\Facades\Event::fake();
+    Event::fake();
 });
 
 describe('with migration run', function () {
@@ -90,7 +93,7 @@ describe('with migration run', function () {
 
         // Act
 
-        new \Seatplus\Eveapi\Services\MigrateDb;
+        new MigrateDb;
 
         // Assert
 
@@ -102,7 +105,7 @@ describe('with migration run', function () {
 it('has no existing mariadb database', function () {
     // Arrange
 
-    $mock = mock(\Seatplus\Eveapi\Services\MigrateDb::class, function (\Mockery\MockInterface $mock) {
+    $mock = mock(MigrateDb::class, function (MockInterface $mock) {
         $mock->shouldReceive('databaseExists')
             ->with('mysql')
             ->once()
@@ -120,9 +123,9 @@ it('returns false if db connection fails', function () {
     // Arrange
     DB::shouldReceive()
         ->connection('pgsql')
-        ->andThrow(new \Exception('PostgreSql database does not exist'));
+        ->andThrow(new Exception('PostgreSql database does not exist'));
 
-    $mock = mock(\Seatplus\Eveapi\Services\MigrateDb::class, function (\Mockery\MockInterface $mock) {
+    $mock = mock(MigrateDb::class, function (MockInterface $mock) {
         $mock->shouldReceive('migrate')
             ->andReturnNull();
     })->makePartial();

--- a/tests/Unit/Services/ResolveLocation/Finders/ThroughCorporationMemberTrackingFinderTest.php
+++ b/tests/Unit/Services/ResolveLocation/Finders/ThroughCorporationMemberTrackingFinderTest.php
@@ -1,11 +1,13 @@
 <?php
 
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Event;
 use Seatplus\Eveapi\Models\Corporation\CorporationMemberTracking;
 use Seatplus\Eveapi\Services\ResolveLocation\Finders\ThroughCorporationMemberTrackingFinder;
 
 it('finds Director Token', function () {
 
-    \Illuminate\Support\Facades\Event::fake();
+    Event::fake();
 
     // arrange
     $scope = 'esi-corporations.track_members.v1';
@@ -26,7 +28,7 @@ it('finds Director Token', function () {
     expect($refresh_token->hasScope($scope))->toBeTrue()
         ->and($refresh_token->character->roles->hasRole('roles', $role))->toBeTrue();
 
-    $tracking = \Illuminate\Database\Eloquent\Collection::make();
+    $tracking = Collection::make();
 
     // act
     $finder = new ThroughCorporationMemberTrackingFinder;

--- a/tests/Unit/Services/ResolveLocation/ResolveLocationServiceTest.php
+++ b/tests/Unit/Services/ResolveLocation/ResolveLocationServiceTest.php
@@ -1,19 +1,22 @@
 <?php
 
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Queue;
+use Mockery\MockInterface;
 use Seatplus\Eveapi\Models\Universe\Location;
 use Seatplus\Eveapi\Services\ResolveLocation\ResolveLocationService;
 use Seatplus\Eveapi\Services\ResolveLocation\Resolver\ResolverInterface;
 
 it('runs through resolvers', function () {
-    \Illuminate\Support\Facades\Event::fake();
-    \Illuminate\Support\Facades\Queue::fake();
+    Event::fake();
+    Queue::fake();
 
     // Arrange
     $location_id = 100; // use low number to avoid being a potential structure or station
 
     ResolveLocationService::make()->handle($location_id);
 
-    expect(\Seatplus\Eveapi\Models\Universe\Location::count())->toBe(0);
+    expect(Location::count())->toBe(0);
 });
 
 it('breaks the loop on successful resolution', function () {
@@ -25,7 +28,7 @@ it('breaks the loop on successful resolution', function () {
     $locationMock->shouldReceive('firstOrNew')->andReturn($locationMock);
 
     // Mock the ResolverInterface
-    $resolverMock = mock(ResolverInterface::class, function (\Mockery\MockInterface $mock) {
+    $resolverMock = mock(ResolverInterface::class, function (MockInterface $mock) {
         $mock->shouldReceive('handle')->once()->andReturn(true);
     });
 

--- a/tests/Unit/Services/ResolveLocation/StationResolverTest.php
+++ b/tests/Unit/Services/ResolveLocation/StationResolverTest.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Queue;
+use Mockery\MockInterface;
 use Seatplus\Eveapi\Models\Universe\Location;
 use Seatplus\Eveapi\Models\Universe\Station;
 use Seatplus\Eveapi\Models\Universe\Structure;
@@ -155,7 +156,7 @@ describe('is potential station', function () {
         {
             protected function dispatchStationResolutionJob(Location $location): void
             {
-                throw new \Exception('test');
+                throw new Exception('test');
             }
         };
 
@@ -166,12 +167,12 @@ describe('is potential station', function () {
 
         // Assert
         expect($result)->toBeTrue();
-    })->throws(\Exception::class);
+    })->throws(Exception::class);
 
 });
 
 it('returns false if location is not a potential station', function () {
-    $location = mock(Location::class, function (\Mockery\MockInterface $mock) {
+    $location = mock(Location::class, function (MockInterface $mock) {
         $mock->shouldReceive('getAttribute')
             ->with('location_id')
             ->andReturn(59_000_000);

--- a/tests/Unit/Services/ResolveLocation/StructureResolverTest.php
+++ b/tests/Unit/Services/ResolveLocation/StructureResolverTest.php
@@ -192,7 +192,7 @@ describe('is potential structure', function () {
         $mocked_refresh_token_finder
             ->shouldReceive('markAsResolved')
             ->once()
-            ->andThrow(new \Exception('test'));
+            ->andThrow(new Exception('test'));
 
         $mocked_refresh_token_finder
             ->shouldReceive('markAsFailed')
@@ -208,6 +208,6 @@ describe('is potential structure', function () {
         // Assert
         expect($result)->toBeTrue()
             ->and(Location::count())->toBe(1);
-    })->throws(\Exception::class);
+    })->throws(Exception::class);
 
 });

--- a/tests/Unit/Services/RestrieveEsiDataTest.php
+++ b/tests/Unit/Services/RestrieveEsiDataTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use Seatplus\EsiClient\DataTransferObjects\EsiResponse;
+use Seatplus\EsiClient\EsiClient;
+use Seatplus\EsiClient\Exceptions\InvalidAuthenticationException;
 use Seatplus\EsiClient\Exceptions\RequestFailedException;
 use Seatplus\Eveapi\Containers\EsiRequestContainer;
 use Seatplus\Eveapi\Models\RefreshToken;
@@ -19,7 +21,7 @@ describe('executes request successfully', function () {
         // build response with raw header X-Kevinrob-Cache HIT
         $response = new EsiResponse(json_encode([]), ['X-Kevinrob-Cache' => 'HIT'], 'now', 200);
 
-        $this->client = mock(\Seatplus\EsiClient\EsiClient::class, function ($mock) use ($response) {
+        $this->client = mock(EsiClient::class, function ($mock) use ($response) {
             $mock->shouldReceive('invoke')
                 ->andReturn($response);
         });
@@ -76,11 +78,11 @@ describe('throws request failed exception', function () {
         );
 
         $service->executeInstance();
-    })->throws(\Seatplus\EsiClient\Exceptions\RequestFailedException::class);
+    })->throws(RequestFailedException::class);
 
     it('during execute', function () {
 
-        $client = mock(\Seatplus\EsiClient\EsiClient::class, function ($mock) {
+        $client = mock(EsiClient::class, function ($mock) {
             $mock->shouldReceive('invoke')
                 ->andThrow($this->requestFailedException);
         });
@@ -93,14 +95,14 @@ describe('throws request failed exception', function () {
         );
 
         $service->executeInstance();
-    })->throws(\Seatplus\EsiClient\Exceptions\RequestFailedException::class);
+    })->throws(RequestFailedException::class);
 
 });
 
 it('throws InvalidAuthenticationException', function () {
-    $client = mock(\Seatplus\EsiClient\EsiClient::class, function ($mock) {
+    $client = mock(EsiClient::class, function ($mock) {
         $mock->shouldReceive('invoke')
-            ->andThrow(new \Seatplus\EsiClient\Exceptions\InvalidAuthenticationException('failed'));
+            ->andThrow(new InvalidAuthenticationException('failed'));
     });
 
     $service = new RetrieveEsiData(
@@ -111,7 +113,7 @@ it('throws InvalidAuthenticationException', function () {
     );
 
     $service->executeInstance();
-})->throws(\Seatplus\EsiClient\Exceptions\InvalidAuthenticationException::class);
+})->throws(InvalidAuthenticationException::class);
 
 it('builds client with authentication', function () {
 
@@ -151,7 +153,7 @@ describe('it logs warnings', function () {
 
         $esiResponse = new EsiResponse(json_encode([]), ['X-Pages' => 1], 'now', 200);
 
-        $client = mock(\Seatplus\EsiClient\EsiClient::class, function ($mock) use ($esiResponse) {
+        $client = mock(EsiClient::class, function ($mock) use ($esiResponse) {
             $mock->shouldReceive('invoke')
                 ->andReturn($esiResponse);
         });
@@ -172,7 +174,7 @@ describe('it logs warnings', function () {
 
         $esiResponse = new EsiResponse(json_encode([]), [], 'now', 200);
 
-        $client = mock(\Seatplus\EsiClient\EsiClient::class, function ($mock) use ($esiResponse) {
+        $client = mock(EsiClient::class, function ($mock) use ($esiResponse) {
             $mock->shouldReceive('invoke')
                 ->andReturn($esiResponse);
         });
@@ -194,7 +196,7 @@ describe('it logs warnings', function () {
 
         $esiResponse = new EsiResponse(json_encode([]), ['Warning' => 'this is a warning'], 'now', 200);
 
-        $client = mock(\Seatplus\EsiClient\EsiClient::class, function ($mock) use ($esiResponse) {
+        $client = mock(EsiClient::class, function ($mock) use ($esiResponse) {
             $mock->shouldReceive('invoke')
                 ->andReturn($esiResponse);
         });
@@ -234,7 +236,7 @@ describe('it handles exceptions', function () {
             getUpToDateRefreshTokenService: $getUpToDateRefreshTokenService
         );
 
-    })->throws(\Seatplus\EsiClient\Exceptions\RequestFailedException::class);
+    })->throws(RequestFailedException::class);
 
     it('handles token expiry too far in future', function () {
 
@@ -325,5 +327,5 @@ it('builds client without refresh_token', function () {
 
     $client = $property->getValue($service);
 
-    expect($client)->toBeInstanceOf(\Seatplus\EsiClient\EsiClient::class);
+    expect($client)->toBeInstanceOf(EsiClient::class);
 });

--- a/tests/Unit/Services/UpdateRefreshTokenServiceTest.php
+++ b/tests/Unit/Services/UpdateRefreshTokenServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Facades\Event;
+use Mockery\MockInterface;
 use Seatplus\EsiClient\DataTransferObjects\EsiAuthentication;
 use Seatplus\EsiClient\Services\UpdateRefreshTokenService as EsiClientUpdateToken;
 use Seatplus\Eveapi\Models\RefreshToken;
@@ -7,15 +9,15 @@ use Seatplus\Eveapi\Services\Esi\UpdateRefreshTokenService;
 
 beforeEach(function () {
     $this->service = UpdateRefreshTokenService::make();
-    \Illuminate\Support\Facades\Event::fake();
+    Event::fake();
 });
 
 it('updates refresh token successfully', function () {
 
-    $esiClientUpdateToken = mock(EsiClientUpdateToken::class, function (Mockery\MockInterface $mock) {
+    $esiClientUpdateToken = mock(EsiClientUpdateToken::class, function (MockInterface $mock) {
 
         $mock->shouldReceive('getRefreshTokenResponse')
-            ->with(\Mockery::type(EsiAuthentication::class))
+            ->with(Mockery::type(EsiAuthentication::class))
             ->andReturn([
                 'access_token' => 'new_access_token',
                 'expires_in' => 3600,

--- a/tests/Unit/Traits/HasRequiredScopesTest.php
+++ b/tests/Unit/Traits/HasRequiredScopesTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Facades\Event;
+use Seatplus\Eveapi\Models\RefreshToken;
 use Seatplus\Eveapi\Traits\HasRequiredScopes;
 
 beforeEach(function () {
@@ -11,21 +13,21 @@ beforeEach(function () {
 
 it('returns refresh token for alliance_id', function () {
 
-    \Illuminate\Support\Facades\Event::fake();
+    Event::fake();
     // arrange
     $alliance_id = testCharacter()->alliance_id;
     $refreshToken = testCharacter()->refresh_token;
 
     // if no refresh token exists, create one
     if (! $refreshToken) {
-        $refreshToken = \Seatplus\Eveapi\Models\RefreshToken::factory()->create([
+        $refreshToken = RefreshToken::factory()->create([
             'character_id' => testCharacter()->character_id,
         ]);
     }
 
-    expect($refreshToken)->toBeInstanceOf(\Seatplus\Eveapi\Models\RefreshToken::class);
+    expect($refreshToken)->toBeInstanceOf(RefreshToken::class);
 
-    \Illuminate\Support\Facades\Event::fakeFor(fn () => updateRefreshTokenScopes($refreshToken, ['scope'])->save());
+    Event::fakeFor(fn () => updateRefreshTokenScopes($refreshToken, ['scope'])->save());
 
     $this->trait->alliance_id = $alliance_id;
     $this->trait->setRequiredScope('scope');


### PR DESCRIPTION
## Summary

Upgrade eveapi to Laravel 13.

## Changes

- `laravel/framework` ^11 → ^13
- `orchestra/testbench` ^9 → ^11 (follows Laravel versioning)
- `pestphp/pest-plugin-laravel` ^4.0 → ^4.1 (adds Laravel 13 support)
- Added `seatplus/esi-schema` VCS repository entry (needed due to dev-branch transitive dep)
- Set `minimum-stability: dev` + `prefer-stable: true`
- Laravel Pint formatting applied across 111 files

## Test status

10 pre-existing failures (same as parent branch `feat/esi-rate-limit-overhaul`):
- `RestrieveEsiDataTest` (7) — calls old `EsiClient::invoke()` signature
- `BatchStatisticTest` (2) — factory/model issue
- `MigrateDbTest` (1) — query exception

None of these are caused by the Laravel 13 upgrade.

514 tests pass.