### PR TITLE
feat: set EVE-compliant User-Agent header on boot

### DIFF
--- a/src/EveapiServiceProvider.php
+++ b/src/EveapiServiceProvider.php
@@ -66,7 +66,7 @@ class EveapiServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $version = InstalledVersions::getPrettyVersion('seatplus/eveapi') ?? 'dev';
-        EsiConfiguration::getInstance()->http_user_agent = "seatplus/eveapi/{$version} +https://github.com/seatplus/eveapi";
+        EsiConfiguration::getInstance()->http_user_agent .= " seatplus/eveapi/{$version} +https://github.com/seatplus/eveapi";
 
         Model::preventLazyLoading(! app()->isProduction());
 

--- a/src/EveapiServiceProvider.php
+++ b/src/EveapiServiceProvider.php
@@ -26,6 +26,7 @@
 
 namespace Seatplus\Eveapi;
 
+use Composer\InstalledVersions;
 use Exception;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Console\Scheduling\Schedule;
@@ -37,6 +38,7 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Horizon\Horizon;
 use Seatplus\EsiClient\EsiClient;
+use Seatplus\EsiClient\EsiConfiguration;
 use Seatplus\Eveapi\Commands\CheckJobsCommand;
 use Seatplus\Eveapi\Commands\ClearCache;
 use Seatplus\Eveapi\Events\RefreshTokenCreated;
@@ -63,6 +65,8 @@ class EveapiServiceProvider extends ServiceProvider
 {
     public function boot(): void
     {
+        $version = InstalledVersions::getPrettyVersion('seatplus/eveapi') ?? 'dev';
+        EsiConfiguration::getInstance()->http_user_agent = "seatplus/eveapi/{$version} +https://github.com/seatplus/eveapi";
 
         Model::preventLazyLoading(! app()->isProduction());
 

--- a/tests/Unit/EveapiServiceProviderTest.php
+++ b/tests/Unit/EveapiServiceProviderTest.php
@@ -11,7 +11,21 @@ use Illuminate\Queue\Middleware\RateLimitedWithRedis;
 use Illuminate\Support\Facades\DB;
 use Laravel\Horizon\Horizon;
 use Seatplus\Auth\Models\User;
+use Seatplus\EsiClient\EsiConfiguration;
 use Seatplus\Eveapi\EveapiServiceProvider;
+
+it('sets EVE-compliant user agent on boot', function () {
+    EsiConfiguration::resetInstance();
+
+    $serviceProvider = new EveapiServiceProvider(app());
+    $serviceProvider->boot();
+
+    $userAgent = EsiConfiguration::getInstance()->http_user_agent;
+
+    expect($userAgent)
+        ->toContain('seatplus/eveapi/')
+        ->toContain('+https://github.com/seatplus/eveapi');
+});
 
 it('tests horizon auth with user', function () {
 


### PR DESCRIPTION
## Summary

Sets a proper EVE developer-compliant `User-Agent` header on every ESI request.

## Before
```
Seatplus Esi Client /1.x.x/Seatplus Esi Client Default Library
```

## After
```
Seatplus Esi Client /1.x.x/seatplus/eveapi/4.x.x +https://github.com/seatplus/eveapi
```

## Why
EVE developer guidelines strongly prefer:
- **App name + version** — `seatplus/eveapi/4.x.x`
- **Source URL** — `+https://github.com/seatplus/eveapi`

No email required; GitHub repo is sufficient contact information.

## How
Follows the same pattern as [eveseat/eseye](https://github.com/eveseat/eseye): the library (`esi-client`) identifies itself first, then the consuming package (`eveapi`) provides its own identifier via `EsiConfiguration::http_user_agent`.

`EsiConfiguration` is a singleton — setting `http_user_agent` once in `EveapiServiceProvider::boot()` propagates to all ESI requests. Version is resolved at runtime via `InstalledVersions::getPrettyVersion()`; falls back to `'dev'` outside Composer.