### PR TITLE
fix: rename main_character to mainCharacter in Application ofCorporation scope

### DIFF
--- a/src/Models/Application.php
+++ b/src/Models/Application.php
@@ -89,7 +89,7 @@ class Application extends Model
         return $query->whereIn('corporation_id', $corporation_ids)
             ->with([
                 'applicationable' => fn (MorphTo $morph_to) => $morph_to->morphWith([
-                    User::class => ['characters.refresh_token', 'main_character', 'characters.application.corporation.ssoScopes', 'characters.application.corporation.alliance.ssoScopes'], // @phpstan-ignore-line
+                    User::class => ['characters.refresh_token', 'mainCharacter', 'characters.application.corporation.ssoScopes', 'characters.application.corporation.alliance.ssoScopes'], // @phpstan-ignore-line
                     CharacterInfo::class => ['refresh_token', 'application.corporation.ssoScopes', 'application.corporation.alliance.ssoScopes'],
                 ]),
             ]);


### PR DESCRIPTION
Fixes compatibility with seatplus/auth ^4.1 which renamed the `main_character()` relation to `mainCharacter()` (camelCase) in Group 4 refactor.

The `Application::ofCorporation()` scope was still eager-loading `main_character` which causes a `RelationNotFoundException` when the web package uses auth 4.1.