### PR TITLE
refactor: camelCase relation methods + locals/properties (idiomatic Laravel)

### DIFF
--- a/database/factories/CharacterInfoFactory.php
+++ b/database/factories/CharacterInfoFactory.php
@@ -45,11 +45,11 @@ class CharacterInfoFactory extends Factory
     {
         return $this->afterCreating(function (CharacterInfo $character_info) {
             $character_info
-                ->character_affiliation()
+                ->characterAffiliation()
                 ->save(CharacterAffiliation::factory()->withAlliance()->create());
 
             Event::fakeFor(function () use ($character_info) {
-                $character_info->refresh_token()->save(RefreshToken::factory()->create());
+                $character_info->refreshToken()->save(RefreshToken::factory()->create());
             });
 
             $character_info->roles()->save(CharacterRole::factory()->create());

--- a/src/Commands/CheckJobsCommand.php
+++ b/src/Commands/CheckJobsCommand.php
@@ -54,7 +54,7 @@ class CheckJobsCommand extends Command
      */
     protected $description = 'Check all used endpoints and whether the jobs are up to date or in need of an update';
 
-    private bool $has_errors = false;
+    private bool $hasErrors = false;
 
     public function __construct(
         private readonly JobChecker $jobChecker
@@ -68,13 +68,13 @@ class CheckJobsCommand extends Command
             ->map(function (EsiJob $job) {
                 $assertions = $this->jobChecker->checkJob($job);
 
-                $has_errors = $assertions->contains(fn (array $assertion) => $assertion['status'] === 'error');
-                $has_warnings = $assertions->contains(fn (array $assertion) => $assertion['status'] === 'warning');
+                $hasErrors = $assertions->contains(fn (array $assertion) => $assertion['status'] === 'error');
+                $hasWarnings = $assertions->contains(fn (array $assertion) => $assertion['status'] === 'warning');
 
                 return [
                     'class' => $job::class,
                     'assertions' => $assertions,
-                    'status' => $has_errors ? 'error' : ($has_warnings ? 'warning' : 'success'),
+                    'status' => $hasErrors ? 'error' : ($hasWarnings ? 'warning' : 'success'),
                 ];
             })
             // sort by status, pass first, warning second, error last
@@ -102,7 +102,7 @@ class CheckJobsCommand extends Command
                 $this->writeNewLine();
             });
 
-        if ($this->has_errors) {
+        if ($this->hasErrors) {
             return self::FAILURE;
         }
 
@@ -111,22 +111,22 @@ class CheckJobsCommand extends Command
 
     private function getAllJobs(): Collection
     {
-        $job_strings = glob(__DIR__.'/../Jobs/*/*.php');
+        $jobStrings = glob(__DIR__.'/../Jobs/*/*.php');
 
-        return collect($job_strings)
-            ->map(function (string $job_string) {
-                $job_string = str_replace(__DIR__.'/../Jobs/', '', $job_string);
-                $job_string = str_replace('.php', '', $job_string);
-                $job_string = str_replace('/', '\\', $job_string);
+        return collect($jobStrings)
+            ->map(function (string $jobString) {
+                $jobString = str_replace(__DIR__.'/../Jobs/', '', $jobString);
+                $jobString = str_replace('.php', '', $jobString);
+                $jobString = str_replace('/', '\\', $jobString);
 
-                return 'Seatplus\\Eveapi\\Jobs\\'.$job_string;
+                return 'Seatplus\\Eveapi\\Jobs\\'.$jobString;
             })
             ->filter(fn (string $job) => is_subclass_of($job, EsiJob::class))
             // filter out abstract classes
             ->filter(fn (string $job) => ! (new ReflectionClass($job))->isAbstract())
             ->map(function (string $job) {
-                $constructor_parameters = (new ReflectionClass($job))->getConstructor()?->getParameters();
-                $constructor_parameters = collect($constructor_parameters)
+                $constructorParameters = (new ReflectionClass($job))->getConstructor()?->getParameters();
+                $constructorParameters = collect($constructorParameters)
                     ->map(function (\ReflectionParameter $parameter) {
                         $type = 'unknown';
 
@@ -148,7 +148,7 @@ class CheckJobsCommand extends Command
                         };
                     });
 
-                return new $job(...$constructor_parameters->toArray());
+                return new $job(...$constructorParameters->toArray());
             });
     }
 
@@ -160,7 +160,7 @@ class CheckJobsCommand extends Command
     private function writeError(string $message): void
     {
         $this->writeAssertionOutput($message, 'text-red font-bold px-2', '⨯');
-        $this->has_errors = true;
+        $this->hasErrors = true;
     }
 
     private function writeWarning(string $message): void
@@ -168,16 +168,16 @@ class CheckJobsCommand extends Command
         $this->writeAssertionOutput($message, 'text-yellow font-bold px-2', '-');
     }
 
-    private function writeAssertionOutput(string $message, string $symbol_class, string $symbol): void
+    private function writeAssertionOutput(string $message, string $symbolClass, string $symbol): void
     {
-        $output = sprintf('<div class="text-gray-800"><span class="%s">%s</span>%s</div>', $symbol_class, $symbol, $message);
+        $output = sprintf('<div class="text-gray-800"><span class="%s">%s</span>%s</div>', $symbolClass, $symbol, $message);
 
         render($output);
     }
 
-    private function writeAssertionHeader(string $job, string $status_class, string $status): void
+    private function writeAssertionHeader(string $job, string $statusClass, string $status): void
     {
-        $output = sprintf('<div><div class="px-2"><span class="%s">%s</span></div>%s</div>', $status_class, $status, $job);
+        $output = sprintf('<div><div class="px-2"><span class="%s">%s</span></div>%s</div>', $statusClass, $status, $job);
 
         render($output);
     }

--- a/src/EveapiServiceProvider.php
+++ b/src/EveapiServiceProvider.php
@@ -136,7 +136,7 @@ class EveapiServiceProvider extends ServiceProvider
         });
 
         // Configure the workers for SeAT plus.
-        $horizon_environments = [
+        $horizonEnvironments = [
             'local' => [
                 'seatplus-workers' => [
                     'connection' => 'redis',
@@ -167,7 +167,7 @@ class EveapiServiceProvider extends ServiceProvider
         ];
 
         // Set the environment configuration.
-        config(['horizon.environments' => $horizon_environments]);
+        config(['horizon.environments' => $horizonEnvironments]);
 
         // remove the default config worker
         config(['horizon.defaults' => []]);
@@ -261,13 +261,13 @@ class EveapiServiceProvider extends ServiceProvider
         RateLimiter::for(
             'character_batch',
             function (object $job) { // @pest-ignore-type
-                $character_id = $job->refresh_token?->character_id;
-                $queue_name = $job->queue;
+                $characterId = $job->refreshToken?->character_id;
+                $queueName = $job->queue;
 
                 // if queue is high then we need no rate limiting
-                return $queue_name === 'high'
+                return $queueName === 'high'
                     ? Limit::none()
-                    : Limit::perHour(1)->by("character_batch_{$character_id}_{$queue_name}");
+                    : Limit::perHour(1)->by("character_batch_{$characterId}_{$queueName}");
             }
         );
     }

--- a/src/Events/RefreshTokenCreated.php
+++ b/src/Events/RefreshTokenCreated.php
@@ -35,5 +35,5 @@ class RefreshTokenCreated
 {
     use SerializesModels;
 
-    public function __construct(public RefreshToken $refresh_token) {}
+    public function __construct(public RefreshToken $refreshToken) {}
 }

--- a/src/Events/UpdatingRefreshTokenEvent.php
+++ b/src/Events/UpdatingRefreshTokenEvent.php
@@ -35,5 +35,5 @@ class UpdatingRefreshTokenEvent
 {
     use SerializesModels;
 
-    public function __construct(public RefreshToken $refresh_token) {}
+    public function __construct(public RefreshToken $refreshToken) {}
 }

--- a/src/Jobs/Alliances/AllianceInfoJob.php
+++ b/src/Jobs/Alliances/AllianceInfoJob.php
@@ -13,12 +13,12 @@ final class AllianceInfoJob extends EsiJob
 {
     protected const string OPERATION_CLASS = GetAlliancesAllianceId::class;
 
-    public function __construct(public int $alliance_id) {}
+    public function __construct(public int $allianceId) {}
 
     #[\Override]
     public function tags(): array
     {
-        return ['alliance', "alliance_id:{$this->alliance_id}", 'info'];
+        return ['alliance', "alliance_id:{$this->allianceId}", 'info'];
     }
 
     #[\Override]
@@ -28,12 +28,12 @@ final class AllianceInfoJob extends EsiJob
             return;
         }
 
-        $response = self::OPERATION_CLASS::execute($esi, $this->alliance_id);
+        $response = self::OPERATION_CLASS::execute($esi, $this->allianceId);
         if ($response->isCachedLoad) {
             return;
         }
 
-        AllianceInfo::firstOrNew(['alliance_id' => $this->alliance_id])->fill([
+        AllianceInfo::firstOrNew(['alliance_id' => $this->allianceId])->fill([
             'creator_corporation_id' => $response->creator_corporation_id,
             'creator_id' => $response->creator_id,
             'date_founded' => carbon($response->date_founded),

--- a/src/Jobs/Assets/CharacterAssetJob.php
+++ b/src/Jobs/Assets/CharacterAssetJob.php
@@ -20,7 +20,7 @@ final class CharacterAssetJob extends EsiJob
 
     private readonly Collection $assets;
 
-    public function __construct(public int $character_id)
+    public function __construct(public int $characterId)
     {
         $this->assets = collect();
     }
@@ -28,13 +28,13 @@ final class CharacterAssetJob extends EsiJob
     #[\Override]
     public function getRefreshToken(): RefreshToken
     {
-        return RefreshToken::findOrFail($this->character_id);
+        return RefreshToken::findOrFail($this->characterId);
     }
 
     #[\Override]
     public function tags(): array
     {
-        return ['character', "character_id:{$this->character_id}", 'assets'];
+        return ['character', "character_id:{$this->characterId}", 'assets'];
     }
 
     #[\Override]
@@ -42,7 +42,7 @@ final class CharacterAssetJob extends EsiJob
     {
         $page = 1;
         do {
-            $response = self::OPERATION_CLASS::execute($esi, $this->character_id, $page);
+            $response = self::OPERATION_CLASS::execute($esi, $this->characterId, $page);
             if ($response->isCachedLoad) {
                 return;
             }
@@ -50,7 +50,7 @@ final class CharacterAssetJob extends EsiJob
             foreach ($response->data as $asset) {
                 $this->assets->push([
                     'item_id' => $asset->item_id,
-                    'assetable_id' => $this->character_id,
+                    'assetable_id' => $this->characterId,
                     'assetable_type' => CharacterInfo::class,
                     'is_blueprint_copy' => $asset->is_blueprint_copy ?? false,
                     'is_singleton' => $asset->is_singleton,
@@ -70,7 +70,7 @@ final class CharacterAssetJob extends EsiJob
         ]);
 
         Asset::query()
-            ->where('assetable_id', $this->character_id)
+            ->where('assetable_id', $this->characterId)
             ->whereNotIn('item_id', $this->assets->pluck('item_id')->toArray())
             ->delete();
 
@@ -85,7 +85,7 @@ final class CharacterAssetJob extends EsiJob
     private function resolveUnknownLocations(): void
     {
         $unknownLocationIds = Asset::query()
-            ->where('assetable_id', $this->character_id)
+            ->where('assetable_id', $this->characterId)
             ->doesntHave('location')
             ->pluck('location_id')
             ->unique();
@@ -94,14 +94,14 @@ final class CharacterAssetJob extends EsiJob
             return;
         }
 
-        $refreshToken = RefreshToken::find($this->character_id);
+        $refreshToken = RefreshToken::find($this->characterId);
         $unknownLocationIds->each(fn (int $locationId) => ResolveLocationJob::dispatch($locationId, $refreshToken)->onQueue('high'));
     }
 
     private function resolveUnknownTypes(): void
     {
         Asset::query()
-            ->where('assetable_id', $this->character_id)
+            ->where('assetable_id', $this->characterId)
             ->doesntHave('type')
             ->pluck('type_id')
             ->unique()

--- a/src/Jobs/Assets/CharacterAssetsNameJob.php
+++ b/src/Jobs/Assets/CharacterAssetsNameJob.php
@@ -30,7 +30,7 @@ final class CharacterAssetsNameJob extends EsiJob
 
     private Collection $assetNames;
 
-    public function __construct(public int $character_id)
+    public function __construct(public int $characterId)
     {
         $this->assetNames = collect();
     }
@@ -38,13 +38,13 @@ final class CharacterAssetsNameJob extends EsiJob
     #[\Override]
     public function getRefreshToken(): RefreshToken
     {
-        return RefreshToken::findOrFail($this->character_id);
+        return RefreshToken::findOrFail($this->characterId);
     }
 
     #[\Override]
     public function tags(): array
     {
-        return ['character', "character_id:{$this->character_id}", 'assets', 'name'];
+        return ['character', "character_id:{$this->characterId}", 'assets', 'name'];
     }
 
     #[\Override]
@@ -60,7 +60,7 @@ final class CharacterAssetsNameJob extends EsiJob
                 self::CELESTIAL_CATEGORY, self::SHIP_CATEGORY, self::DEPLOYABLE_CATEGORY,
                 self::STARBASE_CATEGORY, self::ORBITALS_CATEGORY, self::STRUCTURE_CATEGORY,
             ]))
-            ->where('assetable_id', $this->character_id)
+            ->where('assetable_id', $this->characterId)
             ->where('is_singleton', true)
             ->pluck('item_id')
             ->chunk(1000)
@@ -68,7 +68,7 @@ final class CharacterAssetsNameJob extends EsiJob
                 $response = static::OPERATION_CLASS::execute(
                     $esi,
                     $itemIds->values()->toArray(),
-                    $this->character_id
+                    $this->characterId
                 );
 
                 if ($response->isCachedLoad) {
@@ -81,7 +81,7 @@ final class CharacterAssetsNameJob extends EsiJob
         $this->assetNames
             ->filter(fn (object $item) => $item->name !== 'None')
             ->each(fn (object $item) => Asset::query()
-                ->where('assetable_id', $this->character_id)
+                ->where('assetable_id', $this->characterId)
                 ->where('item_id', $item->item_id)
                 ->update(['name' => $item->name])
             );

--- a/src/Jobs/Character/CharacterAffiliationJob.php
+++ b/src/Jobs/Character/CharacterAffiliationJob.php
@@ -18,15 +18,15 @@ final class CharacterAffiliationJob extends EsiJob
 {
     protected const string OPERATION_CLASS = PostCharactersAffiliation::class;
 
-    private array $manual_ids = [];
+    private array $manualIds = [];
 
-    private readonly Collection $character_affiliations;
+    private readonly Collection $characterAffiliations;
 
-    public function __construct(int|array $character_ids)
+    public function __construct(int|array $characterIds)
     {
-        $this->setManualIds($character_ids);
-        throw_unless(count($this->manual_ids) <= 1000, new \Exception('Character ids must not exceed 1000'));
-        $this->character_affiliations = collect();
+        $this->setManualIds($characterIds);
+        throw_unless(count($this->manualIds) <= 1000, new \Exception('Character ids must not exceed 1000'));
+        $this->characterAffiliations = collect();
     }
 
     #[\Override]
@@ -41,7 +41,7 @@ final class CharacterAffiliationJob extends EsiJob
         $this->updateOrCreateCharacterAffiliations($this->getManualIds(), $esi);
 
         CharacterAffiliation::query()->upsert(
-            $this->character_affiliations->toArray(),
+            $this->characterAffiliations->toArray(),
             ['character_id'],
             ['corporation_id', 'alliance_id', 'faction_id', 'last_pulled']
         );
@@ -51,12 +51,12 @@ final class CharacterAffiliationJob extends EsiJob
 
     public function getManualIds(): array
     {
-        return $this->manual_ids;
+        return $this->manualIds;
     }
 
-    public function setManualIds(int|array $manual_ids): void
+    public function setManualIds(int|array $manualIds): void
     {
-        $this->manual_ids = is_array($manual_ids) ? $manual_ids : [$manual_ids];
+        $this->manualIds = is_array($manualIds) ? $manualIds : [$manualIds];
     }
 
     private function updateOrCreateCharacterAffiliations(array $characterIds, EsiClient $esi): void
@@ -70,7 +70,7 @@ final class CharacterAffiliationJob extends EsiJob
             }
 
             foreach ($response->data as $result) {
-                $this->character_affiliations->push([
+                $this->characterAffiliations->push([
                     'character_id' => $result->character_id,
                     'corporation_id' => $result->corporation_id,
                     'alliance_id' => $result->alliance_id ?? null,

--- a/src/Jobs/Character/CharacterInfoJob.php
+++ b/src/Jobs/Character/CharacterInfoJob.php
@@ -13,23 +13,23 @@ final class CharacterInfoJob extends EsiJob
 {
     protected const string OPERATION_CLASS = GetCharactersCharacterId::class;
 
-    public function __construct(public int $character_id) {}
+    public function __construct(public int $characterId) {}
 
     #[\Override]
     public function tags(): array
     {
-        return ['character', 'info', "character_id:{$this->character_id}"];
+        return ['character', 'info', "character_id:{$this->characterId}"];
     }
 
     #[\Override]
     public function executeJob(EsiClient $esi): void
     {
-        $response = self::OPERATION_CLASS::execute($esi, $this->character_id);
+        $response = self::OPERATION_CLASS::execute($esi, $this->characterId);
         if ($response->isCachedLoad) {
             return;
         }
 
-        CharacterInfo::updateOrCreate(['character_id' => $this->character_id], [
+        CharacterInfo::updateOrCreate(['character_id' => $this->characterId], [
             'name' => $response->name,
             'description' => $response->description,
             'birthday' => $response->birthday,

--- a/src/Jobs/Character/CharacterRoleJob.php
+++ b/src/Jobs/Character/CharacterRoleJob.php
@@ -14,29 +14,29 @@ final class CharacterRoleJob extends EsiJob
 {
     protected const string OPERATION_CLASS = GetCharactersCharacterIdRoles::class;
 
-    public function __construct(public int $character_id) {}
+    public function __construct(public int $characterId) {}
 
     #[\Override]
     public function getRefreshToken(): RefreshToken
     {
-        return RefreshToken::findOrFail($this->character_id);
+        return RefreshToken::findOrFail($this->characterId);
     }
 
     #[\Override]
     public function tags(): array
     {
-        return ['character', "character_id:{$this->character_id}", 'roles'];
+        return ['character', "character_id:{$this->characterId}", 'roles'];
     }
 
     #[\Override]
     public function executeJob(EsiClient $esi): void
     {
-        $response = self::OPERATION_CLASS::execute($esi, $this->character_id);
+        $response = self::OPERATION_CLASS::execute($esi, $this->characterId);
         if ($response->isCachedLoad) {
             return;
         }
 
-        CharacterRole::updateOrCreate(['character_id' => $this->character_id], [
+        CharacterRole::updateOrCreate(['character_id' => $this->characterId], [
             'roles' => $response->roles,
             'roles_at_base' => $response->roles_at_base,
             'roles_at_hq' => $response->roles_at_hq,

--- a/src/Jobs/Character/CorporationHistoryJob.php
+++ b/src/Jobs/Character/CorporationHistoryJob.php
@@ -13,25 +13,25 @@ final class CorporationHistoryJob extends EsiJob
 {
     protected const string OPERATION_CLASS = GetCharactersCharacterIdCorporationhistory::class;
 
-    public function __construct(public int $character_id) {}
+    public function __construct(public int $characterId) {}
 
     #[\Override]
     public function tags(): array
     {
-        return ['character', 'info', "character_id:{$this->character_id}", 'corporationhistory'];
+        return ['character', 'info', "character_id:{$this->characterId}", 'corporationhistory'];
     }
 
     #[\Override]
     public function executeJob(EsiClient $esi): void
     {
-        $response = self::OPERATION_CLASS::execute($esi, $this->character_id);
+        $response = self::OPERATION_CLASS::execute($esi, $this->characterId);
         if ($response->isCachedLoad) {
             return;
         }
 
         $results = collect($response->data)->map(fn (object $record) => [
             'record_id' => $record->record_id,
-            'character_id' => $this->character_id,
+            'character_id' => $this->characterId,
             'corporation_id' => $record->corporation_id,
             'is_deleted' => $record->is_deleted ?? false,
             'start_date' => carbon($record->start_date),

--- a/src/Jobs/Contacts/AllianceContactJob.php
+++ b/src/Jobs/Contacts/AllianceContactJob.php
@@ -16,31 +16,31 @@ final class AllianceContactJob extends ContactBaseJob
     protected const string OPERATION_CLASS = GetAlliancesAllianceIdContacts::class;
 
     public function __construct(
-        public int $alliance_id,
-        public int $character_id
+        public int $allianceId,
+        public int $characterId
     ) {}
 
     #[\Override]
     public function getRefreshToken(): RefreshToken
     {
-        return RefreshToken::findOrFail($this->character_id);
+        return RefreshToken::findOrFail($this->characterId);
     }
 
     #[\Override]
     protected function fetchPage(EsiClient $esi, int $page): EsiResult
     {
-        return self::OPERATION_CLASS::execute($esi, $this->alliance_id, $page);
+        return self::OPERATION_CLASS::execute($esi, $this->allianceId, $page);
     }
 
     #[\Override]
     public function tags(): array
     {
-        return ['alliance', "alliance_id:{$this->alliance_id}", 'contacts'];
+        return ['alliance', "alliance_id:{$this->allianceId}", 'contacts'];
     }
 
     #[\Override]
     public function executeJob(EsiClient $esi): void
     {
-        $this->handleProcessor(new ProcessContactResponse($this->alliance_id, AllianceInfo::class), $esi);
+        $this->handleProcessor(new ProcessContactResponse($this->allianceId, AllianceInfo::class), $esi);
     }
 }

--- a/src/Jobs/Contacts/AllianceContactLabelJob.php
+++ b/src/Jobs/Contacts/AllianceContactLabelJob.php
@@ -16,31 +16,31 @@ final class AllianceContactLabelJob extends ContactBaseJob
     protected const string OPERATION_CLASS = GetAlliancesAllianceIdContactsLabels::class;
 
     public function __construct(
-        public int $alliance_id,
-        public int $character_id,
+        public int $allianceId,
+        public int $characterId,
     ) {}
 
     #[\Override]
     public function getRefreshToken(): RefreshToken
     {
-        return RefreshToken::findOrFail($this->character_id);
+        return RefreshToken::findOrFail($this->characterId);
     }
 
     #[\Override]
     protected function fetchPage(EsiClient $esi, int $page): EsiResult
     {
-        return self::OPERATION_CLASS::execute($esi, $this->alliance_id);
+        return self::OPERATION_CLASS::execute($esi, $this->allianceId);
     }
 
     #[\Override]
     public function tags(): array
     {
-        return ['alliance', "alliance_id:{$this->alliance_id}", 'contacts', 'labels'];
+        return ['alliance', "alliance_id:{$this->allianceId}", 'contacts', 'labels'];
     }
 
     #[\Override]
     public function executeJob(EsiClient $esi): void
     {
-        $this->handleProcessor(new ProcessContactLabelsResponse($this->alliance_id, AllianceInfo::class), $esi);
+        $this->handleProcessor(new ProcessContactLabelsResponse($this->allianceId, AllianceInfo::class), $esi);
     }
 }

--- a/src/Jobs/Contacts/CharacterContactJob.php
+++ b/src/Jobs/Contacts/CharacterContactJob.php
@@ -15,29 +15,29 @@ final class CharacterContactJob extends ContactBaseJob
 {
     protected const string OPERATION_CLASS = GetCharactersCharacterIdContacts::class;
 
-    public function __construct(public int $character_id) {}
+    public function __construct(public int $characterId) {}
 
     #[\Override]
     public function getRefreshToken(): RefreshToken
     {
-        return RefreshToken::findOrFail($this->character_id);
+        return RefreshToken::findOrFail($this->characterId);
     }
 
     #[\Override]
     protected function fetchPage(EsiClient $esi, int $page): EsiResult
     {
-        return self::OPERATION_CLASS::execute($esi, $this->character_id, $page);
+        return self::OPERATION_CLASS::execute($esi, $this->characterId, $page);
     }
 
     #[\Override]
     public function tags(): array
     {
-        return ['character', "character_id:{$this->character_id}", 'contacts'];
+        return ['character', "character_id:{$this->characterId}", 'contacts'];
     }
 
     #[\Override]
     public function executeJob(EsiClient $esi): void
     {
-        $this->handleProcessor(new ProcessContactResponse($this->character_id, CharacterInfo::class), $esi);
+        $this->handleProcessor(new ProcessContactResponse($this->characterId, CharacterInfo::class), $esi);
     }
 }

--- a/src/Jobs/Contacts/CharacterContactLabelJob.php
+++ b/src/Jobs/Contacts/CharacterContactLabelJob.php
@@ -15,29 +15,29 @@ final class CharacterContactLabelJob extends ContactBaseJob
 {
     protected const string OPERATION_CLASS = GetCharactersCharacterIdContactsLabels::class;
 
-    public function __construct(public int $character_id) {}
+    public function __construct(public int $characterId) {}
 
     #[\Override]
     public function getRefreshToken(): RefreshToken
     {
-        return RefreshToken::findOrFail($this->character_id);
+        return RefreshToken::findOrFail($this->characterId);
     }
 
     #[\Override]
     protected function fetchPage(EsiClient $esi, int $page): EsiResult
     {
-        return self::OPERATION_CLASS::execute($esi, $this->character_id);
+        return self::OPERATION_CLASS::execute($esi, $this->characterId);
     }
 
     #[\Override]
     public function tags(): array
     {
-        return ['character', "character_id:{$this->character_id}", 'contacts', 'labels'];
+        return ['character', "character_id:{$this->characterId}", 'contacts', 'labels'];
     }
 
     #[\Override]
     public function executeJob(EsiClient $esi): void
     {
-        $this->handleProcessor(new ProcessContactLabelsResponse($this->character_id, CharacterInfo::class), $esi);
+        $this->handleProcessor(new ProcessContactLabelsResponse($this->characterId, CharacterInfo::class), $esi);
     }
 }

--- a/src/Jobs/Contacts/ContactBaseJob.php
+++ b/src/Jobs/Contacts/ContactBaseJob.php
@@ -16,7 +16,7 @@ abstract class ContactBaseJob extends EsiJob
 
     protected function handleProcessor(ProcessContactLabelsResponse|ProcessContactResponse $processor, EsiClient $esi): void
     {
-        $known_ids = collect();
+        $knownIds = collect();
         $page = 1;
 
         do {
@@ -25,11 +25,11 @@ abstract class ContactBaseJob extends EsiJob
                 return;
             }
 
-            $processed_ids = $processor->execute($response);
-            $known_ids->push($processed_ids);
+            $processedIds = $processor->execute($response);
+            $knownIds->push($processedIds);
             $page++;
         } while ($page <= $response->pages);
 
-        $processor->remove_old_entries($known_ids->flatten()->unique()->toArray());
+        $processor->remove_old_entries($knownIds->flatten()->unique()->toArray());
     }
 }

--- a/src/Jobs/Contacts/CorporationContactJob.php
+++ b/src/Jobs/Contacts/CorporationContactJob.php
@@ -16,31 +16,31 @@ final class CorporationContactJob extends ContactBaseJob
     protected const string OPERATION_CLASS = GetCorporationsCorporationIdContacts::class;
 
     public function __construct(
-        public int $corporation_id,
-        public int $character_id
+        public int $corporationId,
+        public int $characterId
     ) {}
 
     #[\Override]
     public function getRefreshToken(): RefreshToken
     {
-        return RefreshToken::findOrFail($this->character_id);
+        return RefreshToken::findOrFail($this->characterId);
     }
 
     #[\Override]
     protected function fetchPage(EsiClient $esi, int $page): EsiResult
     {
-        return self::OPERATION_CLASS::execute($esi, $this->corporation_id, $page);
+        return self::OPERATION_CLASS::execute($esi, $this->corporationId, $page);
     }
 
     #[\Override]
     public function tags(): array
     {
-        return ['corporation', "corporation_id:{$this->corporation_id}", 'contacts'];
+        return ['corporation', "corporation_id:{$this->corporationId}", 'contacts'];
     }
 
     #[\Override]
     public function executeJob(EsiClient $esi): void
     {
-        $this->handleProcessor(new ProcessContactResponse($this->corporation_id, CorporationInfo::class), $esi);
+        $this->handleProcessor(new ProcessContactResponse($this->corporationId, CorporationInfo::class), $esi);
     }
 }

--- a/src/Jobs/Contacts/CorporationContactLabelJob.php
+++ b/src/Jobs/Contacts/CorporationContactLabelJob.php
@@ -16,31 +16,31 @@ final class CorporationContactLabelJob extends ContactBaseJob
     protected const string OPERATION_CLASS = GetCorporationsCorporationIdContactsLabels::class;
 
     public function __construct(
-        public int $corporation_id,
-        public int $character_id
+        public int $corporationId,
+        public int $characterId
     ) {}
 
     #[\Override]
     public function getRefreshToken(): RefreshToken
     {
-        return RefreshToken::findOrFail($this->character_id);
+        return RefreshToken::findOrFail($this->characterId);
     }
 
     #[\Override]
     protected function fetchPage(EsiClient $esi, int $page): EsiResult
     {
-        return self::OPERATION_CLASS::execute($esi, $this->corporation_id);
+        return self::OPERATION_CLASS::execute($esi, $this->corporationId);
     }
 
     #[\Override]
     public function tags(): array
     {
-        return ['corporation', "corporation_id:{$this->corporation_id}", 'contacts', 'label'];
+        return ['corporation', "corporation_id:{$this->corporationId}", 'contacts', 'label'];
     }
 
     #[\Override]
     public function executeJob(EsiClient $esi): void
     {
-        $this->handleProcessor(new ProcessContactLabelsResponse($this->corporation_id, CorporationInfo::class), $esi);
+        $this->handleProcessor(new ProcessContactLabelsResponse($this->corporationId, CorporationInfo::class), $esi);
     }
 }

--- a/src/Jobs/Contracts/CharacterContractItemsJob.php
+++ b/src/Jobs/Contracts/CharacterContractItemsJob.php
@@ -14,25 +14,25 @@ final class CharacterContractItemsJob extends ContractItemsBase
     protected const string OPERATION_CLASS = GetCharactersCharacterIdContractsContractIdItems::class;
 
     public function __construct(
-        public int $character_id,
-        public int $contract_id,
+        public int $characterId,
+        public int $contractId,
     ) {}
 
     #[\Override]
     public function getRefreshToken(): RefreshToken
     {
-        return RefreshToken::findOrFail($this->character_id);
+        return RefreshToken::findOrFail($this->characterId);
     }
 
     #[\Override]
     protected function fetchItems(EsiClient $esi): EsiResult
     {
-        return self::OPERATION_CLASS::execute($esi, $this->character_id, $this->contract_id);
+        return self::OPERATION_CLASS::execute($esi, $this->characterId, $this->contractId);
     }
 
     #[\Override]
     public function tags(): array
     {
-        return ['character', 'contract', 'items', "character_id:{$this->character_id}", "contract_id:{$this->contract_id}"];
+        return ['character', 'contract', 'items', "character_id:{$this->characterId}", "contract_id:{$this->contractId}"];
     }
 }

--- a/src/Jobs/Contracts/CharacterContractsJob.php
+++ b/src/Jobs/Contracts/CharacterContractsJob.php
@@ -18,18 +18,18 @@ final class CharacterContractsJob extends EsiJob
 {
     protected const string OPERATION_CLASS = GetCharactersCharacterIdContracts::class;
 
-    public function __construct(public int $character_id) {}
+    public function __construct(public int $characterId) {}
 
     #[\Override]
     public function getRefreshToken(): RefreshToken
     {
-        return RefreshToken::findOrFail($this->character_id);
+        return RefreshToken::findOrFail($this->characterId);
     }
 
     #[\Override]
     public function tags(): array
     {
-        return ['character', "character_id:{$this->character_id}", 'contracts'];
+        return ['character', "character_id:{$this->characterId}", 'contracts'];
     }
 
     #[\Override]
@@ -38,7 +38,7 @@ final class CharacterContractsJob extends EsiJob
         $contracts = collect();
         $page = 1;
         do {
-            $response = self::OPERATION_CLASS::execute($esi, $this->character_id, $page);
+            $response = self::OPERATION_CLASS::execute($esi, $this->characterId, $page);
             if ($response->isCachedLoad) {
                 return;
             }
@@ -89,57 +89,57 @@ final class CharacterContractsJob extends EsiJob
             ]
         );
 
-        $character = CharacterInfo::find($this->character_id);
-        $contract_ids = $contracts->pluck('contract_id')->toArray();
+        $character = CharacterInfo::find($this->characterId);
+        $contractIds = $contracts->pluck('contract_id')->toArray();
 
         if ($character) {
-            $character->contracts()->syncWithoutDetaching($contract_ids);
+            $character->contracts()->syncWithoutDetaching($contractIds);
         }
     }
 
     private function dispatchFollowUpJobs(Collection $contracts): void
     {
-        $contract_ids = $contracts->pluck('contract_id')->toArray();
+        $contractIds = $contracts->pluck('contract_id')->toArray();
 
-        $contract_item_jobs = $this->getContractItemJobs($contract_ids);
-        $location_jobs = $this->getLocationJobs($contract_ids);
+        $contractItemJobs = $this->getContractItemJobs($contractIds);
+        $locationJobs = $this->getLocationJobs($contractIds);
 
         if ($this->batching()) {
-            $this->batch()->add([...$contract_item_jobs, ...$location_jobs]);
+            $this->batch()->add([...$contractItemJobs, ...$locationJobs]);
 
             return;
         }
 
-        foreach ([...$contract_item_jobs, ...$location_jobs] as $job) {
+        foreach ([...$contractItemJobs, ...$locationJobs] as $job) {
             dispatch($job)->onQueue('high');
         }
     }
 
-    private function getContractItemJobs(array $contract_ids): Collection
+    private function getContractItemJobs(array $contractIds): Collection
     {
         return Contract::query()
-            ->whereIn('contract_id', $contract_ids)
+            ->whereIn('contract_id', $contractIds)
             ->doesntHave('items')
             ->where('volume', '>', 0)
             ->where('status', '<>', 'deleted')
             ->where('type', '<>', 'courier')
             ->get()
-            ->map(fn (Contract $contract) => new CharacterContractItemsJob($this->character_id, $contract->contract_id));
+            ->map(fn (Contract $contract) => new CharacterContractItemsJob($this->characterId, $contract->contract_id));
     }
 
-    private function getLocationJobs(array $contract_ids): Collection
+    private function getLocationJobs(array $contractIds): Collection
     {
-        $refresh_token = RefreshToken::find($this->character_id);
+        $refreshToken = RefreshToken::find($this->characterId);
 
         return Contract::query()
-            ->whereIn('contract_id', $contract_ids)
+            ->whereIn('contract_id', $contractIds)
             ->where(fn (Builder $query) => $query->whereNotNull('start_location_id')->orWhereNotNull('end_location_id'))
-            ->where(fn (Builder $query) => $query->doesntHave('start_location')->orDoesntHave('end_location'))
+            ->where(fn (Builder $query) => $query->doesntHave('startLocation')->orDoesntHave('endLocation'))
             ->select('start_location_id', 'end_location_id')
             ->get()
             ->map(fn (Contract $contract) => [$contract->start_location_id, $contract->end_location_id])
             ->flatten()
             ->unique()
-            ->map(fn (int $location_id) => new ResolveLocationJob($location_id, $refresh_token));
+            ->map(fn (int $locationId) => new ResolveLocationJob($locationId, $refreshToken));
     }
 }

--- a/src/Jobs/Contracts/ContractItemsBase.php
+++ b/src/Jobs/Contracts/ContractItemsBase.php
@@ -13,7 +13,7 @@ use Seatplus\Eveapi\Models\Contracts\ContractItem;
 
 abstract class ContractItemsBase extends EsiJob implements ShouldBeUnique
 {
-    public int $contract_id;
+    public int $contractId;
 
     abstract protected function fetchItems(EsiClient $esi): EsiResult;
 
@@ -34,7 +34,7 @@ abstract class ContractItemsBase extends EsiJob implements ShouldBeUnique
 
         $contractItems = collect($response->data)->map(fn (object $item) => [
             'record_id' => $item->record_id,
-            'contract_id' => $this->contract_id,
+            'contract_id' => $this->contractId,
             'is_included' => $item->is_included,
             'is_singleton' => $item->is_singleton,
             'quantity' => $item->quantity,

--- a/src/Jobs/Corporation/CorporationDivisionsJob.php
+++ b/src/Jobs/Corporation/CorporationDivisionsJob.php
@@ -15,13 +15,13 @@ final class CorporationDivisionsJob extends EsiJob
 {
     protected const string OPERATION_CLASS = GetCorporationsCorporationIdDivisions::class;
 
-    public function __construct(public int $corporation_id) {}
+    public function __construct(public int $corporationId) {}
 
     #[\Override]
     public function getRefreshToken(): RefreshToken
     {
-        $token = (new FindCorporationRefreshToken)($this->corporation_id, 'esi-corporations.read_divisions.v1', 'Director');
-        throw_unless($token, new \Exception("No eligible refresh token found for corporation {$this->corporation_id}"));
+        $token = (new FindCorporationRefreshToken)($this->corporationId, 'esi-corporations.read_divisions.v1', 'Director');
+        throw_unless($token, new \Exception("No eligible refresh token found for corporation {$this->corporationId}"));
 
         return $token;
     }
@@ -29,13 +29,13 @@ final class CorporationDivisionsJob extends EsiJob
     #[\Override]
     public function tags(): array
     {
-        return ['corporation', "corporation_id:{$this->corporation_id}", 'divisions'];
+        return ['corporation', "corporation_id:{$this->corporationId}", 'divisions'];
     }
 
     #[\Override]
     public function executeJob(EsiClient $esi): void
     {
-        $response = self::OPERATION_CLASS::execute($esi, $this->corporation_id);
+        $response = self::OPERATION_CLASS::execute($esi, $this->corporationId);
         if ($response->isCachedLoad) {
             return;
         }
@@ -44,7 +44,7 @@ final class CorporationDivisionsJob extends EsiJob
 
         foreach (['hangar' => $response->hangar ?? [], 'wallet' => $response->wallet ?? []] as $divisionType => $entries) {
             collect($entries)->each(fn (mixed $entry) => $divisions->push([
-                'corporation_id' => $this->corporation_id,
+                'corporation_id' => $this->corporationId,
                 'division_type' => $divisionType,
                 'division_id' => ((object) $entry)->division,
                 'name' => ((object) $entry)->name ?? '',

--- a/src/Jobs/Corporation/CorporationInfoJob.php
+++ b/src/Jobs/Corporation/CorporationInfoJob.php
@@ -13,23 +13,23 @@ final class CorporationInfoJob extends EsiJob
 {
     protected const string OPERATION_CLASS = GetCorporationsCorporationId::class;
 
-    public function __construct(public int $corporation_id) {}
+    public function __construct(public int $corporationId) {}
 
     #[\Override]
     public function tags(): array
     {
-        return ['corporation', 'info', "corporation_id:{$this->corporation_id}"];
+        return ['corporation', 'info', "corporation_id:{$this->corporationId}"];
     }
 
     #[\Override]
     public function executeJob(EsiClient $esi): void
     {
-        $response = self::OPERATION_CLASS::execute($esi, $this->corporation_id);
+        $response = self::OPERATION_CLASS::execute($esi, $this->corporationId);
         if ($response->isCachedLoad) {
             return;
         }
 
-        CorporationInfo::firstOrNew(['corporation_id' => $this->corporation_id])->fill([
+        CorporationInfo::firstOrNew(['corporation_id' => $this->corporationId])->fill([
             'ticker' => $response->ticker,
             'name' => $response->name,
             'member_count' => $response->member_count,

--- a/src/Jobs/Corporation/CorporationMemberTrackingJob.php
+++ b/src/Jobs/Corporation/CorporationMemberTrackingJob.php
@@ -18,13 +18,13 @@ final class CorporationMemberTrackingJob extends EsiJob
 {
     protected const string OPERATION_CLASS = GetCorporationsCorporationIdMembertracking::class;
 
-    public function __construct(public int $corporation_id) {}
+    public function __construct(public int $corporationId) {}
 
     #[\Override]
     public function getRefreshToken(): RefreshToken
     {
-        $token = (new FindCorporationRefreshToken)($this->corporation_id, 'esi-corporations.track_members.v1', 'Director');
-        throw_unless($token, new \Exception("No eligible refresh token found for corporation {$this->corporation_id}"));
+        $token = (new FindCorporationRefreshToken)($this->corporationId, 'esi-corporations.track_members.v1', 'Director');
+        throw_unless($token, new \Exception("No eligible refresh token found for corporation {$this->corporationId}"));
 
         return $token;
     }
@@ -32,19 +32,19 @@ final class CorporationMemberTrackingJob extends EsiJob
     #[\Override]
     public function tags(): array
     {
-        return ['corporation', "corporation_id:{$this->corporation_id}", 'member', 'tracking'];
+        return ['corporation', "corporation_id:{$this->corporationId}", 'member', 'tracking'];
     }
 
     #[\Override]
     public function executeJob(EsiClient $esi): void
     {
-        $response = self::OPERATION_CLASS::execute($esi, $this->corporation_id);
+        $response = self::OPERATION_CLASS::execute($esi, $this->corporationId);
         if ($response->isCachedLoad) {
             return;
         }
 
         $members = collect($response->data)->map(fn (object $member) => [
-            'corporation_id' => $this->corporation_id,
+            'corporation_id' => $this->corporationId,
             'character_id' => $member->character_id,
             'start_date' => isset($member->start_date) ? carbon($member->start_date) : null,
             'base_id' => $member->base_id ?? null,
@@ -56,10 +56,10 @@ final class CorporationMemberTrackingJob extends EsiJob
 
         CorporationMemberTracking::upsert($members->toArray(), ['corporation_id', 'character_id']);
 
-        CorporationMemberTracking::where('corporation_id', $this->corporation_id)
+        CorporationMemberTracking::where('corporation_id', $this->corporationId)
             ->whereNotIn('character_id', $members->pluck('character_id')->all())
             ->get()
-            ->each(fn (CorporationMemberTracking $ex_member) => $ex_member->delete());
+            ->each(fn (CorporationMemberTracking $exMember) => $exMember->delete());
 
         $this->getMemberCharacterInfo();
         $this->getLocations();
@@ -70,7 +70,7 @@ final class CorporationMemberTrackingJob extends EsiJob
     {
         $refreshToken = $this->getRefreshToken();
         CorporationMemberTracking::query()
-            ->where('corporation_id', $this->corporation_id)
+            ->where('corporation_id', $this->corporationId)
             ->doesntHave('location')
             ->pluck('location_id')
             ->unique()
@@ -80,7 +80,7 @@ final class CorporationMemberTrackingJob extends EsiJob
     private function getMemberCharacterInfo(): void
     {
         CorporationMemberTracking::query()
-            ->where('corporation_id', $this->corporation_id)
+            ->where('corporation_id', $this->corporationId)
             ->doesntHave('character')
             ->pluck('character_id')
             ->unique()
@@ -90,7 +90,7 @@ final class CorporationMemberTrackingJob extends EsiJob
     private function getShipTypes(): void
     {
         CorporationMemberTracking::query()
-            ->where('corporation_id', $this->corporation_id)
+            ->where('corporation_id', $this->corporationId)
             ->doesntHave('ship')
             ->pluck('ship_type_id')
             ->unique()

--- a/src/Jobs/Hydrate/Maintenance/GetMissingBodysFromMails.php
+++ b/src/Jobs/Hydrate/Maintenance/GetMissingBodysFromMails.php
@@ -47,26 +47,26 @@ class GetMissingBodysFromMails extends HydrateMaintenanceBase
         $jobs = Mail::query()
             ->whereNull('body')
             ->pluck('id')
-            ->map(fn (int $mail_id) => $this->createMailBodyJob($mail_id))
+            ->map(fn (int $mailId) => $this->createMailBodyJob($mailId))
             ->filter();
 
         $this->batch()->add($jobs->toArray());
     }
 
-    private function createMailBodyJob(int $mail_id): ?MailBodyJob
+    private function createMailBodyJob(int $mailId): ?MailBodyJob
     {
-        $refresh_tokens = RefreshToken::whereHas('character.mails', fn (Builder $query) => $query->where('mails.id', $mail_id))->get();
+        $refreshTokens = RefreshToken::whereHas('character.mails', fn (Builder $query) => $query->where('mails.id', $mailId))->get();
 
         // if no refresh token is found, we can not hydrate the mail body and skip it
-        if ($refresh_tokens->isEmpty()) {
+        if ($refreshTokens->isEmpty()) {
             return null;
         }
 
-        return $refresh_tokens
+        return $refreshTokens
             ->filter(fn (RefreshToken $token) => $token->hasScope('esi-mail.read_mail.v1'))
             // limit to one refresh token
             ->take(1)
-            ->map(fn (RefreshToken $token) => new MailBodyJob($token->character_id, $mail_id))
+            ->map(fn (RefreshToken $token) => new MailBodyJob($token->character_id, $mailId))
             ->first();
     }
 }

--- a/src/Jobs/Hydrate/Maintenance/GetMissingCategorys.php
+++ b/src/Jobs/Hydrate/Maintenance/GetMissingCategorys.php
@@ -42,9 +42,9 @@ class GetMissingCategorys extends HydrateMaintenanceBase
             return;
         }
 
-        $unknown_type_ids = Group::whereDoesntHave('category')->pluck('category_id')->unique()->values();
+        $unknownTypeIds = Group::whereDoesntHave('category')->pluck('category_id')->unique()->values();
 
-        $jobs = $unknown_type_ids->map(fn (int $id) => new ResolveUniverseCategoryByIdJob($id));
+        $jobs = $unknownTypeIds->map(fn (int $id) => new ResolveUniverseCategoryByIdJob($id));
 
         $this->batch()->add(
             $jobs->toArray()

--- a/src/Jobs/Hydrate/Maintenance/GetMissingCharacterInfosFromCorporationMemberTracking.php
+++ b/src/Jobs/Hydrate/Maintenance/GetMissingCharacterInfosFromCorporationMemberTracking.php
@@ -42,9 +42,9 @@ class GetMissingCharacterInfosFromCorporationMemberTracking extends HydrateMaint
             return;
         }
 
-        $character_ids = CorporationMemberTracking::doesntHave('character')->pluck('character_id')->unique()->values();
+        $characterIds = CorporationMemberTracking::doesntHave('character')->pluck('character_id')->unique()->values();
 
-        $jobs = $character_ids->map(fn (int $character_id) => new CharacterInfoJob($character_id));
+        $jobs = $characterIds->map(fn (int $characterId) => new CharacterInfoJob($characterId));
 
         $this->batch()->add(
             $jobs->toArray()

--- a/src/Jobs/Hydrate/Maintenance/GetMissingConstellations.php
+++ b/src/Jobs/Hydrate/Maintenance/GetMissingConstellations.php
@@ -42,9 +42,9 @@ class GetMissingConstellations extends HydrateMaintenanceBase
             return;
         }
 
-        $unknown_constellation_ids = System::whereDoesntHave('constellation')->pluck('constellation_id')->unique()->values();
+        $unknownConstellationIds = System::whereDoesntHave('constellation')->pluck('constellation_id')->unique()->values();
 
-        $jobs = $unknown_constellation_ids->map(fn (int $id) => new ResolveUniverseConstellationByConstellationIdJob($id));
+        $jobs = $unknownConstellationIds->map(fn (int $id) => new ResolveUniverseConstellationByConstellationIdJob($id));
 
         $this->batch()->add(
             $jobs->toArray()

--- a/src/Jobs/Hydrate/Maintenance/GetMissingGroups.php
+++ b/src/Jobs/Hydrate/Maintenance/GetMissingGroups.php
@@ -42,9 +42,9 @@ class GetMissingGroups extends HydrateMaintenanceBase
             return;
         }
 
-        $unknown_type_ids = Type::whereDoesntHave('group')->pluck('group_id')->unique()->values();
+        $unknownTypeIds = Type::whereDoesntHave('group')->pluck('group_id')->unique()->values();
 
-        $jobs = $unknown_type_ids->map(fn (int $id) => new ResolveUniverseGroupByIdJob($id));
+        $jobs = $unknownTypeIds->map(fn (int $id) => new ResolveUniverseGroupByIdJob($id));
 
         $this->batch()->add(
             $jobs->toArray()

--- a/src/Jobs/Hydrate/Maintenance/GetMissingLocationFromAssets.php
+++ b/src/Jobs/Hydrate/Maintenance/GetMissingLocationFromAssets.php
@@ -53,7 +53,7 @@ class GetMissingLocationFromAssets extends HydrateMaintenanceBase
             ->pluck('location_id')
             ->unique()
             ->filter()
-            ->map(fn (int $location_id) => new ResolveLocationJob($location_id));
+            ->map(fn (int $locationId) => new ResolveLocationJob($locationId));
 
         $this->batch()->add($jobs->toArray());
 

--- a/src/Jobs/Hydrate/Maintenance/GetMissingLocationFromContracts.php
+++ b/src/Jobs/Hydrate/Maintenance/GetMissingLocationFromContracts.php
@@ -48,11 +48,11 @@ class GetMissingLocationFromContracts extends HydrateMaintenanceBase
         $jobs = Contract::query()
             ->where(function (Builder $query) {
                 $query->whereNotNull('start_location_id')
-                    ->whereDoesntHave('start_location', fn (Builder $query) => $query->whereHasMorph('locatable', [Structure::class, Station::class]));
+                    ->whereDoesntHave('startLocation', fn (Builder $query) => $query->whereHasMorph('locatable', [Structure::class, Station::class]));
             })
             ->orWhere(function (Builder $query) {
                 $query->whereNotNull('end_location_id')
-                    ->whereDoesntHave('end_location', fn (Builder $query) => $query->whereHasMorph('locatable', [Structure::class, Station::class]));
+                    ->whereDoesntHave('endLocation', fn (Builder $query) => $query->whereHasMorph('locatable', [Structure::class, Station::class]));
             })
             ->select('start_location_id', 'end_location_id')
             ->inRandomOrder()
@@ -61,7 +61,7 @@ class GetMissingLocationFromContracts extends HydrateMaintenanceBase
             ->flatMap(fn (Contract $contract) => [$contract->start_location_id, $contract->end_location_id])
             ->unique()
             ->filter()
-            ->map(fn (int $location_id) => new ResolveLocationJob($location_id));
+            ->map(fn (int $locationId) => new ResolveLocationJob($locationId));
 
         $this->batch()->add($jobs->toArray());
     }

--- a/src/Jobs/Hydrate/Maintenance/GetMissingLocationFromCorporationMemberTracking.php
+++ b/src/Jobs/Hydrate/Maintenance/GetMissingLocationFromCorporationMemberTracking.php
@@ -51,7 +51,7 @@ class GetMissingLocationFromCorporationMemberTracking extends HydrateMaintenance
             ->pluck('location_id')
             ->unique()
             ->filter()
-            ->map(fn (int $location_id) => new ResolveLocationJob($location_id));
+            ->map(fn (int $locationId) => new ResolveLocationJob($locationId));
 
         $this->batch()->add($jobs->toArray());
     }

--- a/src/Jobs/Hydrate/Maintenance/GetMissingLocationFromWalletTransaction.php
+++ b/src/Jobs/Hydrate/Maintenance/GetMissingLocationFromWalletTransaction.php
@@ -51,7 +51,7 @@ class GetMissingLocationFromWalletTransaction extends HydrateMaintenanceBase
             ->pluck('location_id')
             ->unique()
             ->filter()
-            ->map(fn (int $location_id) => new ResolveLocationJob($location_id));
+            ->map(fn (int $locationId) => new ResolveLocationJob($locationId));
 
         $this->batch()->add($jobs->toArray());
     }

--- a/src/Jobs/Hydrate/Maintenance/GetMissingLocations.php
+++ b/src/Jobs/Hydrate/Maintenance/GetMissingLocations.php
@@ -46,7 +46,7 @@ class GetMissingLocations extends HydrateMaintenanceBase
         $jobs = Location::query()
             ->whereDoesntHave('locatable')
             ->pluck('location_id')
-            ->map(fn (int $location_id) => new ResolveLocationJob($location_id));
+            ->map(fn (int $locationId) => new ResolveLocationJob($locationId));
 
         $this->batch()->add($jobs);
 

--- a/src/Jobs/Hydrate/Maintenance/GetMissingRegions.php
+++ b/src/Jobs/Hydrate/Maintenance/GetMissingRegions.php
@@ -42,9 +42,9 @@ class GetMissingRegions extends HydrateMaintenanceBase
             return;
         }
 
-        $unknown_region_ids = Constellation::whereDoesntHave('region')->pluck('region_id')->unique()->values();
+        $unknownRegionIds = Constellation::whereDoesntHave('region')->pluck('region_id')->unique()->values();
 
-        $jobs = $unknown_region_ids->map(fn (int $id) => new ResolveUniverseRegionByRegionIdJob($id));
+        $jobs = $unknownRegionIds->map(fn (int $id) => new ResolveUniverseRegionByRegionIdJob($id));
 
         $this->batch()->add(
             $jobs->toArray()

--- a/src/Jobs/Hydrate/Maintenance/GetMissingTypesFromCharacterAssets.php
+++ b/src/Jobs/Hydrate/Maintenance/GetMissingTypesFromCharacterAssets.php
@@ -42,10 +42,10 @@ class GetMissingTypesFromCharacterAssets extends HydrateMaintenanceBase
             return;
         }
 
-        $type_ids = Asset::doesntHave('type')->pluck('type_id')->unique()->values();
+        $typeIds = Asset::doesntHave('type')->pluck('type_id')->unique()->values();
 
-        // $type_ids->each(fn ($id) => ResolveUniverseTypeByIdJob::dispatch($id)->onQueue('low'));
-        $jobs = $type_ids->map(fn (int $id) => new ResolveUniverseTypeByIdJob($id));
+        // $typeIds->each(fn ($id) => ResolveUniverseTypeByIdJob::dispatch($id)->onQueue('low'));
+        $jobs = $typeIds->map(fn (int $id) => new ResolveUniverseTypeByIdJob($id));
 
         $this->batch()->add(
             $jobs->toArray()

--- a/src/Jobs/Hydrate/Maintenance/GetMissingTypesFromContractItem.php
+++ b/src/Jobs/Hydrate/Maintenance/GetMissingTypesFromContractItem.php
@@ -42,9 +42,9 @@ class GetMissingTypesFromContractItem extends HydrateMaintenanceBase
             return;
         }
 
-        $type_ids = ContractItem::doesntHave('type')->pluck('type_id')->unique()->values();
+        $typeIds = ContractItem::doesntHave('type')->pluck('type_id')->unique()->values();
 
-        $jobs = $type_ids->map(fn (int $id) => new ResolveUniverseTypeByIdJob($id));
+        $jobs = $typeIds->map(fn (int $id) => new ResolveUniverseTypeByIdJob($id));
 
         $this->batch()->add(
             $jobs->toArray()

--- a/src/Jobs/Hydrate/Maintenance/GetMissingTypesFromCorporationMemberTracking.php
+++ b/src/Jobs/Hydrate/Maintenance/GetMissingTypesFromCorporationMemberTracking.php
@@ -47,7 +47,7 @@ class GetMissingTypesFromCorporationMemberTracking extends HydrateMaintenanceBas
             ->pluck('ship_type_id')
             ->unique()
             ->filter()
-            ->map(fn (int $ship_type_id) => new ResolveUniverseTypeByIdJob($ship_type_id));
+            ->map(fn (int $shipTypeId) => new ResolveUniverseTypeByIdJob($shipTypeId));
 
         $this->batch()->add(
             $jobs->toArray()

--- a/src/Jobs/Hydrate/Maintenance/GetMissingTypesFromLocations.php
+++ b/src/Jobs/Hydrate/Maintenance/GetMissingTypesFromLocations.php
@@ -45,7 +45,7 @@ class GetMissingTypesFromLocations extends HydrateMaintenanceBase
             return;
         }
 
-        $type_ids = Location::whereHasMorph(
+        $typeIds = Location::whereHasMorph(
             'locatable',
             [Station::class, Structure::class],
             function (Builder $query) {
@@ -63,7 +63,7 @@ class GetMissingTypesFromLocations extends HydrateMaintenanceBase
             ->unique()
             ->values();
 
-        $jobs = $type_ids->map(fn (int $id) => new ResolveUniverseTypeByIdJob($id));
+        $jobs = $typeIds->map(fn (int $id) => new ResolveUniverseTypeByIdJob($id));
 
         $this->batch()->add(
             $jobs->toArray()

--- a/src/Jobs/Hydrate/Maintenance/GetMissingTypesFromSkillQueue.php
+++ b/src/Jobs/Hydrate/Maintenance/GetMissingTypesFromSkillQueue.php
@@ -42,10 +42,10 @@ class GetMissingTypesFromSkillQueue extends HydrateMaintenanceBase
             return;
         }
 
-        $type_ids = SkillQueue::doesntHave('type')->pluck('skill_id')->unique()->values();
+        $typeIds = SkillQueue::doesntHave('type')->pluck('skill_id')->unique()->values();
 
-        // $type_ids->each(fn ($id) => ResolveUniverseTypeByIdJob::dispatch($id)->onQueue('low'));
-        $jobs = $type_ids->map(fn (int $id) => new ResolveUniverseTypeByIdJob($id));
+        // $typeIds->each(fn ($id) => ResolveUniverseTypeByIdJob::dispatch($id)->onQueue('low'));
+        $jobs = $typeIds->map(fn (int $id) => new ResolveUniverseTypeByIdJob($id));
 
         $this->batch()->add(
             $jobs->toArray()

--- a/src/Jobs/Hydrate/Maintenance/GetMissingTypesFromSkills.php
+++ b/src/Jobs/Hydrate/Maintenance/GetMissingTypesFromSkills.php
@@ -42,9 +42,9 @@ class GetMissingTypesFromSkills extends HydrateMaintenanceBase
             return;
         }
 
-        $type_ids = Skill::doesntHave('type')->pluck('skill_id')->unique()->values();
+        $typeIds = Skill::doesntHave('type')->pluck('skill_id')->unique()->values();
 
-        $jobs = $type_ids->map(fn (int $id) => new ResolveUniverseTypeByIdJob($id));
+        $jobs = $typeIds->map(fn (int $id) => new ResolveUniverseTypeByIdJob($id));
 
         $this->batch()->add(
             $jobs->toArray()

--- a/src/Jobs/Hydrate/Maintenance/GetMissingTypesFromWalletTransaction.php
+++ b/src/Jobs/Hydrate/Maintenance/GetMissingTypesFromWalletTransaction.php
@@ -42,9 +42,9 @@ class GetMissingTypesFromWalletTransaction extends HydrateMaintenanceBase
             return;
         }
 
-        $type_ids = WalletTransaction::doesntHave('type')->pluck('type_id')->unique()->values();
+        $typeIds = WalletTransaction::doesntHave('type')->pluck('type_id')->unique()->values();
 
-        $jobs = $type_ids->map(fn (int $id) => new ResolveUniverseTypeByIdJob($id));
+        $jobs = $typeIds->map(fn (int $id) => new ResolveUniverseTypeByIdJob($id));
 
         $this->batch()->add(
             $jobs->toArray()

--- a/src/Jobs/Killmails/KillmailJob.php
+++ b/src/Jobs/Killmails/KillmailJob.php
@@ -20,28 +20,28 @@ final class KillmailJob extends EsiJob
     protected const string OPERATION_CLASS = GetKillmailsKillmailIdKillmailHash::class;
 
     public function __construct(
-        public int $killmail_id,
-        public string $killmail_hash
+        public int $killmailId,
+        public string $killmailHash
     ) {}
 
     #[\Override]
     public function tags(): array
     {
-        return ['killmails', "killmail_id:{$this->killmail_id}"];
+        return ['killmails', "killmail_id:{$this->killmailId}"];
     }
 
     #[\Override]
     public function executeJob(EsiClient $esi): void
     {
-        $response = self::OPERATION_CLASS::execute($esi, $this->killmail_hash, $this->killmail_id);
+        $response = self::OPERATION_CLASS::execute($esi, $this->killmailHash, $this->killmailId);
         if ($response->isCachedLoad) {
             return;
         }
 
         $victim = (object) $response->victim;
 
-        $killmail = Killmail::firstOrCreate(['killmail_id' => $this->killmail_id], [
-            'killmail_hash' => $this->killmail_hash,
+        $killmail = Killmail::firstOrCreate(['killmail_id' => $this->killmailId], [
+            'killmail_hash' => $this->killmailHash,
             'solar_system_id' => $response->solar_system_id,
             'victim_character_id' => $victim->character_id ?? null,
             'victim_corporation_id' => $victim->corporation_id ?? null,
@@ -68,12 +68,12 @@ final class KillmailJob extends EsiJob
         $this->createKillmailAttackers($response->attackers);
     }
 
-    private function createKillmailItems(array $items, ?int $location_id = null): void
+    private function createKillmailItems(array $items, ?int $locationId = null): void
     {
-        collect($items)->each(function (mixed $item) use ($location_id) {
+        collect($items)->each(function (mixed $item) use ($locationId) {
             $item = (object) $item;
-            $killmail_item = KillmailItem::create([
-                'location_id' => $location_id ?? $this->killmail_id,
+            $killmailItem = KillmailItem::create([
+                'location_id' => $locationId ?? $this->killmailId,
                 'location_flag' => GetLocationFlagNameService::make()->get(data_get($item, 'flag')),
                 'quantity' => data_get($item, 'quantity_dropped') ?? data_get($item, 'quantity_destroyed'),
                 'type_id' => data_get($item, 'item_type_id'),
@@ -84,7 +84,7 @@ final class KillmailJob extends EsiJob
 
             $contents = data_get($item, 'items');
             if ($contents) {
-                $this->createKillmailItems($contents, $killmail_item->id);
+                $this->createKillmailItems($contents, $killmailItem->id);
             }
         });
 
@@ -98,7 +98,7 @@ final class KillmailJob extends EsiJob
     private function createKillmailAttackers(array $attackers): void
     {
         collect($attackers)->map(fn (mixed $a) => (object) $a)->each(fn (object $attacker) => KillmailAttacker::create([
-            'killmail_id' => $this->killmail_id,
+            'killmail_id' => $this->killmailId,
             'character_id' => $attacker->character_id ?? null,
             'corporation_id' => $attacker->corporation_id ?? null,
             'alliance_id' => $attacker->alliance_id ?? null,

--- a/src/Jobs/Mail/MailBodyJob.php
+++ b/src/Jobs/Mail/MailBodyJob.php
@@ -14,28 +14,28 @@ final class MailBodyJob extends EsiJob
 {
     protected const string OPERATION_CLASS = GetCharactersCharacterIdMailMailId::class;
 
-    public function __construct(public int $character_id, public int $mail_id) {}
+    public function __construct(public int $characterId, public int $mailId) {}
 
     #[\Override]
     public function getRefreshToken(): RefreshToken
     {
-        return RefreshToken::findOrFail($this->character_id);
+        return RefreshToken::findOrFail($this->characterId);
     }
 
     #[\Override]
     public function tags(): array
     {
-        return ['mail', 'body', "character_id:{$this->character_id}", "mail_id:{$this->mail_id}"];
+        return ['mail', 'body', "character_id:{$this->characterId}", "mail_id:{$this->mailId}"];
     }
 
     #[\Override]
     public function executeJob(EsiClient $esi): void
     {
-        $response = self::OPERATION_CLASS::execute($esi, $this->character_id, $this->mail_id);
+        $response = self::OPERATION_CLASS::execute($esi, $this->characterId, $this->mailId);
         if ($response->isCachedLoad) {
             return;
         }
 
-        Mail::where('id', $this->mail_id)->update(['body' => $response->body]);
+        Mail::where('id', $this->mailId)->update(['body' => $response->body]);
     }
 }

--- a/src/Jobs/Mail/MailHeaderJob.php
+++ b/src/Jobs/Mail/MailHeaderJob.php
@@ -19,12 +19,12 @@ final class MailHeaderJob extends EsiJob
 {
     protected const string OPERATION_CLASS = GetCharactersCharacterIdMail::class;
 
-    public function __construct(public int $character_id) {}
+    public function __construct(public int $characterId) {}
 
     #[\Override]
     public function getRefreshToken(): RefreshToken
     {
-        return RefreshToken::findOrFail($this->character_id);
+        return RefreshToken::findOrFail($this->characterId);
     }
 
     #[\Override]
@@ -33,14 +33,14 @@ final class MailHeaderJob extends EsiJob
         return [
             'mail',
             'header',
-            "character_id:{$this->character_id}",
+            "character_id:{$this->characterId}",
         ];
     }
 
     #[\Override]
     public function executeJob(EsiClient $esi): void
     {
-        $response = self::OPERATION_CLASS::execute($esi, $this->character_id);
+        $response = self::OPERATION_CLASS::execute($esi, $this->characterId);
         if ($response->isCachedLoad) {
             return;
         }
@@ -71,26 +71,26 @@ final class MailHeaderJob extends EsiJob
         }
     }
 
-    private function getReceivableType(string $recipient_type): string
+    private function getReceivableType(string $recipientType): string
     {
-        return match ($recipient_type) {
+        return match ($recipientType) {
             'alliance' => AllianceInfo::class,
             'character' => CharacterInfo::class,
             'corporation' => CorporationInfo::class,
             'mailing_list' => 'mailing_list',
-            default => throw new \Exception("Unknown recipient type {$recipient_type}"),
+            default => throw new \Exception("Unknown recipient type {$recipientType}"),
         };
     }
 
     public function handleRecipients(Collection $mails): void
     {
-        $existing_recipients = MailRecipients::query()
+        $existingRecipients = MailRecipients::query()
             ->whereIn('mail_id', $mails->pluck('id'))
             ->get('mail_id')
             ->toArray();
 
         $recipients = $mails
-            ->filter(fn (array $mail) => ! in_array(data_get($mail, 'id'), $existing_recipients))
+            ->filter(fn (array $mail) => ! in_array(data_get($mail, 'id'), $existingRecipients))
             ->map(fn (array $mail) => collect(data_get($mail, 'recipients'))
                 ->map(fn (object $recipient) => [
                     'mail_id' => data_get($mail, 'id'),
@@ -99,7 +99,7 @@ final class MailHeaderJob extends EsiJob
                 ])
                 ->push([
                     'mail_id' => data_get($mail, 'id'),
-                    'receivable_id' => $this->character_id,
+                    'receivable_id' => $this->characterId,
                     'receivable_type' => CharacterInfo::class,
                 ])
                 ->unique()
@@ -118,8 +118,8 @@ final class MailHeaderJob extends EsiJob
             ->select('id')
             ->get()
             ->each(fn (Mail $mail) => $this->batching()
-                ? $this->batch()->add([new MailBodyJob($this->character_id, $mail->id)])
-                : MailBodyJob::dispatch($this->character_id, $mail->id)->onQueue($this->queue)
+                ? $this->batch()->add([new MailBodyJob($this->characterId, $mail->id)])
+                : MailBodyJob::dispatch($this->characterId, $mail->id)->onQueue($this->queue)
             );
     }
 }

--- a/src/Jobs/Seatplus/Batch/CharacterBatchJob.php
+++ b/src/Jobs/Seatplus/Batch/CharacterBatchJob.php
@@ -43,18 +43,18 @@ class CharacterBatchJob implements ShouldBeUnique, ShouldQueue
 
     const int REFRESH_DELAY_MINUTES = 5;
 
-    public RefreshToken $refresh_token;
+    public RefreshToken $refreshToken;
 
-    private array $batch_jobs;
+    private array $batchJobs;
 
     public function __construct(
-        public int $character_id,
+        public int $characterId,
         public $queue = 'default', // @pest-ignore-type
-        array $batch_jobs = [],
+        array $batchJobs = [],
         public bool $reschedule = false,
     ) {
-        $this->refresh_token = RefreshToken::find($this->character_id);
-        $this->batch_jobs = $batch_jobs ?: $this->createBatchJobs();
+        $this->refreshToken = RefreshToken::find($this->characterId);
+        $this->batchJobs = $batchJobs ?: $this->createBatchJobs();
     }
 
     public function middleware(): array
@@ -66,48 +66,48 @@ class CharacterBatchJob implements ShouldBeUnique, ShouldQueue
 
     public function uniqueId(): string
     {
-        return $this->character_id.':'.$this->queue;
+        return $this->characterId.':'.$this->queue;
     }
 
     public function handle(): void
     {
         // 1. Get BatchUpdate Entry
-        $batch_update = $this->getBatchUpdate();
+        $batchUpdate = $this->getBatchUpdate();
 
-        if ($this->shouldDiscardUpdate($batch_update)) {
+        if ($this->shouldDiscardUpdate($batchUpdate)) {
             return;
         }
-        $this->resetBatchUpdate($batch_update);
+        $this->resetBatchUpdate($batchUpdate);
 
         // 3. Dispatch and Return Job
         $batch = $this->execute();
 
         BatchStatistic::createEntry($batch);
 
-        $this->updateBatchId($batch, $batch_update);
+        $this->updateBatchId($batch, $batchUpdate);
     }
 
     private function execute(): Batch
     {
-        $character = $this->refresh_token?->character->name ?? $this->character_id;
-        $batch_name = sprintf('%s (character) update batch', $character);
-        $character_id = $this->character_id;
+        $character = $this->refreshToken?->character->name ?? $this->characterId;
+        $batchName = sprintf('%s (character) update batch', $character);
+        $characterId = $this->characterId;
         $queue = $this->queue;
         $reschedule = $this->reschedule;
 
         return Bus::batch($this->getBatchJobs())
-            ->finally(function (Batch $batch) use ($character_id, $queue, $reschedule) {
+            ->finally(function (Batch $batch) use ($characterId, $queue, $reschedule) {
                 // @codeCoverageIgnoreStart
                 BatchUpdate::where('batch_id', $batch->id)->update(['finished_at' => now()]);
                 BatchStatistic::where('batch_id', $batch->id)->update(['finished_at' => now()]);
 
                 if ($reschedule) {
-                    CharacterBatchJob::dispatch($character_id, $queue, reschedule: true)
+                    CharacterBatchJob::dispatch($characterId, $queue, reschedule: true)
                         ->delay(now()->addMinutes(self::REFRESH_DELAY_MINUTES));
                 }
                 // @codeCoverageIgnoreEnd
             })
-            ->name($batch_name)
+            ->name($batchName)
             ->onQueue($this->queue)
             ->allowFailures()
             ->dispatch();
@@ -119,10 +119,10 @@ class CharacterBatchJob implements ShouldBeUnique, ShouldQueue
             // Add Private Endpoints
             [
                 // Chain character info and affiliation
-                new CharacterInfoJob($this->character_id),
-                new CharacterAffiliationJob($this->character_id),
+                new CharacterInfoJob($this->characterId),
+                new CharacterAffiliationJob($this->characterId),
             ],
-            new CorporationHistoryJob($this->character_id),
+            new CorporationHistoryJob($this->characterId),
             ...$this->addAssetsJobs(),
             ...$this->addCharacterRolesJobs(),
             ...$this->addContactsJobs(),
@@ -137,15 +137,15 @@ class CharacterBatchJob implements ShouldBeUnique, ShouldQueue
     private function addAssetsJobs(): array
     {
         // Return empty array if required scopes are not present
-        if (! $this->refresh_token->hasScope('esi-assets.read_assets.v1')) {
+        if (! $this->refreshToken->hasScope('esi-assets.read_assets.v1')) {
             return [];
         }
 
         return [
             // add chain of jobs to get assets
             [
-                new CharacterAssetJob($this->character_id),
-                new CharacterAssetsNameJob($this->character_id),
+                new CharacterAssetJob($this->characterId),
+                new CharacterAssetsNameJob($this->characterId),
                 new EnrichAssetTypeGroupCategoryJob,
             ],
         ];
@@ -154,12 +154,12 @@ class CharacterBatchJob implements ShouldBeUnique, ShouldQueue
     private function addCharacterRolesJobs(): array
     {
         // Return empty array if required scopes are not present
-        if (! $this->refresh_token->hasScope('esi-characters.read_corporation_roles.v1')) {
+        if (! $this->refreshToken->hasScope('esi-characters.read_corporation_roles.v1')) {
             return [];
         }
 
         return [
-            new CharacterRoleJob($this->character_id),
+            new CharacterRoleJob($this->characterId),
         ];
     }
 
@@ -176,14 +176,14 @@ class CharacterBatchJob implements ShouldBeUnique, ShouldQueue
     private function addCharacterContactsJobs(): array
     {
         // Return empty array if required scopes are not present
-        if (! $this->refresh_token->hasScope('esi-characters.read_contacts.v1')) {
+        if (! $this->refreshToken->hasScope('esi-characters.read_contacts.v1')) {
             return [];
         }
 
         return [
             [
-                new CharacterContactJob($this->character_id),
-                new CharacterContactLabelJob($this->character_id),
+                new CharacterContactJob($this->characterId),
+                new CharacterContactLabelJob($this->characterId),
             ],
         ];
     }
@@ -191,17 +191,17 @@ class CharacterBatchJob implements ShouldBeUnique, ShouldQueue
     private function addCorporationContactsJobs(): array
     {
         // Return empty array if required scopes are not present
-        if (! $this->refresh_token->hasScope('esi-corporations.read_contacts.v1')) {
+        if (! $this->refreshToken->hasScope('esi-corporations.read_contacts.v1')) {
             return [];
         }
 
         // Get corporation_id from character
-        $corporation_id = $this->refresh_token->character?->corporation_id;
+        $corporationId = $this->refreshToken->character?->corporation_id;
 
         return [
             [
-                new CorporationContactJob($corporation_id, $this->character_id),
-                new CorporationContactLabelJob($corporation_id, $this->character_id),
+                new CorporationContactJob($corporationId, $this->characterId),
+                new CorporationContactLabelJob($corporationId, $this->characterId),
             ],
         ];
     }
@@ -209,22 +209,22 @@ class CharacterBatchJob implements ShouldBeUnique, ShouldQueue
     private function addAllianceContactsJobs(): array
     {
         // Return empty array if required scopes are not present
-        if (! $this->refresh_token->hasScope('esi-alliances.read_contacts.v1')) {
+        if (! $this->refreshToken->hasScope('esi-alliances.read_contacts.v1')) {
             return [];
         }
 
         // Get alliance_id from character
-        $alliance_id = $this->refresh_token->character?->alliance_id;
+        $allianceId = $this->refreshToken->character?->alliance_id;
 
         // Return empty array if character has no alliance
-        if (! $alliance_id) {
+        if (! $allianceId) {
             return [];
         }
 
         return [
             [
-                new AllianceContactJob($alliance_id, $this->character_id),
-                new AllianceContactLabelJob($alliance_id, $this->character_id),
+                new AllianceContactJob($allianceId, $this->characterId),
+                new AllianceContactLabelJob($allianceId, $this->characterId),
             ],
         ];
     }
@@ -232,95 +232,95 @@ class CharacterBatchJob implements ShouldBeUnique, ShouldQueue
     private function addWalletJobs(): array
     {
         // Return empty array if required scopes are not present
-        if (! $this->refresh_token->hasScope('esi-wallet.read_character_wallet.v1')) {
+        if (! $this->refreshToken->hasScope('esi-wallet.read_character_wallet.v1')) {
             return [];
         }
 
         return [
-            new CharacterWalletJournalJob($this->character_id),
-            new CharacterWalletTransactionJob($this->character_id),
-            new CharacterBalanceJob($this->character_id),
+            new CharacterWalletJournalJob($this->characterId),
+            new CharacterWalletTransactionJob($this->characterId),
+            new CharacterBalanceJob($this->characterId),
         ];
     }
 
     private function addContractJobs(): array
     {
         // Return empty array if required scopes are not present
-        if (! $this->refresh_token->hasScope('esi-contracts.read_character_contracts.v1')) {
+        if (! $this->refreshToken->hasScope('esi-contracts.read_character_contracts.v1')) {
             return [];
         }
 
         return [
-            new CharacterContractsJob($this->character_id),
+            new CharacterContractsJob($this->characterId),
         ];
     }
 
     private function addSkillsJobs(): array
     {
         // Return empty array if required scopes are not present
-        if (! $this->refresh_token->hasScope('esi-skills.read_skills.v1')) {
+        if (! $this->refreshToken->hasScope('esi-skills.read_skills.v1')) {
             return [];
         }
 
         return [
-            new SkillsJob($this->character_id),
+            new SkillsJob($this->characterId),
         ];
     }
 
     private function addSkillQueueJobs(): array
     {
         // Return empty array if required scopes are not present
-        if (! $this->refresh_token->hasScope('esi-skills.read_skillqueue.v1')) {
+        if (! $this->refreshToken->hasScope('esi-skills.read_skillqueue.v1')) {
             return [];
         }
 
         return [
-            new SkillQueueJob($this->character_id),
+            new SkillQueueJob($this->characterId),
         ];
     }
 
     private function addMailsJobs(): array
     {
         // Return empty array if required scopes are not present
-        if (! $this->refresh_token->hasScope('esi-mail.read_mail.v1')) {
+        if (! $this->refreshToken->hasScope('esi-mail.read_mail.v1')) {
             return [];
         }
 
         return [
-            new MailHeaderJob($this->character_id),
+            new MailHeaderJob($this->characterId),
         ];
     }
 
     public function getBatchJobs(): array
     {
-        return $this->batch_jobs;
+        return $this->batchJobs;
     }
 
     public function getBatchUpdate(): BatchUpdate
     {
         return BatchUpdate::firstOrCreate([
-            'batchable_id' => $this->character_id,
+            'batchable_id' => $this->characterId,
             'batchable_type' => CharacterInfo::class,
         ]);
     }
 
-    private function shouldDiscardUpdate(mixed $batch_update): bool
+    private function shouldDiscardUpdate(mixed $batchUpdate): bool
     {
-        return $batch_update->is_pending;
+        return $batchUpdate->is_pending;
     }
 
-    public function resetBatchUpdate(BatchUpdate $batch_update): void
+    public function resetBatchUpdate(BatchUpdate $batchUpdate): void
     {
         // reset batch_id, finished_at, started_at and queue
-        $batch_update->finished_at = null;
-        $batch_update->batch_id = null;
-        $batch_update->started_at = now();
-        $batch_update->queue = $this->queue;
+        $batchUpdate->finished_at = null;
+        $batchUpdate->batch_id = null;
+        $batchUpdate->started_at = now();
+        $batchUpdate->queue = $this->queue;
     }
 
-    public function updateBatchId(Batch $batch, mixed $batch_update): void
+    public function updateBatchId(Batch $batch, mixed $batchUpdate): void
     {
-        $batch_update->batch_id = $batch->id;
-        $batch_update->save();
+        $batchUpdate->batch_id = $batch->id;
+        $batchUpdate->save();
     }
 }

--- a/src/Jobs/Seatplus/UpdateCharacter.php
+++ b/src/Jobs/Seatplus/UpdateCharacter.php
@@ -42,13 +42,13 @@ class UpdateCharacter implements ShouldQueue
     use Queueable;
 
     public function __construct(
-        public ?RefreshToken $refresh_token = null
+        public ?RefreshToken $refreshToken = null
     ) {}
 
     public function handle(): void
     {
         // if refresh_token is set, we only want to update this character
-        $this->refresh_token
+        $this->refreshToken
             ? $this->updateSingleCharacter()
             // otherwise bootstrap/catchup: dispatch chars that need scheduling
             : $this->updateNextIncrementOfCharacters();
@@ -56,15 +56,15 @@ class UpdateCharacter implements ShouldQueue
 
     private function updateSingleCharacter(): void
     {
-        CharacterBatchJob::dispatch($this->refresh_token->character_id)->onQueue('high');
+        CharacterBatchJob::dispatch($this->refreshToken->character_id)->onQueue('high');
     }
 
     private function updateNextIncrementOfCharacters(): void
     {
-        $stale_threshold = now()->subMinutes(CharacterBatchJob::REFRESH_DELAY_MINUTES * 2);
+        $staleThreshold = now()->subMinutes(CharacterBatchJob::REFRESH_DELAY_MINUTES * 2);
 
         // Characters that never had a BatchUpdate record
-        $never_updated = RefreshToken::query()
+        $neverUpdated = RefreshToken::query()
             ->whereNotIn('character_id', BatchUpdate::query()
                 ->select('batchable_id')
                 ->where('batchable_type', CharacterInfo::class)
@@ -72,16 +72,16 @@ class UpdateCharacter implements ShouldQueue
             ->get();
 
         // Characters whose last batch finished before the stale threshold (not currently running)
-        $stale_updated = RefreshToken::query()
+        $staleUpdated = RefreshToken::query()
             ->whereIn('character_id', BatchUpdate::query()
                 ->select('batchable_id')
                 ->where('batchable_type', CharacterInfo::class)
                 ->whereNotNull('finished_at')
-                ->where('finished_at', '<', $stale_threshold)
+                ->where('finished_at', '<', $staleThreshold)
             )
             ->get();
 
-        $tokens = $never_updated->merge($stale_updated)->unique('character_id');
+        $tokens = $neverUpdated->merge($staleUpdated)->unique('character_id');
 
         $tokens->each(function (RefreshToken $token, int $index) {
             CharacterBatchJob::dispatch($token->character_id, 'default', reschedule: true)

--- a/src/Jobs/Seatplus/UpdateCorporation.php
+++ b/src/Jobs/Seatplus/UpdateCorporation.php
@@ -49,7 +49,7 @@ class UpdateCorporation implements ShouldQueue
     private FindCorporationRefreshToken $findCorporationRefreshToken;
 
     public function __construct(
-        public ?int $corporation_id = null,
+        public ?int $corporationId = null,
     ) {
         $this->findCorporationRefreshToken = new FindCorporationRefreshToken;
     }
@@ -63,27 +63,27 @@ class UpdateCorporation implements ShouldQueue
 
     public function handle(): void
     {
-        if ($this->corporation_id) {
-            $this->execute($this->corporation_id, 'high');
+        if ($this->corporationId) {
+            $this->execute($this->corporationId, 'high');
         } else {
             RefreshToken::with(['corporation', 'character.roles'])
                 ->cursor()
                 ->map(fn (RefreshToken $token) => $token->corporation?->corporation_id)
                 ->filter()
                 ->unique()
-                ->each(fn (int $corporation_id) => $this->execute($corporation_id));
+                ->each(fn (int $corporationId) => $this->execute($corporationId));
         }
     }
 
-    private function execute(int $corporation_id, string $queue = 'default'): void
+    private function execute(int $corporationId, string $queue = 'default'): void
     {
-        $corporation = optional(CorporationInfo::find($corporation_id))->name ?? $corporation_id;
+        $corporation = optional(CorporationInfo::find($corporationId))->name ?? $corporationId;
 
-        $batch_name = sprintf('%s (corporation) update batch', $corporation);
+        $batchName = sprintf('%s (corporation) update batch', $corporation);
 
-        $batch = Bus::batch($this->getBatchJobs($corporation_id))
+        $batch = Bus::batch($this->getBatchJobs($corporationId))
             ->then(fn (Batch $batch) => BatchStatistic::where('batch_id', $batch->id)->update(['finished_at' => now()]))
-            ->name($batch_name)
+            ->name($batchName)
             ->onQueue($queue)
             ->allowFailures()
             ->dispatch();
@@ -91,48 +91,48 @@ class UpdateCorporation implements ShouldQueue
         BatchStatistic::createEntry($batch);
     }
 
-    private function getBatchJobs(int $corporation_id): array
+    private function getBatchJobs(int $corporationId): array
     {
         return collect()
-            ->merge($this->addCorporationDivisionsJobs($corporation_id))
-            ->merge($this->addCorporationMemberTrackingJobs($corporation_id))
-            ->merge($this->addCorporationWalletHydrateBatch($corporation_id))
+            ->merge($this->addCorporationDivisionsJobs($corporationId))
+            ->merge($this->addCorporationMemberTrackingJobs($corporationId))
+            ->merge($this->addCorporationWalletHydrateBatch($corporationId))
             ->values()
             ->toArray();
     }
 
-    private function addCorporationDivisionsJobs(int $corporation_id): array
+    private function addCorporationDivisionsJobs(int $corporationId): array
     {
-        if (! call_user_func_array($this->findCorporationRefreshToken, [$corporation_id, 'esi-corporations.read_divisions.v1', 'Director'])) {
+        if (! call_user_func_array($this->findCorporationRefreshToken, [$corporationId, 'esi-corporations.read_divisions.v1', 'Director'])) {
             return [];
         }
 
         return [
-            new CorporationDivisionsJob($corporation_id),
+            new CorporationDivisionsJob($corporationId),
         ];
     }
 
-    private function addCorporationMemberTrackingJobs(int $corporation_id): array
+    private function addCorporationMemberTrackingJobs(int $corporationId): array
     {
-        if (! call_user_func_array($this->findCorporationRefreshToken, [$corporation_id, 'esi-corporations.track_members.v1', 'Director'])) {
+        if (! call_user_func_array($this->findCorporationRefreshToken, [$corporationId, 'esi-corporations.track_members.v1', 'Director'])) {
             return [];
         }
 
         return [
-            new CorporationMemberTrackingJob($corporation_id),
+            new CorporationMemberTrackingJob($corporationId),
         ];
     }
 
-    private function addCorporationWalletHydrateBatch(int $corporation_id): array
+    private function addCorporationWalletHydrateBatch(int $corporationId): array
     {
-        if (! call_user_func_array($this->findCorporationRefreshToken, [$corporation_id, head(config('eveapi.scopes.corporation.wallet')), ['Accountant', 'Junior_Accountant']])) {
+        if (! call_user_func_array($this->findCorporationRefreshToken, [$corporationId, head(config('eveapi.scopes.corporation.wallet')), ['Accountant', 'Junior_Accountant']])) {
             return [];
         }
 
         return [
             [
-                new CorporationBalanceJob($corporation_id),
-                new CorporationWalletJournalJob($corporation_id),
+                new CorporationBalanceJob($corporationId),
+                new CorporationWalletJournalJob($corporationId),
             ],
         ];
     }

--- a/src/Jobs/Skills/SkillQueueJob.php
+++ b/src/Jobs/Skills/SkillQueueJob.php
@@ -15,30 +15,30 @@ final class SkillQueueJob extends EsiJob
 {
     protected const string OPERATION_CLASS = GetCharactersCharacterIdSkillqueue::class;
 
-    public function __construct(private readonly int $character_id) {}
+    public function __construct(private readonly int $characterId) {}
 
     #[\Override]
     public function getRefreshToken(): RefreshToken
     {
-        return RefreshToken::findOrFail($this->character_id);
+        return RefreshToken::findOrFail($this->characterId);
     }
 
     #[\Override]
     public function tags(): array
     {
-        return ['character', "character_id:{$this->character_id}", 'skillqueue'];
+        return ['character', "character_id:{$this->characterId}", 'skillqueue'];
     }
 
     #[\Override]
     public function executeJob(EsiClient $esi): void
     {
-        $response = self::OPERATION_CLASS::execute($esi, $this->character_id);
+        $response = self::OPERATION_CLASS::execute($esi, $this->characterId);
         if ($response->isCachedLoad) {
             return;
         }
 
         $skillQueue = collect($response->data)->map(fn (object $item) => [
-            'character_id' => $this->character_id,
+            'character_id' => $this->characterId,
             'skill_id' => $item->skill_id,
             'queue_position' => $item->queue_position,
             'finished_level' => $item->finished_level,
@@ -49,11 +49,11 @@ final class SkillQueueJob extends EsiJob
             'level_end_sp' => $item->level_end_sp ?? null,
         ]);
 
-        SkillQueue::query()->where('character_id', $this->character_id)->delete();
+        SkillQueue::query()->where('character_id', $this->characterId)->delete();
         SkillQueue::upsert($skillQueue->toArray(), ['character_id', 'skill_id', 'queue_position']);
 
         SkillQueue::query()
-            ->where('character_id', $this->character_id)
+            ->where('character_id', $this->characterId)
             ->doesntHave('type')
             ->pluck('skill_id')
             ->each(fn (int $skillId) => ResolveUniverseTypeByIdJob::dispatch($skillId)->onQueue('high'));

--- a/src/Jobs/Skills/SkillsJob.php
+++ b/src/Jobs/Skills/SkillsJob.php
@@ -16,30 +16,30 @@ final class SkillsJob extends EsiJob
 {
     protected const string OPERATION_CLASS = GetCharactersCharacterIdSkills::class;
 
-    public function __construct(private readonly int $character_id) {}
+    public function __construct(private readonly int $characterId) {}
 
     #[\Override]
     public function getRefreshToken(): RefreshToken
     {
-        return RefreshToken::findOrFail($this->character_id);
+        return RefreshToken::findOrFail($this->characterId);
     }
 
     #[\Override]
     public function tags(): array
     {
-        return ['character', "character_id:{$this->character_id}", 'skills'];
+        return ['character', "character_id:{$this->characterId}", 'skills'];
     }
 
     #[\Override]
     public function executeJob(EsiClient $esi): void
     {
-        $response = self::OPERATION_CLASS::execute($esi, $this->character_id);
+        $response = self::OPERATION_CLASS::execute($esi, $this->characterId);
         if ($response->isCachedLoad) {
             return;
         }
 
         $skills = collect($response->skills)->map(fn (object $skill) => [
-            'character_id' => $this->character_id,
+            'character_id' => $this->characterId,
             'skill_id' => $skill->skill_id,
             'active_skill_level' => $skill->active_skill_level,
             'skillpoints_in_skill' => $skill->skillpoints_in_skill,
@@ -52,13 +52,13 @@ final class SkillsJob extends EsiJob
             ['skillpoints_in_skill', 'trained_skill_level', 'active_skill_level']
         );
 
-        CharacterInfo::where('character_id', $this->character_id)->update([
+        CharacterInfo::where('character_id', $this->characterId)->update([
             'total_sp' => $response->total_sp,
             'unallocated_sp' => $response->unallocated_sp,
         ]);
 
         Skill::query()
-            ->where('character_id', $this->character_id)
+            ->where('character_id', $this->characterId)
             ->doesntHave('type')
             ->pluck('skill_id')
             ->each(fn (int $skillId) => ResolveUniverseTypeByIdJob::dispatch($skillId)->onQueue('high'));

--- a/src/Jobs/Universe/ResolveLocationJob.php
+++ b/src/Jobs/Universe/ResolveLocationJob.php
@@ -59,29 +59,29 @@ class ResolveLocationJob implements ShouldBeUnique, ShouldQueue
     }
 
     public function __construct(
-        public int $location_id,
-        public ?RefreshToken $refresh_token = null
+        public int $locationId,
+        public ?RefreshToken $refreshToken = null
     ) {}
 
     public function tags(): array
     {
-        if ($this->refresh_token) {
+        if ($this->refreshToken) {
             return [
                 'location_resolve',
-                'location_id:'.$this->location_id,
-                'via character: '.$this->refresh_token->character_id,
+                'location_id:'.$this->locationId,
+                'via character: '.$this->refreshToken->character_id,
             ];
         }
 
         return [
             'location_resolve',
-            'location_id:'.$this->location_id,
+            'location_id:'.$this->locationId,
         ];
     }
 
     public function handle(): void
     {
 
-        ResolveLocationService::make($this->refresh_token)->handle($this->location_id);
+        ResolveLocationService::make($this->refreshToken)->handle($this->locationId);
     }
 }

--- a/src/Jobs/Universe/ResolveUniverseCategoryByIdJob.php
+++ b/src/Jobs/Universe/ResolveUniverseCategoryByIdJob.php
@@ -13,18 +13,18 @@ final class ResolveUniverseCategoryByIdJob extends EsiJob
 {
     protected const string OPERATION_CLASS = GetUniverseCategoriesCategoryId::class;
 
-    public function __construct(private readonly int $category_id) {}
+    public function __construct(private readonly int $categoryId) {}
 
     #[\Override]
     public function tags(): array
     {
-        return ['resolve', 'universe', 'category', "category_id:{$this->category_id}"];
+        return ['resolve', 'universe', 'category', "category_id:{$this->categoryId}"];
     }
 
     #[\Override]
     public function executeJob(EsiClient $esi): void
     {
-        $response = self::OPERATION_CLASS::execute($esi, $this->category_id);
+        $response = self::OPERATION_CLASS::execute($esi, $this->categoryId);
 
         if ($response->isCachedLoad) {
             return;

--- a/src/Jobs/Universe/ResolveUniverseConstellationByConstellationIdJob.php
+++ b/src/Jobs/Universe/ResolveUniverseConstellationByConstellationIdJob.php
@@ -13,18 +13,18 @@ final class ResolveUniverseConstellationByConstellationIdJob extends EsiJob
 {
     protected const string OPERATION_CLASS = GetUniverseConstellationsConstellationId::class;
 
-    public function __construct(public int $constellation_id) {}
+    public function __construct(public int $constellationId) {}
 
     #[\Override]
     public function tags(): array
     {
-        return ['resolve', 'universe', 'constellation', "constellation_id:{$this->constellation_id}"];
+        return ['resolve', 'universe', 'constellation', "constellation_id:{$this->constellationId}"];
     }
 
     #[\Override]
     public function executeJob(EsiClient $esi): void
     {
-        $response = self::OPERATION_CLASS::execute($esi, $this->constellation_id);
+        $response = self::OPERATION_CLASS::execute($esi, $this->constellationId);
 
         if ($response->isCachedLoad) {
             return;

--- a/src/Jobs/Universe/ResolveUniverseGroupByIdJob.php
+++ b/src/Jobs/Universe/ResolveUniverseGroupByIdJob.php
@@ -13,18 +13,18 @@ final class ResolveUniverseGroupByIdJob extends EsiJob
 {
     protected const string OPERATION_CLASS = GetUniverseGroupsGroupId::class;
 
-    public function __construct(private readonly int $group_id) {}
+    public function __construct(private readonly int $groupId) {}
 
     #[\Override]
     public function tags(): array
     {
-        return ['resolve', 'universe', 'group', "group_id:{$this->group_id}"];
+        return ['resolve', 'universe', 'group', "group_id:{$this->groupId}"];
     }
 
     #[\Override]
     public function executeJob(EsiClient $esi): void
     {
-        $response = self::OPERATION_CLASS::execute($esi, $this->group_id);
+        $response = self::OPERATION_CLASS::execute($esi, $this->groupId);
 
         if ($response->isCachedLoad) {
             return;

--- a/src/Jobs/Universe/ResolveUniverseRegionByRegionIdJob.php
+++ b/src/Jobs/Universe/ResolveUniverseRegionByRegionIdJob.php
@@ -13,18 +13,18 @@ final class ResolveUniverseRegionByRegionIdJob extends EsiJob
 {
     protected const string OPERATION_CLASS = GetUniverseRegionsRegionId::class;
 
-    public function __construct(private readonly int $region_id) {}
+    public function __construct(private readonly int $regionId) {}
 
     #[\Override]
     public function tags(): array
     {
-        return ['resolve', 'universe', 'region', "region_id:{$this->region_id}"];
+        return ['resolve', 'universe', 'region', "region_id:{$this->regionId}"];
     }
 
     #[\Override]
     public function executeJob(EsiClient $esi): void
     {
-        $response = self::OPERATION_CLASS::execute($esi, $this->region_id);
+        $response = self::OPERATION_CLASS::execute($esi, $this->regionId);
 
         if ($response->isCachedLoad) {
             return;

--- a/src/Jobs/Universe/ResolveUniverseStationByIdJob.php
+++ b/src/Jobs/Universe/ResolveUniverseStationByIdJob.php
@@ -16,28 +16,28 @@ final class ResolveUniverseStationByIdJob extends EsiJob
 
     public const array STATION_IDS_RANGE = [60000000, 64000000];
 
-    public function __construct(public int $location_id) {}
+    public function __construct(public int $locationId) {}
 
     #[\Override]
     public function tags(): array
     {
-        return ['resolve', 'universe', 'station', "location_id:{$this->location_id}"];
+        return ['resolve', 'universe', 'station', "location_id:{$this->locationId}"];
     }
 
     #[\Override]
     public function executeJob(EsiClient $esi): void
     {
-        if ($this->location_id < head(self::STATION_IDS_RANGE) || $this->location_id > last(self::STATION_IDS_RANGE)) {
+        if ($this->locationId < head(self::STATION_IDS_RANGE) || $this->locationId > last(self::STATION_IDS_RANGE)) {
             return;
         }
 
-        $response = self::OPERATION_CLASS::execute($esi, $this->location_id);
+        $response = self::OPERATION_CLASS::execute($esi, $this->locationId);
 
         if ($response->isCachedLoad) {
             return;
         }
 
-        Station::updateOrCreate(['station_id' => $this->location_id], [
+        Station::updateOrCreate(['station_id' => $this->locationId], [
             'type_id' => $response->type_id,
             'name' => $response->name,
             'owner_id' => $response->owner ?? null,
@@ -49,8 +49,8 @@ final class ResolveUniverseStationByIdJob extends EsiJob
             'office_rental_cost' => $response->office_rental_cost,
         ])->touch();
 
-        Location::updateOrCreate(['location_id' => $this->location_id], [
-            'locatable_id' => $this->location_id,
+        Location::updateOrCreate(['location_id' => $this->locationId], [
+            'locatable_id' => $this->locationId,
             'locatable_type' => Station::class,
         ]);
     }

--- a/src/Jobs/Universe/ResolveUniverseStructureByIdJob.php
+++ b/src/Jobs/Universe/ResolveUniverseStructureByIdJob.php
@@ -20,14 +20,14 @@ final class ResolveUniverseStructureByIdJob extends EsiJob
     protected const string OPERATION_CLASS = GetUniverseStructuresStructureId::class;
 
     public function __construct(
-        public int $character_id,
-        public int $location_id
+        public int $characterId,
+        public int $locationId
     ) {}
 
     #[\Override]
     public function tags(): array
     {
-        return ['resolve', 'universe', 'structure', "location_id:{$this->location_id}"];
+        return ['resolve', 'universe', 'structure', "location_id:{$this->locationId}"];
     }
 
     #[\Override]
@@ -44,26 +44,26 @@ final class ResolveUniverseStructureByIdJob extends EsiJob
     #[\Override]
     public function getRefreshToken(): RefreshToken
     {
-        return RefreshToken::findOrFail($this->character_id);
+        return RefreshToken::findOrFail($this->characterId);
     }
 
     #[\Override]
     public function executeJob(EsiClient $esi): void
     {
-        $response = self::OPERATION_CLASS::execute($esi, $this->location_id);
+        $response = self::OPERATION_CLASS::execute($esi, $this->locationId);
         if ($response->isCachedLoad) {
             return;
         }
 
-        Structure::updateOrCreate(['structure_id' => $this->location_id], [
+        Structure::updateOrCreate(['structure_id' => $this->locationId], [
             'name' => $response->name,
             'owner_id' => $response->owner_id,
             'solar_system_id' => $response->solar_system_id,
             'type_id' => $response->type_id ?? null,
         ])->touch();
 
-        Location::updateOrCreate(['location_id' => $this->location_id], [
-            'locatable_id' => $this->location_id,
+        Location::updateOrCreate(['location_id' => $this->locationId], [
+            'locatable_id' => $this->locationId,
             'locatable_type' => Structure::class,
         ]);
     }

--- a/src/Jobs/Universe/ResolveUniverseSystemBySystemIdJob.php
+++ b/src/Jobs/Universe/ResolveUniverseSystemBySystemIdJob.php
@@ -13,18 +13,18 @@ final class ResolveUniverseSystemBySystemIdJob extends EsiJob
 {
     protected const string OPERATION_CLASS = GetUniverseSystemsSystemId::class;
 
-    public function __construct(private readonly int $system_id) {}
+    public function __construct(private readonly int $systemId) {}
 
     #[\Override]
     public function tags(): array
     {
-        return ['resolve', 'universe', 'system', "system_id:{$this->system_id}"];
+        return ['resolve', 'universe', 'system', "system_id:{$this->systemId}"];
     }
 
     #[\Override]
     public function executeJob(EsiClient $esi): void
     {
-        $response = self::OPERATION_CLASS::execute($esi, $this->system_id);
+        $response = self::OPERATION_CLASS::execute($esi, $this->systemId);
 
         if ($response->isCachedLoad) {
             return;

--- a/src/Jobs/Universe/ResolveUniverseTypeByIdJob.php
+++ b/src/Jobs/Universe/ResolveUniverseTypeByIdJob.php
@@ -13,18 +13,18 @@ final class ResolveUniverseTypeByIdJob extends EsiJob
 {
     protected const string OPERATION_CLASS = GetUniverseTypesTypeId::class;
 
-    public function __construct(private readonly int $type_id) {}
+    public function __construct(private readonly int $typeId) {}
 
     #[\Override]
     public function tags(): array
     {
-        return ['resolve', 'universe', 'type', "type_id:{$this->type_id}"];
+        return ['resolve', 'universe', 'type', "type_id:{$this->typeId}"];
     }
 
     #[\Override]
     public function executeJob(EsiClient $esi): void
     {
-        $response = self::OPERATION_CLASS::execute($esi, $this->type_id);
+        $response = self::OPERATION_CLASS::execute($esi, $this->typeId);
 
         if ($response->isCachedLoad) {
             return;

--- a/src/Jobs/Wallet/CharacterBalanceJob.php
+++ b/src/Jobs/Wallet/CharacterBalanceJob.php
@@ -15,30 +15,30 @@ final class CharacterBalanceJob extends EsiJob
 {
     protected const string OPERATION_CLASS = GetCharactersCharacterIdWallet::class;
 
-    public function __construct(public int $character_id) {}
+    public function __construct(public int $characterId) {}
 
     #[\Override]
     public function getRefreshToken(): RefreshToken
     {
-        return RefreshToken::findOrFail($this->character_id);
+        return RefreshToken::findOrFail($this->characterId);
     }
 
     #[\Override]
     public function tags(): array
     {
-        return ['character', "character_id:{$this->character_id}", 'wallet', 'balance'];
+        return ['character', "character_id:{$this->characterId}", 'wallet', 'balance'];
     }
 
     #[\Override]
     public function executeJob(EsiClient $esi): void
     {
-        $response = self::OPERATION_CLASS::execute($esi, $this->character_id);
+        $response = self::OPERATION_CLASS::execute($esi, $this->characterId);
         if ($response->isCachedLoad) {
             return;
         }
 
         Balance::updateOrCreate(
-            ['balanceable_id' => $this->character_id, 'balanceable_type' => CharacterInfo::class],
+            ['balanceable_id' => $this->characterId, 'balanceable_type' => CharacterInfo::class],
             ['balance' => $response->data]
         );
     }

--- a/src/Jobs/Wallet/CharacterWalletJournalJob.php
+++ b/src/Jobs/Wallet/CharacterWalletJournalJob.php
@@ -14,24 +14,24 @@ final class CharacterWalletJournalJob extends WalletJournalBase
 {
     protected const string OPERATION_CLASS = GetCharactersCharacterIdWalletJournal::class;
 
-    public function __construct(public int $character_id) {}
+    public function __construct(public int $characterId) {}
 
     #[\Override]
     public function getRefreshToken(): RefreshToken
     {
-        return RefreshToken::findOrFail($this->character_id);
+        return RefreshToken::findOrFail($this->characterId);
     }
 
     #[\Override]
     protected function fetchPage(EsiClient $esi, int $page): EsiResult
     {
-        return self::OPERATION_CLASS::execute($esi, $this->character_id, $page);
+        return self::OPERATION_CLASS::execute($esi, $this->characterId, $page);
     }
 
     #[\Override]
     protected function walletableId(): int
     {
-        return $this->character_id;
+        return $this->characterId;
     }
 
     #[\Override]
@@ -43,6 +43,6 @@ final class CharacterWalletJournalJob extends WalletJournalBase
     #[\Override]
     public function tags(): array
     {
-        return ['character', "character_id:{$this->character_id}", 'wallet', 'journal'];
+        return ['character', "character_id:{$this->characterId}", 'wallet', 'journal'];
     }
 }

--- a/src/Jobs/Wallet/CharacterWalletTransactionJob.php
+++ b/src/Jobs/Wallet/CharacterWalletTransactionJob.php
@@ -14,24 +14,24 @@ final class CharacterWalletTransactionJob extends WalletTransactionBase
 {
     protected const string OPERATION_CLASS = GetCharactersCharacterIdWalletTransactions::class;
 
-    public function __construct(public int $character_id) {}
+    public function __construct(public int $characterId) {}
 
     #[\Override]
     public function getRefreshToken(): RefreshToken
     {
-        return RefreshToken::findOrFail($this->character_id);
+        return RefreshToken::findOrFail($this->characterId);
     }
 
     #[\Override]
     protected function fetchTransactions(EsiClient $esi, ?int $fromId): EsiResult
     {
-        return self::OPERATION_CLASS::execute($esi, $this->character_id, $fromId);
+        return self::OPERATION_CLASS::execute($esi, $this->characterId, $fromId);
     }
 
     #[\Override]
     protected function transactionableId(): int
     {
-        return $this->character_id;
+        return $this->characterId;
     }
 
     #[\Override]
@@ -43,6 +43,6 @@ final class CharacterWalletTransactionJob extends WalletTransactionBase
     #[\Override]
     public function tags(): array
     {
-        return ['character', "character_id:{$this->character_id}", 'wallet', 'transaction'];
+        return ['character', "character_id:{$this->characterId}", 'wallet', 'transaction'];
     }
 }

--- a/src/Jobs/Wallet/CorporationBalanceJob.php
+++ b/src/Jobs/Wallet/CorporationBalanceJob.php
@@ -17,17 +17,17 @@ final class CorporationBalanceJob extends EsiJob
 {
     protected const string OPERATION_CLASS = GetCorporationsCorporationIdWallets::class;
 
-    public function __construct(public int $corporation_id) {}
+    public function __construct(public int $corporationId) {}
 
     #[\Override]
     public function getRefreshToken(): RefreshToken
     {
         $token = (new FindCorporationRefreshToken)(
-            $this->corporation_id,
+            $this->corporationId,
             head(config('eveapi.scopes.corporation.wallet')),
             ['Accountant', 'Junior_Accountant']
         );
-        throw_unless($token, new \Exception("No eligible refresh token found for corporation {$this->corporation_id}"));
+        throw_unless($token, new \Exception("No eligible refresh token found for corporation {$this->corporationId}"));
 
         return $token;
     }
@@ -35,19 +35,19 @@ final class CorporationBalanceJob extends EsiJob
     #[\Override]
     public function tags(): array
     {
-        return ['corporation', "corporation_id:{$this->corporation_id}", 'balances'];
+        return ['corporation', "corporation_id:{$this->corporationId}", 'balances'];
     }
 
     #[\Override]
     public function executeJob(EsiClient $esi): void
     {
-        $response = self::OPERATION_CLASS::execute($esi, $this->corporation_id);
+        $response = self::OPERATION_CLASS::execute($esi, $this->corporationId);
         if ($response->isCachedLoad) {
             return;
         }
 
         $balances = collect($response->data)->map(fn (object $wallet) => [
-            'balanceable_id' => $this->corporation_id,
+            'balanceable_id' => $this->corporationId,
             'balanceable_type' => CorporationInfo::class,
             'division' => $wallet->division,
             'balance' => $wallet->balance,
@@ -61,8 +61,8 @@ final class CorporationBalanceJob extends EsiJob
     private function dispatchDivisionJobs(Collection $balances): void
     {
         $balances->each(function (array $balance) {
-            CorporationWalletJournalByDivisionJob::dispatch($this->corporation_id, $balance['division'])->onQueue('high');
-            CorporationWalletTransactionByDivisionJob::dispatch($this->corporation_id, $balance['division'])->onQueue('high');
+            CorporationWalletJournalByDivisionJob::dispatch($this->corporationId, $balance['division'])->onQueue('high');
+            CorporationWalletTransactionByDivisionJob::dispatch($this->corporationId, $balance['division'])->onQueue('high');
         });
     }
 }

--- a/src/Jobs/Wallet/CorporationWalletJournalByDivisionJob.php
+++ b/src/Jobs/Wallet/CorporationWalletJournalByDivisionJob.php
@@ -16,7 +16,7 @@ final class CorporationWalletJournalByDivisionJob extends WalletJournalBase
     protected const string OPERATION_CLASS = GetCorporationsCorporationIdWalletsDivisionJournal::class;
 
     public function __construct(
-        public int $corporation_id,
+        public int $corporationId,
         private readonly int $division
     ) {}
 
@@ -24,11 +24,11 @@ final class CorporationWalletJournalByDivisionJob extends WalletJournalBase
     public function getRefreshToken(): RefreshToken
     {
         $token = (new FindCorporationRefreshToken)(
-            $this->corporation_id,
+            $this->corporationId,
             head(config('eveapi.scopes.corporation.wallet')),
             ['Accountant', 'Junior_Accountant']
         );
-        throw_unless($token, new \Exception("No eligible refresh token for corporation {$this->corporation_id}"));
+        throw_unless($token, new \Exception("No eligible refresh token for corporation {$this->corporationId}"));
 
         return $token;
     }
@@ -36,13 +36,13 @@ final class CorporationWalletJournalByDivisionJob extends WalletJournalBase
     #[\Override]
     protected function fetchPage(EsiClient $esi, int $page): EsiResult
     {
-        return self::OPERATION_CLASS::execute($esi, $this->corporation_id, $this->division, $page);
+        return self::OPERATION_CLASS::execute($esi, $this->corporationId, $this->division, $page);
     }
 
     #[\Override]
     protected function walletableId(): int
     {
-        return $this->corporation_id;
+        return $this->corporationId;
     }
 
     #[\Override]
@@ -60,6 +60,6 @@ final class CorporationWalletJournalByDivisionJob extends WalletJournalBase
     #[\Override]
     public function tags(): array
     {
-        return ['corporation', "corporation_id:{$this->corporation_id}", 'wallet', 'journal', "division:{$this->division}"];
+        return ['corporation', "corporation_id:{$this->corporationId}", 'wallet', 'journal', "division:{$this->division}"];
     }
 }

--- a/src/Jobs/Wallet/CorporationWalletJournalJob.php
+++ b/src/Jobs/Wallet/CorporationWalletJournalJob.php
@@ -42,7 +42,7 @@ class CorporationWalletJournalJob implements ShouldBeUnique, ShouldQueue
     use Queueable;
 
     public function __construct(
-        private int $corporation_id
+        private int $corporationId
     ) {}
 
     /**
@@ -57,7 +57,7 @@ class CorporationWalletJournalJob implements ShouldBeUnique, ShouldQueue
     {
         return sprintf(
             'Corporation wallet journal dispatcher for corporation_id %s ',
-            $this->corporation_id
+            $this->corporationId
         );
     }
 
@@ -65,7 +65,7 @@ class CorporationWalletJournalJob implements ShouldBeUnique, ShouldQueue
     {
         return [
             'corporation',
-            'corporation_id: '.$this->corporation_id,
+            'corporation_id: '.$this->corporationId,
             'wallet',
             'journals',
         ];
@@ -82,7 +82,7 @@ class CorporationWalletJournalJob implements ShouldBeUnique, ShouldQueue
             ->whereHasMorph(
                 'balanceable',
                 CorporationInfo::class,
-                fn (Builder $query) => $query->where('corporation_id', $this->corporation_id)
+                fn (Builder $query) => $query->where('corporation_id', $this->corporationId)
             )
             ->get()
             ->each(
@@ -103,12 +103,12 @@ class CorporationWalletJournalJob implements ShouldBeUnique, ShouldQueue
         }
 
         $this->batch()->add([
-            new CorporationWalletJournalByDivisionJob($this->corporation_id, $division),
+            new CorporationWalletJournalByDivisionJob($this->corporationId, $division),
         ]);
     }
 
     private function handleNonBatching(int $division): void
     {
-        CorporationWalletJournalByDivisionJob::dispatch($this->corporation_id, $division)->onQueue($this->queue);
+        CorporationWalletJournalByDivisionJob::dispatch($this->corporationId, $division)->onQueue($this->queue);
     }
 }

--- a/src/Jobs/Wallet/CorporationWalletTransactionByDivisionJob.php
+++ b/src/Jobs/Wallet/CorporationWalletTransactionByDivisionJob.php
@@ -16,7 +16,7 @@ final class CorporationWalletTransactionByDivisionJob extends WalletTransactionB
     protected const string OPERATION_CLASS = GetCorporationsCorporationIdWalletsDivisionTransactions::class;
 
     public function __construct(
-        public int $corporation_id,
+        public int $corporationId,
         private readonly int $division
     ) {}
 
@@ -24,11 +24,11 @@ final class CorporationWalletTransactionByDivisionJob extends WalletTransactionB
     public function getRefreshToken(): RefreshToken
     {
         $token = (new FindCorporationRefreshToken)(
-            $this->corporation_id,
+            $this->corporationId,
             head(config('eveapi.scopes.corporation.wallet')),
             ['Accountant', 'Junior_Accountant']
         );
-        throw_unless($token, new \Exception("No eligible refresh token for corporation {$this->corporation_id}"));
+        throw_unless($token, new \Exception("No eligible refresh token for corporation {$this->corporationId}"));
 
         return $token;
     }
@@ -36,13 +36,13 @@ final class CorporationWalletTransactionByDivisionJob extends WalletTransactionB
     #[\Override]
     protected function fetchTransactions(EsiClient $esi, ?int $fromId): EsiResult
     {
-        return self::OPERATION_CLASS::execute($esi, $this->corporation_id, $this->division, $fromId);
+        return self::OPERATION_CLASS::execute($esi, $this->corporationId, $this->division, $fromId);
     }
 
     #[\Override]
     protected function transactionableId(): int
     {
-        return $this->corporation_id;
+        return $this->corporationId;
     }
 
     #[\Override]
@@ -60,6 +60,6 @@ final class CorporationWalletTransactionByDivisionJob extends WalletTransactionB
     #[\Override]
     public function tags(): array
     {
-        return ['corporation', "corporation_id:{$this->corporation_id}", 'wallet', 'transaction', "division:{$this->division}"];
+        return ['corporation', "corporation_id:{$this->corporationId}", 'wallet', 'transaction', "division:{$this->division}"];
     }
 }

--- a/src/Jobs/Wallet/WalletTransactionBase.php
+++ b/src/Jobs/Wallet/WalletTransactionBase.php
@@ -13,7 +13,7 @@ use Seatplus\Eveapi\Models\Wallet\WalletTransaction;
 
 abstract class WalletTransactionBase extends EsiJob
 {
-    protected int $from_id = PHP_INT_MAX;
+    protected int $fromId = PHP_INT_MAX;
 
     protected array $transactions = [];
 
@@ -33,11 +33,11 @@ abstract class WalletTransactionBase extends EsiJob
     {
         $latest = WalletTransaction::where('wallet_transactionable_id', $this->transactionableId())->latest()->first();
         if ($latest) {
-            $this->from_id = $latest->transaction_id - 1;
+            $this->fromId = $latest->transaction_id - 1;
         }
 
         while (true) {
-            $fromId = $this->from_id === PHP_INT_MAX ? null : $this->from_id;
+            $fromId = $this->fromId === PHP_INT_MAX ? null : $this->fromId;
             $response = $this->fetchTransactions($esi, $fromId);
 
             if ($response->isCachedLoad) {
@@ -67,10 +67,10 @@ abstract class WalletTransactionBase extends EsiJob
             }
 
             $lastTransactionId = end($transactions)['transaction_id'] - 1;
-            if ($lastTransactionId === $this->from_id) {
+            if ($lastTransactionId === $this->fromId) {
                 break;
             }
-            $this->from_id = $lastTransactionId;
+            $this->fromId = $lastTransactionId;
             $this->transactions = array_merge($this->transactions, $transactions);
         }
 

--- a/src/Listeners/DispatchGetConstellationById.php
+++ b/src/Listeners/DispatchGetConstellationById.php
@@ -33,12 +33,12 @@ use Seatplus\Eveapi\Jobs\Universe\ResolveUniverseConstellationByConstellationIdJ
 
 class DispatchGetConstellationById
 {
-    public function handle(UniverseSystemCreated $universe_system_created): void
+    public function handle(UniverseSystemCreated $universeSystemCreated): void
     {
-        if ($universe_system_created->system->constellation) {
+        if ($universeSystemCreated->system->constellation) {
             return;
         }
 
-        ResolveUniverseConstellationByConstellationIdJob::dispatch($universe_system_created->system->constellation_id)->onQueue('default');
+        ResolveUniverseConstellationByConstellationIdJob::dispatch($universeSystemCreated->system->constellation_id)->onQueue('default');
     }
 }

--- a/src/Listeners/DispatchGetRegionById.php
+++ b/src/Listeners/DispatchGetRegionById.php
@@ -33,12 +33,12 @@ use Seatplus\Eveapi\Jobs\Universe\ResolveUniverseRegionByRegionIdJob;
 
 class DispatchGetRegionById
 {
-    public function handle(UniverseConstellationCreated $universe_constellation_created): void
+    public function handle(UniverseConstellationCreated $universeConstellationCreated): void
     {
-        if ($universe_constellation_created->constellation->region) {
+        if ($universeConstellationCreated->constellation->region) {
             return;
         }
 
-        ResolveUniverseRegionByRegionIdJob::dispatch($universe_constellation_created->constellation->region_id)->onQueue('default');
+        ResolveUniverseRegionByRegionIdJob::dispatch($universeConstellationCreated->constellation->region_id)->onQueue('default');
     }
 }

--- a/src/Listeners/DispatchGetSystemJobSubscriber.php
+++ b/src/Listeners/DispatchGetSystemJobSubscriber.php
@@ -36,18 +36,18 @@ use Seatplus\Eveapi\Models\Universe\System;
 
 class DispatchGetSystemJobSubscriber
 {
-    private int $system_id;
+    private int $systemId;
 
     public function handleUniverseStationCreated(UniverseStationCreated $event): void
     {
-        $this->system_id = $event->station->system_id;
+        $this->systemId = $event->station->system_id;
 
         $this->handleSystemId();
     }
 
     public function handleUniverseStructureCreated(UniverseStructureCreated $event): void
     {
-        $this->system_id = $event->structure->solar_system_id;
+        $this->systemId = $event->structure->solar_system_id;
 
         $this->handleSystemId();
     }
@@ -67,11 +67,11 @@ class DispatchGetSystemJobSubscriber
 
     private function handleSystemId(): void
     {
-        if (System::find($this->system_id)) {
+        if (System::find($this->systemId)) {
             return;
         }
 
-        $job = new ResolveUniverseSystemBySystemIdJob($this->system_id);
+        $job = new ResolveUniverseSystemBySystemIdJob($this->systemId);
 
         dispatch($job)->onQueue('default');
     }

--- a/src/Listeners/ReactOnFreshRefreshToken.php
+++ b/src/Listeners/ReactOnFreshRefreshToken.php
@@ -33,10 +33,10 @@ use Seatplus\Eveapi\Jobs\Seatplus\UpdateCharacter;
 
 class ReactOnFreshRefreshToken
 {
-    public function handle(RefreshTokenCreated $refresh_token_event): void
+    public function handle(RefreshTokenCreated $refreshTokenEvent): void
     {
-        $refresh_token = $refresh_token_event->refresh_token;
+        $refreshToken = $refreshTokenEvent->refreshToken;
 
-        UpdateCharacter::dispatch($refresh_token)->onQueue('high');
+        UpdateCharacter::dispatch($refreshToken)->onQueue('high');
     }
 }

--- a/src/Listeners/UpdatingRefreshTokenListener.php
+++ b/src/Listeners/UpdatingRefreshTokenListener.php
@@ -35,30 +35,30 @@ use Seatplus\Eveapi\Jobs\Seatplus\UpdateCorporation;
 
 class UpdatingRefreshTokenListener
 {
-    public function handle(UpdatingRefreshTokenEvent $refresh_token_event): void
+    public function handle(UpdatingRefreshTokenEvent $refreshTokenEvent): void
     {
-        $refresh_token = $refresh_token_event->refresh_token;
-        $original_scopes = $refresh_token->getOriginal('scopes');
-        $new_scopes = $this->getScopes($refresh_token->token);
+        $refreshToken = $refreshTokenEvent->refreshToken;
+        $originalScopes = $refreshToken->getOriginal('scopes');
+        $newScopes = $this->getScopes($refreshToken->token);
 
-        if (array_diff($new_scopes, $original_scopes)) {
-            UpdateCharacter::dispatch($refresh_token)->onQueue('high');
+        if (array_diff($newScopes, $originalScopes)) {
+            UpdateCharacter::dispatch($refreshToken)->onQueue('high');
 
-            $corporation_id = data_get($refresh_token, 'character.corporation.corporation_id');
+            $corporationId = data_get($refreshToken, 'character.corporation.corporation_id');
 
-            if ($corporation_id) {
-                UpdateCorporation::dispatch($corporation_id)->onQueue('high');
+            if ($corporationId) {
+                UpdateCorporation::dispatch($corporationId)->onQueue('high');
             }
         }
     }
 
     private function getScopes(string $jwt): array
     {
-        $jwt_payload_base64_encoded = explode('.', $jwt)[1];
+        $jwtPayloadBase64Encoded = explode('.', $jwt)[1];
 
-        $jwt_payload = JWT::urlsafeB64Decode($jwt_payload_base64_encoded);
+        $jwtPayload = JWT::urlsafeB64Decode($jwtPayloadBase64Encoded);
 
-        $scopes = data_get(json_decode($jwt_payload), 'scp', []);
+        $scopes = data_get(json_decode($jwtPayload), 'scp', []);
 
         return is_array($scopes) ? $scopes : [$scopes];
     }

--- a/src/Models/Application.php
+++ b/src/Models/Application.php
@@ -76,7 +76,7 @@ class Application extends Model
         return $this->morphTo();
     }
 
-    public function log_entries(): HasMany
+    public function logEntries(): HasMany
     {
         return $this->hasMany(ApplicationLogs::class);
     }
@@ -84,19 +84,19 @@ class Application extends Model
     /** @return Attribute<int, never> */
     protected function decisionCount(): Attribute
     {
-        return Attribute::make(get: fn () => $this->log_entries()->where('type', 'decision')->count());
+        return Attribute::make(get: fn () => $this->logEntries()->where('type', 'decision')->count());
     }
 
     #[Scope]
     protected function ofCorporation(Builder $query, int|array $corporation): Builder
     {
-        $corporation_ids = is_int($corporation) ? [$corporation] : $corporation;
+        $corporationIds = is_int($corporation) ? [$corporation] : $corporation;
 
-        return $query->whereIn('corporation_id', $corporation_ids)
+        return $query->whereIn('corporation_id', $corporationIds)
             ->with([
-                'applicationable' => fn (MorphTo $morph_to) => $morph_to->morphWith([
-                    User::class => ['characters.refresh_token', 'mainCharacter', 'characters.application.corporation.ssoScopes', 'characters.application.corporation.alliance.ssoScopes'], // @phpstan-ignore-line
-                    CharacterInfo::class => ['refresh_token', 'application.corporation.ssoScopes', 'application.corporation.alliance.ssoScopes'],
+                'applicationable' => fn (MorphTo $morphTo) => $morphTo->morphWith([
+                    User::class => ['characters.refreshToken', 'mainCharacter', 'characters.application.corporation.ssoScopes', 'characters.application.corporation.alliance.ssoScopes'], // @phpstan-ignore-line
+                    CharacterInfo::class => ['refreshToken', 'application.corporation.ssoScopes', 'application.corporation.alliance.ssoScopes'],
                 ]),
             ]);
     }

--- a/src/Models/Assets/Asset.php
+++ b/src/Models/Assets/Asset.php
@@ -50,7 +50,7 @@ class Asset extends Model implements TypeWatchListInterface
 
     const int ASSET_SAFETY = 2004;
 
-    protected array $affiliated_ids = [];
+    protected array $affiliatedIds = [];
 
     /**
      * @var string
@@ -101,27 +101,27 @@ class Asset extends Model implements TypeWatchListInterface
     #[Scope]
     public function filterByTypeIds(Builder $query, int|array $types): Builder
     {
-        $type_ids = is_array($types) ? $types : [$types];
+        $typeIds = is_array($types) ? $types : [$types];
 
-        return $query->whereIn('type_id', $type_ids);
+        return $query->whereIn('type_id', $typeIds);
     }
 
     #[\Override]
     #[Scope]
     public function filterByGroupIds(Builder $query, int|array $groups): Builder
     {
-        $group_ids = is_array($groups) ? $groups : [$groups];
+        $groupIds = is_array($groups) ? $groups : [$groups];
 
-        return $query->whereIn('group_id', $group_ids);
+        return $query->whereIn('group_id', $groupIds);
     }
 
     #[\Override]
     #[Scope]
     public function filterByCategoryIds(Builder $query, int|array $categories): Builder
     {
-        $category_ids = is_array($categories) ? $categories : [$categories];
+        $categoryIds = is_array($categories) ? $categories : [$categories];
 
-        return $query->whereIn('category_id', $category_ids);
+        return $query->whereIn('category_id', $categoryIds);
     }
 
     #[\Override]

--- a/src/Models/BatchStatistic.php
+++ b/src/Models/BatchStatistic.php
@@ -27,10 +27,10 @@ class BatchStatistic extends Model
     protected function duration(): Attribute
     {
         return Attribute::make(get: function () {
-            /** @var Carbon $finished_at */
-            $finished_at = $this->finished_at;
+            /** @var Carbon $finishedAt */
+            $finishedAt = $this->finished_at;
 
-            return (int) $this->started_at->diffInSeconds($finished_at);
+            return (int) $this->started_at->diffInSeconds($finishedAt);
         });
     }
 
@@ -47,13 +47,13 @@ class BatchStatistic extends Model
         $env = config('app.env');
 
         // get horizon config
-        $horizon_config = config("horizon.environments.{$env}.seatplus-workers");
+        $horizonConfig = config("horizon.environments.{$env}.seatplus-workers");
 
         // convert array to string
-        $queue_balancing_configuration = json_encode($horizon_config);
+        $queueBalancingConfiguration = json_encode($horizonConfig);
 
         // add to attributes
-        $attributes['queue_balancing_configuration'] = $queue_balancing_configuration;
+        $attributes['queue_balancing_configuration'] = $queueBalancingConfiguration;
 
         return self::create($attributes);
     }

--- a/src/Models/Character/CharacterInfo.php
+++ b/src/Models/Character/CharacterInfo.php
@@ -69,7 +69,7 @@ class CharacterInfo extends Model
     protected $primaryKey = 'character_id';
 
     /** @return HasOne<RefreshToken, $this> */
-    public function refresh_token(): HasOne
+    public function refreshToken(): HasOne
     {
         return $this->hasOne(RefreshToken::class, 'character_id', 'character_id');
     }
@@ -105,7 +105,7 @@ class CharacterInfo extends Model
     }
 
     /** @return HasOne<CharacterAffiliation, $this> */
-    public function character_affiliation(): HasOne
+    public function characterAffiliation(): HasOne
     {
         return $this->hasOne(CharacterAffiliation::class, 'character_id', 'character_id');
     }
@@ -118,13 +118,13 @@ class CharacterInfo extends Model
     /** @return Attribute<int|null, never> */
     protected function corporationId(): Attribute
     {
-        return Attribute::make(get: fn () => $this->character_affiliation?->corporation_id);
+        return Attribute::make(get: fn () => $this->characterAffiliation?->corporation_id);
     }
 
     /** @return Attribute<int|null, never> */
     protected function allianceId(): Attribute
     {
-        return Attribute::make(get: fn () => $this->character_affiliation?->alliance_id);
+        return Attribute::make(get: fn () => $this->characterAffiliation?->alliance_id);
     }
 
     public function assets(): MorphMany
@@ -142,12 +142,12 @@ class CharacterInfo extends Model
         return $this->morphMany(Label::class, 'labelable');
     }
 
-    public function wallet_journals(): MorphMany
+    public function walletJournals(): MorphMany
     {
         return $this->morphMany(WalletJournal::class, 'wallet_journable');
     }
 
-    public function wallet_transactions(): MorphMany
+    public function walletTransactions(): MorphMany
     {
         return $this->morphMany(WalletTransaction::class, 'wallet_transactionable');
     }
@@ -163,7 +163,7 @@ class CharacterInfo extends Model
         );
     }
 
-    public function corporation_history(): HasMany
+    public function corporationHistory(): HasMany
     {
         return $this->hasMany(CorporationHistory::class, 'character_id');
     }
@@ -173,7 +173,7 @@ class CharacterInfo extends Model
         return $this->hasMany(Skill::class, 'character_id');
     }
 
-    public function skill_queues(): HasMany
+    public function skillQueues(): HasMany
     {
         return $this->hasMany(SkillQueue::class, 'character_id');
     }
@@ -195,7 +195,7 @@ class CharacterInfo extends Model
         return $this->morphOne(Balance::class, 'balanceable');
     }
 
-    public function batch_update(): MorphOne
+    public function batchUpdate(): MorphOne
     {
         return $this->morphOne(BatchUpdate::class, 'batchable');
     }

--- a/src/Models/Character/CharacterRole.php
+++ b/src/Models/Character/CharacterRole.php
@@ -43,7 +43,7 @@ class CharacterRole extends Model
      */
     protected $primaryKey = 'character_id';
 
-    protected array $roles_array = [
+    protected array $rolesArray = [
         'Account_Take_1', 'Account_Take_2', 'Account_Take_3', 'Account_Take_4', 'Account_Take_5', 'Account_Take_6',
         'Account_Take_7', 'Accountant', 'Auditor', 'Communications_Officer', 'Config_Equipment', 'Config_Starbase_Equipment',
         'Container_Take_1', 'Container_Take_2', 'Container_Take_3', 'Container_Take_4', 'Container_Take_5', 'Container_Take_6',
@@ -61,7 +61,7 @@ class CharacterRole extends Model
 
     public function hasRole(string $scope, string $role): bool
     {
-        if (! in_array($role, $this->roles_array) || is_null($this->$scope)) {
+        if (! in_array($role, $this->rolesArray) || is_null($this->$scope)) {
             return false;
         }
 

--- a/src/Models/Contacts/Contact.php
+++ b/src/Models/Contacts/Contact.php
@@ -55,9 +55,9 @@ class Contact extends Model
     }
 
     #[Scope]
-    protected function entityFilter(Builder $query, array $contactable_ids): Builder
+    protected function entityFilter(Builder $query, array $contactableIds): Builder
     {
-        return $query->whereIn('contactable_id', $contactable_ids);
+        return $query->whereIn('contactable_id', $contactableIds);
     }
 
     /** @return Attribute<?CharacterAffiliation, never> */
@@ -65,17 +65,17 @@ class Contact extends Model
     {
         return Attribute::make(get: function () {
             $this->loadMissing([
-                'character_affiliation',
-                'corporation_affiliation',
-                'alliance_affiliation',
-                'faction_affiliation',
+                'characterAffiliation',
+                'corporationAffiliation',
+                'allianceAffiliation',
+                'factionAffiliation',
             ]);
 
             return collect([
-                $this->character_affiliation,
-                $this->corporation_affiliation,
-                $this->alliance_affiliation,
-                $this->faction_affiliation,
+                $this->characterAffiliation,
+                $this->corporationAffiliation,
+                $this->allianceAffiliation,
+                $this->factionAffiliation,
             ])
                 ->filter()
                 ->first();
@@ -83,25 +83,25 @@ class Contact extends Model
     }
 
     /** @return HasOne<CharacterAffiliation, $this> */
-    public function character_affiliation(): HasOne
+    public function characterAffiliation(): HasOne
     {
         return $this->hasOne(CharacterAffiliation::class, 'character_id', 'contact_id');
     }
 
     /** @return HasOne<CharacterAffiliation, $this> */
-    public function corporation_affiliation(): HasOne
+    public function corporationAffiliation(): HasOne
     {
         return $this->hasOne(CharacterAffiliation::class, 'corporation_id', 'contact_id');
     }
 
     /** @return HasOne<CharacterAffiliation, $this> */
-    public function alliance_affiliation(): HasOne
+    public function allianceAffiliation(): HasOne
     {
         return $this->hasOne(CharacterAffiliation::class, 'alliance_id', 'contact_id');
     }
 
     /** @return HasOne<CharacterAffiliation, $this> */
-    public function faction_affiliation(): HasOne
+    public function factionAffiliation(): HasOne
     {
         return $this->hasOne(CharacterAffiliation::class, 'faction_id', 'contact_id');
     }

--- a/src/Models/Contracts/Contract.php
+++ b/src/Models/Contracts/Contract.php
@@ -61,7 +61,7 @@ class Contract extends Model implements LocationWatchListInterface, TypeWatchLis
      */
     public function issuer(): Attribute
     {
-        return new Attribute(fn () => $this->for_corporation ? $this->issuer_corporation : $this->issuer_character);
+        return new Attribute(fn () => $this->for_corporation ? $this->issuerCorporation : $this->issuerCharacter);
     }
 
     /**
@@ -69,7 +69,7 @@ class Contract extends Model implements LocationWatchListInterface, TypeWatchLis
      */
     public function assignee(): Attribute
     {
-        return new Attribute(get: fn () => $this->assignee_character ?? $this->assignee_corporation);
+        return new Attribute(get: fn () => $this->assigneeCharacter ?? $this->assigneeCorporation);
     }
 
     public function items(): HasMany
@@ -77,34 +77,34 @@ class Contract extends Model implements LocationWatchListInterface, TypeWatchLis
         return $this->hasMany(ContractItem::class, 'contract_id', 'contract_id');
     }
 
-    public function start_location(): HasOne
+    public function startLocation(): HasOne
     {
         return $this->hasOne(Location::class, 'location_id', 'start_location_id');
     }
 
-    public function end_location(): HasOne
+    public function endLocation(): HasOne
     {
         return $this->hasOne(Location::class, 'location_id', 'end_location_id');
     }
 
     /** @return BelongsTo<CharacterInfo, $this> */
-    public function assignee_character(): BelongsTo
+    public function assigneeCharacter(): BelongsTo
     {
         return $this->belongsTo(CharacterInfo::class, 'assignee_id', 'character_id');
     }
 
-    public function assignee_corporation(): BelongsTo
+    public function assigneeCorporation(): BelongsTo
     {
         return $this->belongsTo(CorporationInfo::class, 'assignee_id', 'corporation_id');
     }
 
     /** @return BelongsTo<CharacterInfo, $this> */
-    public function issuer_character(): BelongsTo
+    public function issuerCharacter(): BelongsTo
     {
         return $this->belongsTo(CharacterInfo::class, 'issuer_id', 'character_id');
     }
 
-    public function issuer_corporation(): BelongsTo
+    public function issuerCorporation(): BelongsTo
     {
         return $this->belongsTo(CorporationInfo::class, 'issuer_corporation_id', 'corporation_id');
     }
@@ -118,48 +118,48 @@ class Contract extends Model implements LocationWatchListInterface, TypeWatchLis
     #[Scope]
     public function filterByRegionIds(Builder $query, int|array $regions): Builder
     {
-        $region_ids = is_array($regions) ? $regions : [$regions];
+        $regionIds = is_array($regions) ? $regions : [$regions];
 
         return $query // TODO merge tables like assets for improved db performance
-            ->whereHas('start_location.locatable.system.region', fn (Builder $query) => $query->whereIn('universe_regions.region_id', $region_ids))
-            ->orWhereHas('end_location.locatable.system.region', fn (Builder $query) => $query->whereIn('universe_regions.region_id', $region_ids));
+            ->whereHas('startLocation.locatable.system.region', fn (Builder $query) => $query->whereIn('universe_regions.region_id', $regionIds))
+            ->orWhereHas('endLocation.locatable.system.region', fn (Builder $query) => $query->whereIn('universe_regions.region_id', $regionIds));
     }
 
     #[\Override]
     #[Scope]
     public function filterBySystemIds(Builder $query, int|array $systems): Builder
     {
-        $system_ids = is_array($systems) ? $systems : [$systems];
+        $systemIds = is_array($systems) ? $systems : [$systems];
 
         return $query
-            ->whereHas('start_location.locatable.system', fn (Builder $query) => $query->whereIn('system_id', $system_ids))
-            ->orWhereHas('end_location.locatable.system', fn (Builder $query) => $query->whereIn('system_id', $system_ids));
+            ->whereHas('startLocation.locatable.system', fn (Builder $query) => $query->whereIn('system_id', $systemIds))
+            ->orWhereHas('endLocation.locatable.system', fn (Builder $query) => $query->whereIn('system_id', $systemIds));
     }
 
     #[\Override]
     #[Scope]
     public function filterByTypeIds(Builder $query, int|array $types): Builder
     {
-        $type_ids = is_array($types) ? $types : [$types];
+        $typeIds = is_array($types) ? $types : [$types];
 
-        return $query->whereHas('items', fn (Builder $query) => $query->whereIn('type_id', $type_ids));
+        return $query->whereHas('items', fn (Builder $query) => $query->whereIn('type_id', $typeIds));
     }
 
     #[\Override]
     #[Scope]
     public function filterByGroupIds(Builder $query, int|array $groups): Builder
     {
-        $group_ids = is_array($groups) ? $groups : [$groups];
+        $groupIds = is_array($groups) ? $groups : [$groups];
 
-        return $query->whereHas('items.type', fn (Builder $query) => $query->whereIn('group_id', $group_ids));
+        return $query->whereHas('items.type', fn (Builder $query) => $query->whereIn('group_id', $groupIds));
     }
 
     #[\Override]
     #[Scope]
     public function filterByCategoryIds(Builder $query, int|array $category): Builder
     {
-        $category_ids = is_array($category) ? $category : [$category];
+        $categoryIds = is_array($category) ? $category : [$category];
 
-        return $query->whereHas('items.type.group', fn (Builder $query) => $query->whereIn('category_id', $category_ids));
+        return $query->whereHas('items.type.group', fn (Builder $query) => $query->whereIn('category_id', $categoryIds));
     }
 }

--- a/src/Models/Corporation/CorporationInfo.php
+++ b/src/Models/Corporation/CorporationInfo.php
@@ -104,12 +104,12 @@ class CorporationInfo extends Model
         return $this->morphMany(Balance::class, 'balanceable');
     }
 
-    public function wallet_journals(): MorphMany
+    public function walletJournals(): MorphMany
     {
         return $this->morphMany(WalletJournal::class, 'wallet_journable');
     }
 
-    public function wallet_transactions(): MorphMany
+    public function walletTransactions(): MorphMany
     {
         return $this->morphMany(WalletTransaction::class, 'wallet_transactionable');
     }

--- a/src/Models/LocationRefreshToken.php
+++ b/src/Models/LocationRefreshToken.php
@@ -20,7 +20,7 @@ class LocationRefreshToken extends Model
     }
 
     /** @return BelongsTo<RefreshToken, $this> */
-    public function refresh_token(): BelongsTo
+    public function refreshToken(): BelongsTo
     {
         return $this->belongsTo(RefreshToken::class, 'character_id', 'character_id');
     }

--- a/src/Models/RefreshToken.php
+++ b/src/Models/RefreshToken.php
@@ -106,9 +106,9 @@ class RefreshToken extends Model
     {
         return Attribute::make(get: function () {
             $jwt = $this->getRawOriginal('token');
-            $jwt_payload_base64_encoded = explode('.', (string) $jwt)[1];
-            $jwt_payload = JWT::urlsafeB64Decode($jwt_payload_base64_encoded);
-            $scopes = data_get(json_decode($jwt_payload), 'scp', []);
+            $jwtPayloadBase64Encoded = explode('.', (string) $jwt)[1];
+            $jwtPayload = JWT::urlsafeB64Decode($jwtPayloadBase64Encoded);
+            $scopes = data_get(json_decode($jwtPayload), 'scp', []);
 
             return is_array($scopes) ? $scopes : [$scopes];
         });

--- a/src/Models/Universe/Location.php
+++ b/src/Models/Universe/Location.php
@@ -71,10 +71,10 @@ class Location extends Model implements LocationWatchListInterface
     #[Scope]
     public function filterByRegionIds(Builder $query, int|array $regions): Builder
     {
-        $region_ids = is_array($regions) ? $regions : [$regions];
+        $regionIds = is_array($regions) ? $regions : [$regions];
 
-        return $query->whereHas('locatable.system.constellation', function (Builder $query) use ($region_ids) {
-            $query->whereIn('region_id', $region_ids);
+        return $query->whereHas('locatable.system.constellation', function (Builder $query) use ($regionIds) {
+            $query->whereIn('region_id', $regionIds);
         });
     }
 
@@ -82,10 +82,10 @@ class Location extends Model implements LocationWatchListInterface
     #[Scope]
     public function filterBySystemIds(Builder $query, int|array $systems): Builder
     {
-        $system_ids = is_array($systems) ? $systems : [$systems];
+        $systemIds = is_array($systems) ? $systems : [$systems];
 
-        return $query->whereHas('locatable.system', function (Builder $query) use ($system_ids) {
-            $query->whereIn('system_id', $system_ids);
+        return $query->whereHas('locatable.system', function (Builder $query) use ($systemIds) {
+            $query->whereIn('system_id', $systemIds);
         });
     }
 }

--- a/src/Models/Wallet/WalletJournal.php
+++ b/src/Models/Wallet/WalletJournal.php
@@ -38,9 +38,9 @@ class WalletJournal extends Model
 {
     use HasFactory;
 
-    public function wallet_journable(): MorphTo
+    public function walletJournable(): MorphTo
     {
-        return $this->morphTo();
+        return $this->morphTo('wallet_journable');
     }
 
     /**

--- a/src/Models/Wallet/WalletTransaction.php
+++ b/src/Models/Wallet/WalletTransaction.php
@@ -43,9 +43,9 @@ class WalletTransaction extends Model
 
     protected $primaryKey = 'transaction_id';
 
-    public function wallet_transactionable(): MorphTo
+    public function walletTransactionable(): MorphTo
     {
-        return $this->morphTo();
+        return $this->morphTo('wallet_transactionable');
     }
 
     public function type(): HasOne

--- a/src/Observers/CharacterInfoObserver.php
+++ b/src/Observers/CharacterInfoObserver.php
@@ -41,9 +41,9 @@ class CharacterInfoObserver
      *
      * @throws InvalidContainerDataException
      */
-    public function created(CharacterInfo $character_info): void
+    public function created(CharacterInfo $characterInfo): void
     {
-        CharacterAffiliationJob::dispatch($character_info->character_id)->onQueue('high');
+        CharacterAffiliationJob::dispatch($characterInfo->character_id)->onQueue('high');
     }
 
     /**
@@ -53,8 +53,8 @@ class CharacterInfoObserver
      *
      * @throws InvalidContainerDataException
      */
-    public function updating(CharacterInfo $character_info): void
+    public function updating(CharacterInfo $characterInfo): void
     {
-        CharacterAffiliationJob::dispatch($character_info->character_id)->onQueue('high');
+        CharacterAffiliationJob::dispatch($characterInfo->character_id)->onQueue('high');
     }
 }

--- a/src/Services/Character/RefreshCharacterAffiliationsService.php
+++ b/src/Services/Character/RefreshCharacterAffiliationsService.php
@@ -14,27 +14,27 @@ class RefreshCharacterAffiliationsService
     public function __invoke(): void
     {
 
-        $character_ids = [
+        $characterIds = [
             ...$this->getIdsToUpdateFromDatabase(),
             ...$this->getIdsToUpdateFromCache(),
             ...$this->getMissingIdsFromCharacterInfo(),
         ];
 
-        $this->processAffiliations($character_ids);
+        $this->processAffiliations($characterIds);
     }
 
     private function getMissingIdsFromCharacterInfo(): array
     {
         return CharacterInfo::query()
-            ->whereDoesntHave('character_affiliation')
+            ->whereDoesntHave('characterAffiliation')
             ->pluck('character_id')
             ->toArray();
     }
 
     private function processAffiliations(array $ids): void
     {
-        $unique_ids = array_unique($ids);
-        $chunks = array_chunk($unique_ids, 1000);
+        $uniqueIds = array_unique($ids);
+        $chunks = array_chunk($uniqueIds, 1000);
 
         foreach ($chunks as $chunk) {
             CharacterAffiliationJob::dispatch($chunk)->onQueue('high');

--- a/src/Services/Contacts/ProcessContactLabelsResponse.php
+++ b/src/Services/Contacts/ProcessContactLabelsResponse.php
@@ -35,29 +35,29 @@ use Seatplus\Eveapi\Models\Contacts\Label;
 class ProcessContactLabelsResponse
 {
     public function __construct(
-        private readonly int $labelable_id,
-        private readonly string $labelable_type
+        private readonly int $labelableId,
+        private readonly string $labelableType
     ) {}
 
     public function execute(EsiResult $response): Collection
     {
         return collect($response->data)
-            ->each(fn (object $contact_label) => Label::updateOrCreate([
-                'label_id' => $contact_label->label_id,
-                'labelable_id' => $this->labelable_id,
-                'labelable_type' => $this->labelable_type,
+            ->each(fn (object $contactLabel) => Label::updateOrCreate([
+                'label_id' => $contactLabel->label_id,
+                'labelable_id' => $this->labelableId,
+                'labelable_type' => $this->labelableType,
             ], [
-                'label_name' => $contact_label->label_name,
+                'label_name' => $contactLabel->label_name,
             ]))->pluck('label_id');
     }
 
-    public function remove_old_entries(array $known_ids): void
+    public function remove_old_entries(array $knownIds): void
     {
         // Cleanup
         Label::query()
-            ->where('labelable_id', $this->labelable_id)
-            ->where('labelable_type', $this->labelable_type)
-            ->whereNotIn('label_id', $known_ids)
+            ->where('labelable_id', $this->labelableId)
+            ->where('labelable_type', $this->labelableType)
+            ->whereNotIn('label_id', $knownIds)
             ->delete();
     }
 }

--- a/src/Services/Contacts/ProcessContactResponse.php
+++ b/src/Services/Contacts/ProcessContactResponse.php
@@ -35,16 +35,16 @@ use Seatplus\Eveapi\Services\Jobs\CacheCharacterAffiliationIdsService;
 
 class ProcessContactResponse
 {
-    public function __construct(private readonly int $contactable_id, private readonly string $contactable_type) {}
+    public function __construct(private readonly int $contactableId, private readonly string $contactableType) {}
 
     public function execute(EsiResult $response): Collection
     {
         return collect($response->data)
             ->each(function (object $contact) {
-                $contact_model = Contact::updateOrCreate([
+                $contactModel = Contact::updateOrCreate([
                     'contact_id' => $contact->contact_id,
-                    'contactable_id' => $this->contactable_id,
-                    'contactable_type' => $this->contactable_type,
+                    'contactable_id' => $this->contactableId,
+                    'contactable_type' => $this->contactableType,
                 ], [
                     'contact_type' => $contact->contact_type,
                     'standing' => $contact->standing,
@@ -52,14 +52,14 @@ class ProcessContactResponse
                     'is_watched' => $contact->is_watched ?? null,
                 ]);
 
-                $contact_model->labels()->whereNotIn('label_id', $contact->label_ids ?? [])->delete();
+                $contactModel->labels()->whereNotIn('label_id', $contact->label_ids ?? [])->delete();
 
                 if (isset($contact->label_ids)) {
-                    $already_existing_label_ids = $contact_model->labels()->pluck('label_id');
+                    $alreadyExistingLabelIds = $contactModel->labels()->pluck('label_id');
 
-                    $labels_to_save = collect($contact->label_ids)->diff($already_existing_label_ids);
+                    $labelsToSave = collect($contact->label_ids)->diff($alreadyExistingLabelIds);
 
-                    $contact_model->labels()->createMany($labels_to_save->map(fn (int $label_id) => ['label_id' => $label_id]));
+                    $contactModel->labels()->createMany($labelsToSave->map(fn (int $labelId) => ['label_id' => $labelId]));
                 }
             })->pipe(function (Collection $response) {
                 CacheCharacterAffiliationIdsService::make()
@@ -69,12 +69,12 @@ class ProcessContactResponse
             })->pluck('contact_id');
     }
 
-    public function remove_old_entries(array $known_ids): void
+    public function remove_old_entries(array $knownIds): void
     {
         // Cleanup
-        Contact::where('contactable_id', $this->contactable_id)
-            ->where('contactable_type', $this->contactable_type)
-            ->whereNotIn('contact_id', $known_ids)
+        Contact::where('contactable_id', $this->contactableId)
+            ->where('contactable_type', $this->contactableType)
+            ->whereNotIn('contact_id', $knownIds)
             ->delete();
     }
 }

--- a/src/Services/DispatchIndividualUpdate.php
+++ b/src/Services/DispatchIndividualUpdate.php
@@ -36,21 +36,21 @@ class DispatchIndividualUpdate
     use DispatchesJobs;
 
     public function __construct(
-        private RefreshToken $refresh_token
+        private RefreshToken $refreshToken
     ) {}
 
-    public function execute(string $job_name): mixed
+    public function execute(string $jobName): mixed
     {
-        $job_class = config('eveapi.jobs')[$job_name];
+        $jobClass = config('eveapi.jobs')[$jobName];
 
-        $id = $this->refresh_token->character_id;
+        $id = $this->refreshToken->character_id;
 
         // check if job_name starts with corporation
-        if (str_starts_with($job_name, 'corporation')) {
-            $id = $this->refresh_token->character->corporation_id;
+        if (str_starts_with($jobName, 'corporation')) {
+            $id = $this->refreshToken->character->corporation_id;
         }
 
-        $job = (new $job_class($id))->onQueue('high');
+        $job = (new $jobClass($id))->onQueue('high');
 
         return $this->dispatch($job);
     }

--- a/src/Services/Esi/GetUpToDateRefreshTokenService.php
+++ b/src/Services/Esi/GetUpToDateRefreshTokenService.php
@@ -18,13 +18,13 @@ class GetUpToDateRefreshTokenService
     /**
      * @throws InvalidRefreshTokenException
      */
-    public function get(RefreshToken $refresh_token): RefreshToken
+    public function get(RefreshToken $refreshToken): RefreshToken
     {
-        $character_id = $refresh_token->character_id;
+        $characterId = $refreshToken->character_id;
 
-        return Cache::lock("get up to date refresh_token of character_id: {$character_id}", 10)
-            ->block(30, function () use ($refresh_token) {
-                $token = $refresh_token->refresh();
+        return Cache::lock("get up to date refresh_token of character_id: {$characterId}", 10)
+            ->block(30, function () use ($refreshToken) {
+                $token = $refreshToken->refresh();
 
                 if (carbon($token->expires_on)->gt(now()->addMinute())) {
                     return $token;
@@ -35,7 +35,7 @@ class GetUpToDateRefreshTokenService
                 } catch (RequestFailedException $e) {
                     if ($e->getCode() === 400 || $e->getCode() === 401) {
                         throw new InvalidRefreshTokenException(
-                            "Refresh token for character {$refresh_token->character_id} is invalid: {$e->getMessage()}",
+                            "Refresh token for character {$refreshToken->character_id} is invalid: {$e->getMessage()}",
                             $e->getCode(),
                             $e,
                         );

--- a/src/Services/FindCorporationRefreshToken.php
+++ b/src/Services/FindCorporationRefreshToken.php
@@ -33,13 +33,13 @@ use Seatplus\Eveapi\Models\RefreshToken;
 
 class FindCorporationRefreshToken
 {
-    public function __invoke(int $corporation_id, string|array $scope, string|array $role): ?RefreshToken
+    public function __invoke(int $corporationId, string|array $scope, string|array $role): ?RefreshToken
     {
         $scopes = is_string($scope) ? [$scope] : $scope;
         $roles = is_string($role) ? [$role] : $role;
 
         return RefreshToken::with('corporation', 'character.roles')
-            ->whereHas('corporation', fn (Builder $query) => $query->where('corporation_infos.corporation_id', $corporation_id))
+            ->whereHas('corporation', fn (Builder $query) => $query->where('corporation_infos.corporation_id', $corporationId))
             ->get()
             ->shuffle()
             ->first(fn (RefreshToken $token) => $this->tokenHasScopes($token, $scopes) && $this->tokenHasRoles($token, $roles));

--- a/src/Services/JobChecker.php
+++ b/src/Services/JobChecker.php
@@ -24,13 +24,13 @@ class JobChecker
 
     private function checkMiddleware(EsiJob $job): array
     {
-        $used_middlewares = collect($job->middleware());
+        $usedMiddlewares = collect($job->middleware());
 
-        if (! $used_middlewares->first(fn (object $m) => $m instanceof ThrottlesExceptionsWithRedis)) {
+        if (! $usedMiddlewares->first(fn (object $m) => $m instanceof ThrottlesExceptionsWithRedis)) {
             return $this->assertionResult('error', 'ThrottlesExceptionsWithRedis middleware is not used');
         }
 
-        if (! $used_middlewares->first(fn (object $m) => $m instanceof EsiProactiveRateLimitMiddleware)) {
+        if (! $usedMiddlewares->first(fn (object $m) => $m instanceof EsiProactiveRateLimitMiddleware)) {
             return $this->assertionResult('error', 'EsiProactiveRateLimitMiddleware is not used');
         }
 

--- a/src/Services/Jobs/CacheCharacterAffiliationIdsService.php
+++ b/src/Services/Jobs/CacheCharacterAffiliationIdsService.php
@@ -14,12 +14,12 @@ class CacheCharacterAffiliationIdsService
         return new self;
     }
 
-    final public function queue(int|array $character_ids): void
+    final public function queue(int|array $characterIds): void
     {
-        $character_ids = is_array($character_ids) ? $character_ids : [$character_ids];
+        $characterIds = is_array($characterIds) ? $characterIds : [$characterIds];
 
         Cache::lock('CharacterAffiliationLock')
-            ->get(fn () => Cache::put('CharacterAffiliationIds', $this->getIdsCollection()->merge($character_ids)));
+            ->get(fn () => Cache::put('CharacterAffiliationIds', $this->getIdsCollection()->merge($characterIds)));
     }
 
     final public function retrieve(): Collection

--- a/src/Services/Jobs/GetLocationFlagNameService.php
+++ b/src/Services/Jobs/GetLocationFlagNameService.php
@@ -37,9 +37,9 @@ class GetLocationFlagNameService
         return new self;
     }
 
-    public function get(int $flag_id): string
+    public function get(int $flagId): string
     {
-        $location_flags = [
+        $locationFlags = [
             'highslots' => range(27, 34),
             'midslots' => range(19, 26),
             'lowslots' => range(11, 18),
@@ -59,9 +59,9 @@ class GetLocationFlagNameService
             ],
         ];
 
-        foreach ($location_flags as $location_flag => $ids) {
-            if (in_array($flag_id, $ids)) {
-                return $location_flag;
+        foreach ($locationFlags as $locationFlag => $ids) {
+            if (in_array($flagId, $ids)) {
+                return $locationFlag;
             }
         }
 

--- a/src/Services/ResolveLocation/Finders/FinderInterface.php
+++ b/src/Services/ResolveLocation/Finders/FinderInterface.php
@@ -9,5 +9,5 @@ use Seatplus\Eveapi\Models\RefreshToken;
 
 interface FinderInterface
 {
-    public function handle(int $location_id, Collection $tracings): ?RefreshToken;
+    public function handle(int $locationId, Collection $tracings): ?RefreshToken;
 }

--- a/src/Services/ResolveLocation/Finders/ThroughCharacterAssetsFinder.php
+++ b/src/Services/ResolveLocation/Finders/ThroughCharacterAssetsFinder.php
@@ -12,22 +12,22 @@ use Seatplus\Eveapi\Models\RefreshToken;
 class ThroughCharacterAssetsFinder implements FinderInterface
 {
     #[\Override]
-    public function handle(int $location_id, Collection $tracings): ?RefreshToken
+    public function handle(int $locationId, Collection $tracings): ?RefreshToken
     {
 
-        $character_ids_to_ignore = $tracings->pluck('character_id');
+        $characterIdsToIgnore = $tracings->pluck('character_id');
 
         return Asset::query()
-            ->whereHas('assetable.refresh_token')
-            ->where('location_id', $location_id)
-            ->whereNotIn('assetable_id', $character_ids_to_ignore)
+            ->whereHas('assetable.refreshToken')
+            ->where('location_id', $locationId)
+            ->whereNotIn('assetable_id', $characterIdsToIgnore)
             ->where('assetable_type', CharacterInfo::class)
             ->inRandomOrder()
             ->get()
-            ->map(fn (Asset $asset) => data_get($asset, 'assetable.refresh_token'))
+            ->map(fn (Asset $asset) => data_get($asset, 'assetable.refreshToken'))
             ->unique()
             // filter refresh token that has scope esi-universe.read_structures.v1
-            ->filter(fn (RefreshToken $refresh_token) => $refresh_token->hasScope('esi-universe.read_structures.v1'))
+            ->filter(fn (RefreshToken $refreshToken) => $refreshToken->hasScope('esi-universe.read_structures.v1'))
             ->first();
 
     }

--- a/src/Services/ResolveLocation/Finders/ThroughContractsFinder.php
+++ b/src/Services/ResolveLocation/Finders/ThroughContractsFinder.php
@@ -12,33 +12,33 @@ use Seatplus\Eveapi\Models\RefreshToken;
 class ThroughContractsFinder implements FinderInterface
 {
     #[\Override]
-    public function handle(int $location_id, Collection $tracings): ?RefreshToken
+    public function handle(int $locationId, Collection $tracings): ?RefreshToken
     {
-        $character_ids_to_ignore = $tracings->pluck('character_id');
+        $characterIdsToIgnore = $tracings->pluck('character_id');
 
         return Contract::query()
             ->where(fn (Builder $query) => $query
-                ->where('start_location_id', $location_id)
-                ->orWhere('end_location_id', $location_id)
+                ->where('start_location_id', $locationId)
+                ->orWhere('end_location_id', $locationId)
             )
             ->where(fn (Builder $query) => $query
-                ->whereHas('issuer_character.refresh_token')
-                ->orWhereHas('assignee_character.refresh_token')
+                ->whereHas('issuerCharacter.refreshToken')
+                ->orWhereHas('assigneeCharacter.refreshToken')
             )
             ->where(fn (Builder $query) => $query
-                ->whereNotIn('issuer_id', $character_ids_to_ignore)
-                ->orWhereNotIn('assignee_id', $character_ids_to_ignore)
+                ->whereNotIn('issuer_id', $characterIdsToIgnore)
+                ->orWhereNotIn('assignee_id', $characterIdsToIgnore)
             )
             ->inRandomOrder()
             ->get()
             ->map(fn (Contract $contract) => [
-                $contract->issuer_character?->refresh_token,
-                $contract->assignee_character?->refresh_token,
+                $contract->issuerCharacter?->refreshToken,
+                $contract->assigneeCharacter?->refreshToken,
             ])
             ->flatten()
             ->unique()
             ->filter()
-            ->filter(fn (RefreshToken $refresh_token) => $refresh_token->hasScope('esi-universe.read_structures.v1'))
+            ->filter(fn (RefreshToken $refreshToken) => $refreshToken->hasScope('esi-universe.read_structures.v1'))
             ->first();
     }
 }

--- a/src/Services/ResolveLocation/Finders/ThroughCorporationMemberTrackingFinder.php
+++ b/src/Services/ResolveLocation/Finders/ThroughCorporationMemberTrackingFinder.php
@@ -14,41 +14,41 @@ use Seatplus\Eveapi\Services\FindCorporationRefreshToken;
 class ThroughCorporationMemberTrackingFinder implements FinderInterface
 {
     #[\Override]
-    public function handle(int $location_id, Collection $tracking): ?RefreshToken
+    public function handle(int $locationId, Collection $tracking): ?RefreshToken
     {
 
-        $corporation_member_tracking_query = CorporationMemberTracking::query()
-            ->where('location_id', $location_id);
+        $corporationMemberTrackingQuery = CorporationMemberTracking::query()
+            ->where('location_id', $locationId);
 
-        $refresh_token = app(Pipeline::class)
-            ->send($corporation_member_tracking_query)
+        $refreshToken = app(Pipeline::class)
+            ->send($corporationMemberTrackingQuery)
             ->through([
                 $this->findMemberTokenWithStructureScope($tracking),
                 $this->findDirectorToken(),
             ])
             ->thenReturn();
 
-        return $refresh_token;
+        return $refreshToken;
     }
 
     private function findMemberTokenWithStructureScope(Collection $tracking): \Closure
     {
-        $character_ids_to_ignore = $tracking->pluck('character_id');
+        $characterIdsToIgnore = $tracking->pluck('character_id');
 
-        return function (Builder $query, \Closure $next) use ($character_ids_to_ignore) {
-            $refresh_token = $query
-                ->whereNotIn('character_id', $character_ids_to_ignore)
-                ->whereHas('character.refresh_token')
+        return function (Builder $query, \Closure $next) use ($characterIdsToIgnore) {
+            $refreshToken = $query
+                ->whereNotIn('character_id', $characterIdsToIgnore)
+                ->whereHas('character.refreshToken')
                 ->inRandomOrder()
                 ->get()
-                ->map(fn (CorporationMemberTracking $member_tracking) => $member_tracking->character->refresh_token)
+                ->map(fn (CorporationMemberTracking $memberTracking) => $memberTracking->character->refreshToken)
                 ->unique()
                 // filter refresh token that has scope esi-universe.read_structures.v1
-                ->filter(fn (RefreshToken $refresh_token) => $refresh_token->hasScope('esi-universe.read_structures.v1'))
+                ->filter(fn (RefreshToken $refreshToken) => $refreshToken->hasScope('esi-universe.read_structures.v1'))
                 ->first();
 
-            if (! is_null($refresh_token)) {
-                return $refresh_token;
+            if (! is_null($refreshToken)) {
+                return $refreshToken;
             }
 
             return $next($query);
@@ -58,20 +58,20 @@ class ThroughCorporationMemberTrackingFinder implements FinderInterface
     private function findDirectorToken(): \Closure
     {
         return function (Builder $query) {
-            $refresh_token = $query
+            $refreshToken = $query
                 ->inRandomOrder()
                 ->pluck('corporation_id')
                 ->unique()
-                ->map(function (int $corporation_id) {
+                ->map(function (int $corporationId) {
 
                     $service = new FindCorporationRefreshToken;
 
-                    return $service($corporation_id, 'esi-corporations.track_members.v1', 'Director');
+                    return $service($corporationId, 'esi-corporations.track_members.v1', 'Director');
                 })
                 ->filter()
                 ->first();
 
-            return $refresh_token;
+            return $refreshToken;
         };
     }
 }

--- a/src/Services/ResolveLocation/Finders/ThroughPreviouslyFailedRefreshTokenFinder.php
+++ b/src/Services/ResolveLocation/Finders/ThroughPreviouslyFailedRefreshTokenFinder.php
@@ -11,7 +11,7 @@ use Seatplus\Eveapi\Models\RefreshToken;
 class ThroughPreviouslyFailedRefreshTokenFinder implements FinderInterface
 {
     #[\Override]
-    public function handle(int $location_id, Collection $tracings): ?RefreshToken
+    public function handle(int $locationId, Collection $tracings): ?RefreshToken
     {
 
         $record = $tracings
@@ -20,7 +20,7 @@ class ThroughPreviouslyFailedRefreshTokenFinder implements FinderInterface
 
         // check if record is LocationRefreshToken
         if ($record instanceof LocationRefreshToken) {
-            return $record->refresh_token;
+            return $record->refreshToken;
         }
 
         return null;

--- a/src/Services/ResolveLocation/Finders/ThroughRandomRefreshTokenFinder.php
+++ b/src/Services/ResolveLocation/Finders/ThroughRandomRefreshTokenFinder.php
@@ -10,15 +10,15 @@ use Seatplus\Eveapi\Models\RefreshToken;
 class ThroughRandomRefreshTokenFinder implements FinderInterface
 {
     #[\Override]
-    public function handle(int $location_id, Collection $tracings): ?RefreshToken
+    public function handle(int $locationId, Collection $tracings): ?RefreshToken
     {
 
-        $character_ids_to_ignore = $tracings->pluck('character_id');
+        $characterIdsToIgnore = $tracings->pluck('character_id');
 
         return RefreshToken::query()
-            ->whereNotIn('character_id', $character_ids_to_ignore)
+            ->whereNotIn('character_id', $characterIdsToIgnore)
             ->inRandomOrder()
             ->cursor()
-            ->firstWhere(fn (RefreshToken $refresh_token) => $refresh_token->hasScope('esi-universe.read_structures.v1'));
+            ->firstWhere(fn (RefreshToken $refreshToken) => $refreshToken->hasScope('esi-universe.read_structures.v1'));
     }
 }

--- a/src/Services/ResolveLocation/Finders/ThroughSuccessfulRefreshTokenFinder.php
+++ b/src/Services/ResolveLocation/Finders/ThroughSuccessfulRefreshTokenFinder.php
@@ -11,14 +11,14 @@ use Seatplus\Eveapi\Models\RefreshToken;
 class ThroughSuccessfulRefreshTokenFinder implements FinderInterface
 {
     #[\Override]
-    public function handle(int $location_id, Collection $tracings): ?RefreshToken
+    public function handle(int $locationId, Collection $tracings): ?RefreshToken
     {
         $record = $tracings->first(fn (LocationRefreshToken $tracking) => $tracking->resolved);
 
         // if we have a resolved tracking, we can return the refresh token
         // in order to work with phpstan we need to check if the tracking is of type LocationRefreshTokens
         if ($record instanceof LocationRefreshToken) {
-            return $record->refresh_token;
+            return $record->refreshToken;
         }
 
         return null;

--- a/src/Services/ResolveLocation/Finders/ThroughWalletTransactionsFinder.php
+++ b/src/Services/ResolveLocation/Finders/ThroughWalletTransactionsFinder.php
@@ -15,42 +15,42 @@ use Seatplus\Eveapi\Services\FindCorporationRefreshToken;
 class ThroughWalletTransactionsFinder implements FinderInterface
 {
     #[\Override]
-    public function handle(int $location_id, Collection $tracings): ?RefreshToken
+    public function handle(int $locationId, Collection $tracings): ?RefreshToken
     {
-        $character_ids_to_ignore = $tracings->pluck('character_id');
+        $characterIdsToIgnore = $tracings->pluck('character_id');
 
-        $refresh_token = WalletTransaction::query()
-            ->where('location_id', $location_id)
-            ->whereNotIn('wallet_transactionable_id', $character_ids_to_ignore)
+        $refreshToken = WalletTransaction::query()
+            ->where('location_id', $locationId)
+            ->whereNotIn('wallet_transactionable_id', $characterIdsToIgnore)
             ->whereHasMorph(
-                'wallet_transactionable',
+                'walletTransactionable',
                 CharacterInfo::class,
-                fn (Builder $query) => $query->whereHas('refresh_token')
+                fn (Builder $query) => $query->whereHas('refreshToken')
             )
             ->where('wallet_transactionable_type', CharacterInfo::class)
             ->inRandomOrder()
             ->get()
-            ->map(fn (WalletTransaction $wallet_transaction) => data_get($wallet_transaction, 'wallet_transactionable.refresh_token'))
+            ->map(fn (WalletTransaction $walletTransaction) => data_get($walletTransaction, 'walletTransactionable.refreshToken'))
             ->unique()
             // filter refresh token that has scope esi-universe.read_structures.v1
-            ->filter(fn (RefreshToken $refresh_token) => $refresh_token->hasScope('esi-universe.read_structures.v1'))
+            ->filter(fn (RefreshToken $refreshToken) => $refreshToken->hasScope('esi-universe.read_structures.v1'))
             ->first();
 
-        if ($refresh_token) {
-            return $refresh_token;
+        if ($refreshToken) {
+            return $refreshToken;
         }
 
         return WalletTransaction::query()
-            ->where('location_id', $location_id)
+            ->where('location_id', $locationId)
             ->where('wallet_transactionable_type', CorporationInfo::class)
             ->inRandomOrder()
             ->pluck('wallet_transactionable_id')
             ->unique()
-            ->map(function (int $corporation_id) {
+            ->map(function (int $corporationId) {
 
                 $service = new FindCorporationRefreshToken;
 
-                return $service($corporation_id, 'esi-universe.read_structures.v1', 'Director');
+                return $service($corporationId, 'esi-universe.read_structures.v1', 'Director');
             })
             ->filter()
             ->first();

--- a/src/Services/ResolveLocation/ResolveLocationService.php
+++ b/src/Services/ResolveLocation/ResolveLocationService.php
@@ -14,34 +14,34 @@ use Seatplus\Eveapi\Services\ResolveLocation\Resolver\StructureResolver;
 class ResolveLocationService
 {
     public function __construct(
-        private readonly ?RefreshToken $refresh_token = null,
+        private readonly ?RefreshToken $refreshToken = null,
         private array $resolvers = []
     ) {
         $this->resolvers = $resolvers ?: [
             new StationResolver,
-            new StructureResolver($this->refresh_token),
+            new StructureResolver($this->refreshToken),
         ];
     }
 
-    public static function make(?RefreshToken $refresh_token = null): self
+    public static function make(?RefreshToken $refreshToken = null): self
     {
-        return new self($refresh_token);
+        return new self($refreshToken);
     }
 
     /**
      * @throws Exception
      */
-    public function handle(int $location_id): void
+    public function handle(int $locationId): void
     {
         $location = Location::with('locatable')->firstOrNew([
-            'location_id' => $location_id,
+            'location_id' => $locationId,
         ]);
 
         foreach ($this->resolvers as $resolver) {
             if ($resolver instanceof ResolverInterface) {
-                $is_resolved = $resolver->handle($location);
+                $isResolved = $resolver->handle($location);
 
-                if ($is_resolved) {
+                if ($isResolved) {
                     break;
                 }
             }

--- a/src/Services/ResolveLocation/Resolver/StructureRefreshTokenFinder.php
+++ b/src/Services/ResolveLocation/Resolver/StructureRefreshTokenFinder.php
@@ -18,15 +18,15 @@ use Seatplus\Eveapi\Services\ResolveLocation\Finders\ThroughWalletTransactionsFi
 
 class StructureRefreshTokenFinder
 {
-    private int $location_id;
+    private int $locationId;
 
     public function __construct(
         public ?RefreshToken $refreshToken = null,
     ) {}
 
-    public function findValidToken(int $location_id): ?RefreshToken
+    public function findValidToken(int $locationId): ?RefreshToken
     {
-        $this->location_id = $location_id;
+        $this->locationId = $locationId;
 
         if ($this->refreshToken) {
             return $this->refreshToken;
@@ -53,7 +53,7 @@ class StructureRefreshTokenFinder
     {
         LocationRefreshToken::query()
             ->updateOrCreate([
-                'location_id' => $this->location_id,
+                'location_id' => $this->locationId,
                 'character_id' => $this->refreshToken->character_id,
             ], [
                 'resolved' => $resolved,
@@ -69,7 +69,7 @@ class StructureRefreshTokenFinder
     private function incrementAttempts(): void
     {
         LocationRefreshToken::query()
-            ->where('location_id', $this->location_id)
+            ->where('location_id', $this->locationId)
             ->where('character_id', $this->refreshToken->character_id)
             ->increment('attempts');
     }
@@ -77,7 +77,7 @@ class StructureRefreshTokenFinder
     private function resetAttempts(): void
     {
         LocationRefreshToken::query()
-            ->where('location_id', $this->location_id)
+            ->where('location_id', $this->locationId)
             ->where('character_id', $this->refreshToken->character_id)
             ->update(['attempts' => 0]);
     }
@@ -98,7 +98,7 @@ class StructureRefreshTokenFinder
     private function getLocationRefreshTokens(): Collection
     {
         return LocationRefreshToken::query()
-            ->where('location_id', $this->location_id)
+            ->where('location_id', $this->locationId)
             ->inRandomOrder()
             ->get();
     }
@@ -109,7 +109,7 @@ class StructureRefreshTokenFinder
             $instance = new $class;
 
             if ($instance instanceof FinderInterface) {
-                $this->refreshToken = $instance->handle($this->location_id, $tracings);
+                $this->refreshToken = $instance->handle($this->locationId, $tracings);
 
                 if ($this->refreshToken) {
                     break;

--- a/tests/Integration/CharacterAffiliationLifeCycleTest.php
+++ b/tests/Integration/CharacterAffiliationLifeCycleTest.php
@@ -13,41 +13,41 @@ use Seatplus\Eveapi\Models\Character\CharacterAffiliation;
 use Seatplus\Eveapi\Models\Character\CharacterInfo;
 use Seatplus\Eveapi\Models\Corporation\CorporationInfo;
 
-it('handles follow-up job', function (string $job_class, array $configuration = [], bool $pushed = true) {
+it('handles follow-up job', function (string $jobClass, array $configuration = [], bool $pushed = true) {
     Queue::fake();
     Queue::assertNothingPushed();
 
-    $character_id = CharacterAffiliation::factory()->make()->character_id;
-    $character_id = Arr::get($configuration, 'character_id', $character_id);
+    $characterId = CharacterAffiliation::factory()->make()->character_id;
+    $characterId = Arr::get($configuration, 'character_id', $characterId);
 
     $character = CharacterInfo::factory()->create([
-        'character_id' => $character_id,
+        'character_id' => $characterId,
     ]);
-    $character->character_affiliation()->delete();
+    $character->characterAffiliation()->delete();
 
     $attributes = array_merge([
-        'character_id' => $character_id,
+        'character_id' => $characterId,
     ], Arr::only($configuration, ['alliance_id', 'corporation_id']));
 
-    $character_affiliation = CharacterAffiliation::factory()->create([
+    $characterAffiliation = CharacterAffiliation::factory()->create([
         'character_id' => $character->character_id,
         ...$attributes,
     ]);
 
     $esi = Mockery::mock(EsiClient::class);
-    mockEsiTransport($esi, makeEsiResult([(object) $character_affiliation->toArray()]));
+    mockEsiTransport($esi, makeEsiResult([(object) $characterAffiliation->toArray()]));
 
-    if ($job_class === CorporationInfoJob::class && $pushed) {
-        $character_affiliation->corporation()->delete();
+    if ($jobClass === CorporationInfoJob::class && $pushed) {
+        $characterAffiliation->corporation()->delete();
     }
 
-    $job = new CharacterAffiliationJob($character_id);
+    $job = new CharacterAffiliationJob($characterId);
     $job->executeJob($esi);
 
     if ($pushed) {
-        Queue::assertPushedOn('high', $job_class);
+        Queue::assertPushedOn('high', $jobClass);
     } else {
-        Queue::assertNotPushed($job_class);
+        Queue::assertNotPushed($jobClass);
     }
 })->with([
     'dispatching alliance job, if alliance is unknown' => [AllianceInfoJob::class, ['alliance_id' => 123456]],
@@ -69,9 +69,9 @@ it('applies binary search and caches it if one id is invalid', function () {
     Queue::fake();
 
     CharacterAffiliation::query()->delete();
-    $mock_data = CharacterAffiliation::factory()->make();
+    $mockData = CharacterAffiliation::factory()->make();
 
-    $ids = [123456789, $mock_data->character_id];
+    $ids = [123456789, $mockData->character_id];
 
     $exceptionMock = Mockery::mock(Exception::class);
     $exceptionMock->shouldReceive('getResponse->getReasonPhrase')->andReturn('Invalid character ID');
@@ -85,7 +85,7 @@ it('applies binary search and caches it if one id is invalid', function () {
     $esi->shouldReceive('invoke')
         ->once()->ordered()->andThrow($exception);
     $esi->shouldReceive('invoke')
-        ->once()->ordered()->andReturn(makeEsiRawResponse(makeEsiResult([(object) $mock_data->toArray()])));
+        ->once()->ordered()->andReturn(makeEsiRawResponse(makeEsiResult([(object) $mockData->toArray()])));
 
     $job = new CharacterAffiliationJob($ids);
     $job->executeJob($esi);
@@ -93,17 +93,17 @@ it('applies binary search and caches it if one id is invalid', function () {
     expect(cache('invalid_character_ids'))->toBe([123456789])
         ->and(CharacterAffiliation::all())->toHaveCount(1)
         ->and(CharacterAffiliation::first())->character_id
-        ->toBe($mock_data->character_id);
+        ->toBe($mockData->character_id);
 });
 
 it('skips db write when character affiliation response is a cached load', function () {
     CharacterAffiliation::query()->delete();
-    $mock_data = CharacterAffiliation::factory()->make();
+    $mockData = CharacterAffiliation::factory()->make();
 
     $esi = Mockery::mock(EsiClient::class);
-    mockEsiTransport($esi, makeEsiResult([(object) $mock_data->toArray()], isCachedLoad: true));
+    mockEsiTransport($esi, makeEsiResult([(object) $mockData->toArray()], isCachedLoad: true));
 
-    $job = new CharacterAffiliationJob($mock_data->character_id);
+    $job = new CharacterAffiliationJob($mockData->character_id);
     $job->executeJob($esi);
 
     expect(CharacterAffiliation::count())->toBe(0);

--- a/tests/Integration/CharacterBalanceLifecycleTest.php
+++ b/tests/Integration/CharacterBalanceLifecycleTest.php
@@ -10,10 +10,10 @@ beforeEach(function () {
 });
 
 test('run wallet balance job', function () {
-    $mock_data = Balance::factory()->make();
+    $mockData = Balance::factory()->make();
 
     $esi = Mockery::mock(EsiClient::class);
-    mockEsiTransport($esi, makeEsiResult($mock_data->balance));
+    mockEsiTransport($esi, makeEsiResult($mockData->balance));
 
     expect(Balance::all())->toHaveCount(0);
 

--- a/tests/Integration/CharacterUpdateTest.php
+++ b/tests/Integration/CharacterUpdateTest.php
@@ -10,7 +10,7 @@ use Seatplus\Eveapi\Models\RefreshToken;
 test('if constructor receives single refresh token push update to high queue', function () {
     Queue::fake();
 
-    (new UpdateCharacter(testCharacter()->refresh_token))->handle();
+    (new UpdateCharacter(testCharacter()->refreshToken))->handle();
 
     Queue::assertPushedOn('high', CharacterBatchJob::class);
 });

--- a/tests/Integration/CharacterWalletJournalLifecycleTest.php
+++ b/tests/Integration/CharacterWalletJournalLifecycleTest.php
@@ -11,19 +11,19 @@ beforeEach(function () {
 });
 
 test('run wallet journal job', function () {
-    $mock_data = WalletJournal::factory()->count(5)->make();
+    $mockData = WalletJournal::factory()->count(5)->make();
 
-    $esi_data = $mock_data->map(fn (WalletJournal $j) => CharactersCharacterIdWalletJournalGetItem::from(
+    $esiData = $mockData->map(fn (WalletJournal $j) => CharactersCharacterIdWalletJournalGetItem::from(
         (object) $j->toArray()
     ))->toArray();
 
     $esi = Mockery::mock(EsiClient::class);
-    mockEsiTransport($esi, makeEsiResult($esi_data));
+    mockEsiTransport($esi, makeEsiResult($esiData));
 
     $job = new CharacterWalletJournalJob(testCharacter()->character_id);
     $job->executeJob($esi);
 
-    foreach ($mock_data as $data) {
+    foreach ($mockData as $data) {
         $this->assertDatabaseHas('wallet_journals', [
             'wallet_journable_id' => $this->test_character->character_id,
             'id' => $data->id,

--- a/tests/Integration/ContactLabelJobTest.php
+++ b/tests/Integration/ContactLabelJobTest.php
@@ -12,10 +12,10 @@ beforeEach(function () {
 });
 
 test('run character contact label', function () {
-    $mock_data = Label::factory()->count(5)->make();
+    $mockData = Label::factory()->count(5)->make();
 
     $esi = Mockery::mock(EsiClient::class);
-    mockEsiTransport($esi, makeEsiResult(array_map(fn ($l) => (object) $l, $mock_data->toArray())));
+    mockEsiTransport($esi, makeEsiResult(array_map(fn ($l) => (object) $l, $mockData->toArray())));
 
     expect(Label::all())->toHaveCount(0);
 
@@ -26,10 +26,10 @@ test('run character contact label', function () {
 });
 
 test('run corporation contact label', function () {
-    $mock_data = Label::factory()->count(5)->make();
+    $mockData = Label::factory()->count(5)->make();
 
     $esi = Mockery::mock(EsiClient::class);
-    mockEsiTransport($esi, makeEsiResult(array_map(fn ($l) => (object) $l, $mock_data->toArray())));
+    mockEsiTransport($esi, makeEsiResult(array_map(fn ($l) => (object) $l, $mockData->toArray())));
 
     expect(Label::all())->toHaveCount(0);
 
@@ -40,10 +40,10 @@ test('run corporation contact label', function () {
 });
 
 test('run alliance contact label', function () {
-    $mock_data = Label::factory()->count(5)->make();
+    $mockData = Label::factory()->count(5)->make();
 
     $esi = Mockery::mock(EsiClient::class);
-    mockEsiTransport($esi, makeEsiResult(array_map(fn ($l) => (object) $l, $mock_data->toArray())));
+    mockEsiTransport($esi, makeEsiResult(array_map(fn ($l) => (object) $l, $mockData->toArray())));
 
     expect(Label::all())->toHaveCount(0);
 

--- a/tests/Integration/ContactLifecycleTest.php
+++ b/tests/Integration/ContactLifecycleTest.php
@@ -13,61 +13,61 @@ beforeEach(function () {
 });
 
 test('run character contact', function () {
-    $mock_data = Contact::factory()->count(5)->make();
+    $mockData = Contact::factory()->count(5)->make();
 
     $esi = Mockery::mock(EsiClient::class);
-    mockEsiTransport($esi, makeEsiResult(array_map(fn ($c) => (object) $c, $mock_data->toArray())));
+    mockEsiTransport($esi, makeEsiResult(array_map(fn ($c) => (object) $c, $mockData->toArray())));
 
     $job = new CharacterContactJob(testCharacter()->character_id);
     $job->executeJob($esi);
 
-    $cached_ids = CacheCharacterAffiliationIdsService::make()->retrieve();
+    $cachedIds = CacheCharacterAffiliationIdsService::make()->retrieve();
 
-    foreach ($mock_data as $data) {
+    foreach ($mockData as $data) {
         $this->assertDatabaseHas('contacts', [
             'contactable_id' => $this->test_character->character_id,
             'contact_id' => $data->contact_id,
         ]);
 
         if ($data->contact_type === 'character') {
-            expect(in_array($data->contact_id, $cached_ids->toArray()))->toBeTrue();
+            expect(in_array($data->contact_id, $cachedIds->toArray()))->toBeTrue();
         }
     }
 });
 
 test('run corporation contact', function () {
-    $mock_data = Contact::factory()->count(5)->make();
+    $mockData = Contact::factory()->count(5)->make();
 
     $esi = Mockery::mock(EsiClient::class);
-    mockEsiTransport($esi, makeEsiResult(array_map(fn ($c) => (object) $c, $mock_data->toArray())));
+    mockEsiTransport($esi, makeEsiResult(array_map(fn ($c) => (object) $c, $mockData->toArray())));
 
     $job = new CorporationContactJob(testCharacter()->corporation->corporation_id, testCharacter()->character_id);
     $job->executeJob($esi);
 
-    $cached_ids = CacheCharacterAffiliationIdsService::make()->retrieve();
+    $cachedIds = CacheCharacterAffiliationIdsService::make()->retrieve();
 
-    foreach ($mock_data as $data) {
+    foreach ($mockData as $data) {
         $this->assertDatabaseHas('contacts', [
             'contactable_id' => $this->test_character->corporation->corporation_id,
             'contact_id' => $data->contact_id,
         ]);
 
         if ($data->contact_type === 'character') {
-            expect(in_array($data->contact_id, $cached_ids->toArray()))->toBeTrue();
+            expect(in_array($data->contact_id, $cachedIds->toArray()))->toBeTrue();
         }
     }
 });
 
 test('run alliance contact', function () {
-    $mock_data = Contact::factory()->count(5)->make();
+    $mockData = Contact::factory()->count(5)->make();
 
     $esi = Mockery::mock(EsiClient::class);
-    mockEsiTransport($esi, makeEsiResult(array_map(fn ($c) => (object) $c, $mock_data->toArray())));
+    mockEsiTransport($esi, makeEsiResult(array_map(fn ($c) => (object) $c, $mockData->toArray())));
 
     $job = new AllianceContactJob(testCharacter()->corporation->alliance_id, testCharacter()->character_id);
     $job->executeJob($esi);
 
-    foreach ($mock_data as $data) {
+    foreach ($mockData as $data) {
         $this->assertDatabaseHas('contacts', [
             'contactable_id' => $this->test_character->corporation->alliance_id,
             'contact_id' => $data->contact_id,
@@ -76,10 +76,10 @@ test('run alliance contact', function () {
 });
 
 it('has labels', function () {
-    $mock_data = Contact::factory()->withLabels()->make();
+    $mockData = Contact::factory()->withLabels()->make();
 
     $esi = Mockery::mock(EsiClient::class);
-    mockEsiTransport($esi, makeEsiResult([(object) $mock_data->toArray()]));
+    mockEsiTransport($esi, makeEsiResult([(object) $mockData->toArray()]));
 
     expect($this->test_character->contacts)->toHaveCount(0);
 

--- a/tests/Integration/ContractLifeCycleTest.php
+++ b/tests/Integration/ContractLifeCycleTest.php
@@ -14,8 +14,8 @@ test('job dispatches nothing by default upon creation with factory', function ()
         'issuer_id' => testCharacter()->character_id,
     ]);
 
-    expect($contract->start_location)->not()->toBeNull()
-        ->and($contract->end_location)->not()->toBeNull()
+    expect($contract->startLocation)->not()->toBeNull()
+        ->and($contract->endLocation)->not()->toBeNull()
         ->and($contract->issuer)->not()->toBeNull();
 
     $esi = Mockery::mock(EsiClient::class);
@@ -42,8 +42,8 @@ test('job dispatches location job with unknown location id', function () {
     $job = new CharacterContractsJob(testCharacter()->character_id);
     $job->executeJob($esi);
 
-    expect($contract->start_location)->toBeNull()
-        ->and($contract->end_location)->not()->toBeNull()
+    expect($contract->startLocation)->toBeNull()
+        ->and($contract->endLocation)->not()->toBeNull()
         ->and($contract->issuer)->not()->toBeNull();
 
     Queue::assertPushedOn('high', ResolveLocationJob::class);

--- a/tests/Integration/CorporationBalanceLifeCycleTest.php
+++ b/tests/Integration/CorporationBalanceLifeCycleTest.php
@@ -15,13 +15,13 @@ use Seatplus\Eveapi\Models\Wallet\WalletJournal;
 it('runs the job', function () {
     Queue::fake();
 
-    $mock_data = Balance::factory()->withDivision()->count(7)->make([
+    $mockData = Balance::factory()->withDivision()->count(7)->make([
         'balanceable_id' => testCharacter()->corporation->corporation_id,
         'balanceable_type' => CorporationInfo::class,
     ]);
 
     $esi = Mockery::mock(EsiClient::class);
-    mockEsiTransport($esi, makeEsiResult(array_map(fn ($b) => (object) $b, $mock_data->toArray())));
+    mockEsiTransport($esi, makeEsiResult(array_map(fn ($b) => (object) $b, $mockData->toArray())));
 
     expect(Balance::all())->toHaveCount(0);
 
@@ -72,23 +72,23 @@ it('spawns a job for every wallet division', function () {
 it('creates wallet journal entries', function () {
     $corporation = $this->test_character->corporation;
 
-    expect($corporation->wallet_journals)->toHaveCount(0);
+    expect($corporation->walletJournals)->toHaveCount(0);
 
-    $mock_data = WalletJournal::factory()->count(7)->make([
+    $mockData = WalletJournal::factory()->count(7)->make([
         'wallet_journable_id' => testCharacter()->corporation->corporation_id,
         'wallet_journable_type' => CorporationInfo::class,
         'division' => 3,
     ]);
 
     $esi = Mockery::mock(EsiClient::class);
-    mockEsiTransport($esi, makeEsiResult($mock_data->map(fn (WalletJournal $j) => CorporationsCorporationIdWalletsDivisionJournalGetItem::from(
+    mockEsiTransport($esi, makeEsiResult($mockData->map(fn (WalletJournal $j) => CorporationsCorporationIdWalletsDivisionJournalGetItem::from(
         (object) $j->toArray()
     ))->toArray()));
 
-    $job = new CorporationWalletJournalByDivisionJob(testCharacter()->corporation->corporation_id, $mock_data->first()->division);
+    $job = new CorporationWalletJournalByDivisionJob(testCharacter()->corporation->corporation_id, $mockData->first()->division);
     $job->executeJob($esi);
 
     $corporation = $corporation->refresh();
-    expect($corporation->wallet_journals)->toHaveCount($mock_data->count());
-    expect($corporation->wallet_journals->first())->toBeInstanceOf(WalletJournal::class);
+    expect($corporation->walletJournals)->toHaveCount($mockData->count());
+    expect($corporation->walletJournals->first())->toBeInstanceOf(WalletJournal::class);
 });

--- a/tests/Integration/CorporationHistoryTest.php
+++ b/tests/Integration/CorporationHistoryTest.php
@@ -5,13 +5,13 @@ use Seatplus\Eveapi\Jobs\Character\CorporationHistoryJob;
 use Seatplus\Eveapi\Models\Character\CorporationHistory;
 
 test('job creates db entry', function () {
-    $corporation_history = CorporationHistory::factory()->count(3)->make([
+    $corporationHistory = CorporationHistory::factory()->count(3)->make([
         'character_id' => $this->test_character->character_id,
         'corporation_id' => $this->test_character->corporation->corporation_id,
     ]);
 
     $esi = Mockery::mock(EsiClient::class);
-    mockEsiTransport($esi, makeEsiResult(array_map(fn ($h) => (object) $h, $corporation_history->toArray())));
+    mockEsiTransport($esi, makeEsiResult(array_map(fn ($h) => (object) $h, $corporationHistory->toArray())));
 
     expect(CorporationHistory::all())->toHaveCount(0);
 
@@ -19,5 +19,5 @@ test('job creates db entry', function () {
     $job->executeJob($esi);
 
     expect(CorporationHistory::all())->toHaveCount(3)
-        ->and($this->test_character->corporation_history)->toHaveCount(3);
+        ->and($this->test_character->corporationHistory)->toHaveCount(3);
 });

--- a/tests/Integration/CorporationMemberTrackingLifeCycleTest.php
+++ b/tests/Integration/CorporationMemberTrackingLifeCycleTest.php
@@ -15,10 +15,10 @@ beforeEach(function () {
     Queue::fake();
 });
 
-it('handles missing jobs after corporation member job', function (string $job_class, array $configuration, bool $should_be_queued = true) {
-    updateRefreshTokenScopes(testCharacter()->refresh_token, ['esi-corporations.track_members.v1'])->save();
+it('handles missing jobs after corporation member job', function (string $jobClass, array $configuration, bool $shouldBeQueued = true) {
+    updateRefreshTokenScopes(testCharacter()->refreshToken, ['esi-corporations.track_members.v1'])->save();
 
-    expect(testCharacter()->refresh_token->scopes)->toContain('esi-corporations.track_members.v1');
+    expect(testCharacter()->refreshToken->scopes)->toContain('esi-corporations.track_members.v1');
 
     updateCharacterRoles(['Director']);
 
@@ -36,9 +36,9 @@ it('handles missing jobs after corporation member job', function (string $job_cl
     $job = new CorporationMemberTrackingJob($tracking->corporation_id);
     $job->executeJob($esi);
 
-    match ($should_be_queued) {
-        true => Queue::assertPushedOn('high', $job_class),
-        false => Queue::assertNotPushed($job_class),
+    match ($shouldBeQueued) {
+        true => Queue::assertPushedOn('high', $jobClass),
+        false => Queue::assertNotPushed($jobClass),
     };
 })->with([
     'resolves type if ship is unknown' => [ResolveUniverseTypeByIdJob::class, ['ship_type_id' => 1234]],

--- a/tests/Integration/MailIntegrationTest.php
+++ b/tests/Integration/MailIntegrationTest.php
@@ -16,9 +16,9 @@ beforeEach(function () {
 it('runs mail header job', function () {
     expect(Mail::all())->toHaveCount(0);
 
-    $mocked_mails = Event::fakeFor(fn () => Mail::factory()->count(5)->make());
+    $mockedMails = Event::fakeFor(fn () => Mail::factory()->count(5)->make());
 
-    $mock_data = $mocked_mails->map(fn ($mail) => (object) [
+    $mockData = $mockedMails->map(fn ($mail) => (object) [
         'mail_id' => data_get($mail, 'id'),
         'subject' => data_get($mail, 'subject'),
         'from' => data_get($mail, 'from'),
@@ -35,7 +35,7 @@ it('runs mail header job', function () {
     ]);
 
     $esi = Mockery::mock(EsiClient::class);
-    mockEsiTransport($esi, makeEsiResult($mock_data->values()->toArray()));
+    mockEsiTransport($esi, makeEsiResult($mockData->values()->toArray()));
 
     $job = new MailHeaderJob(testCharacter()->character_id);
     $job->executeJob($esi);
@@ -66,7 +66,7 @@ it('adds MailBodyJob to batch if batched', function () {
     $mails = Event::fakeFor(fn () => Mail::factory()->count(5)->create(['body' => null]));
 
     $job = mock(MailHeaderJob::class, function (MockInterface $mock) {
-        $mock->character_id = testCharacter()->character_id;
+        $mock->characterId = testCharacter()->character_id;
         $mock->shouldReceive('batching')->andReturnTrue();
         $mock->shouldReceive('batch->add')->times(5);
     })->makePartial();

--- a/tests/Integration/RefreshTokenLifeCycleTest.php
+++ b/tests/Integration/RefreshTokenLifeCycleTest.php
@@ -10,51 +10,51 @@ use Seatplus\Eveapi\Models\RefreshToken;
 it('generates an event', function () {
     Event::fake();
 
-    $refresh_token = RefreshToken::factory()->create();
+    $refreshToken = RefreshToken::factory()->create();
 
-    Event::assertDispatched(RefreshTokenCreated::class, fn ($e) => $e->refresh_token === $refresh_token);
+    Event::assertDispatched(RefreshTokenCreated::class, fn ($e) => $e->refreshToken === $refreshToken);
 });
 
 it('queues update character job', function () {
     Queue::fake();
 
-    $refresh_token = RefreshToken::factory()->create();
+    $refreshToken = RefreshToken::factory()->create();
 
     Queue::assertPushedOn('high', UpdateCharacter::class);
 });
 
 it('queues update character job after scope change', function () {
-    $refresh_token = Event::fakeFor(fn () => RefreshToken::factory()->scopes(['esi-assets.read_assets.v1', 'esi-universe.read_structures.v1'])->create());
+    $refreshToken = Event::fakeFor(fn () => RefreshToken::factory()->scopes(['esi-assets.read_assets.v1', 'esi-universe.read_structures.v1'])->create());
 
     Queue::fake();
 
     $helperToken = RefreshToken::factory()->scopes(['public'])->make();
 
-    $refresh_token->token = $helperToken->token;
-    $refresh_token->save();
+    $refreshToken->token = $helperToken->token;
+    $refreshToken->save();
 
     Queue::assertPushedOn('high', UpdateCharacter::class);
 });
 
 it('does not queues update character job after no scope change', function () {
-    $refresh_token = Event::fakeFor(fn () => RefreshToken::factory()->scopes(['esi-assets.read_assets.v1', 'esi-universe.read_structures.v1'])->create());
+    $refreshToken = Event::fakeFor(fn () => RefreshToken::factory()->scopes(['esi-assets.read_assets.v1', 'esi-universe.read_structures.v1'])->create());
 
     Queue::fake();
 
     $helperToken = RefreshToken::factory()->scopes(['esi-assets.read_assets.v1', 'esi-universe.read_structures.v1'])->make();
 
-    $refresh_token->token = $helperToken->token;
-    $refresh_token->save();
+    $refreshToken->token = $helperToken->token;
+    $refreshToken->save();
 
     Queue::assertNotPushed(UpdateCharacter::class);
 });
 
 it('queues update corporation job after scope change', function () {
-    $refresh_token = $this->test_character->refresh_token;
+    $refreshToken = $this->test_character->refreshToken;
 
     Queue::fake();
 
-    $token = updateRefreshTokenScopes($refresh_token, ['updating']);
+    $token = updateRefreshTokenScopes($refreshToken, ['updating']);
     $token->save();
 
     Queue::assertPushedOn('high', UpdateCorporation::class);

--- a/tests/Integration/SkillLifeCycleTest.php
+++ b/tests/Integration/SkillLifeCycleTest.php
@@ -15,7 +15,7 @@ beforeEach(function () {
 it('runs skill job', function () {
     expect(Skill::all())->toHaveCount(0);
 
-    $mocked_skills = Event::fakeFor(
+    $mockedSkills = Event::fakeFor(
         fn () => Skill::factory(['character_id' => testCharacter()->character_id])
             ->count(5)
             ->make()
@@ -23,7 +23,7 @@ it('runs skill job', function () {
 
     $esi = Mockery::mock(EsiClient::class);
     mockEsiTransport($esi, makeEsiResult((object) [
-        'skills' => array_map(fn ($s) => (object) $s, $mocked_skills->toArray()),
+        'skills' => array_map(fn ($s) => (object) $s, $mockedSkills->toArray()),
         'total_sp' => 1337,
         'unallocated_sp' => 42,
     ]));

--- a/tests/Integration/SkillQueueLifeCycleTest.php
+++ b/tests/Integration/SkillQueueLifeCycleTest.php
@@ -14,14 +14,14 @@ beforeEach(function () {
 it('runs skill queue job', function () {
     expect(SkillQueue::all())->toHaveCount(0);
 
-    $mocked_skill_queue = Event::fakeFor(
+    $mockedSkillQueue = Event::fakeFor(
         fn () => SkillQueue::factory(['character_id' => testCharacter()->character_id])
             ->count(5)
             ->make()
     );
 
     $esi = Mockery::mock(EsiClient::class);
-    mockEsiTransport($esi, makeEsiResult(array_map(fn ($s) => (object) $s, $mocked_skill_queue->toArray())));
+    mockEsiTransport($esi, makeEsiResult(array_map(fn ($s) => (object) $s, $mockedSkillQueue->toArray())));
 
     $job = new SkillQueueJob(testCharacter()->character_id);
     $job->executeJob($esi);

--- a/tests/Integration/UniverseRegionTest.php
+++ b/tests/Integration/UniverseRegionTest.php
@@ -20,42 +20,42 @@ it('has tags', function () {
 });
 
 it('resolves system', function () {
-    $mock_data = System::factory()->make();
+    $mockData = System::factory()->make();
 
     $esi = Mockery::mock(EsiClient::class);
-    mockEsiTransport($esi, makeEsiResult((object) $mock_data->toArray()));
+    mockEsiTransport($esi, makeEsiResult((object) $mockData->toArray()));
 
     expect(System::all())->toHaveCount(0);
 
-    $job = new ResolveUniverseSystemBySystemIdJob($mock_data->system_id);
+    $job = new ResolveUniverseSystemBySystemIdJob($mockData->system_id);
     $job->executeJob($esi);
 
     expect(System::all())->toHaveCount(1);
 });
 
 it('resolves constellation', function () {
-    $mock_data = Constellation::factory()->make();
+    $mockData = Constellation::factory()->make();
 
     $esi = Mockery::mock(EsiClient::class);
-    mockEsiTransport($esi, makeEsiResult((object) $mock_data->toArray()));
+    mockEsiTransport($esi, makeEsiResult((object) $mockData->toArray()));
 
     expect(Constellation::all())->toHaveCount(0);
 
-    $job = new ResolveUniverseConstellationByConstellationIdJob($mock_data->constellation_id);
+    $job = new ResolveUniverseConstellationByConstellationIdJob($mockData->constellation_id);
     $job->executeJob($esi);
 
     expect(Constellation::all())->toHaveCount(1);
 });
 
 it('resolves region', function () {
-    $mock_data = Region::factory()->make();
+    $mockData = Region::factory()->make();
 
     $esi = Mockery::mock(EsiClient::class);
-    mockEsiTransport($esi, makeEsiResult((object) $mock_data->toArray()));
+    mockEsiTransport($esi, makeEsiResult((object) $mockData->toArray()));
 
     expect(Region::all())->toHaveCount(0);
 
-    $job = new ResolveUniverseRegionByRegionIdJob($mock_data->region_id);
+    $job = new ResolveUniverseRegionByRegionIdJob($mockData->region_id);
     $job->executeJob($esi);
 
     expect(Region::all())->toHaveCount(1);

--- a/tests/Integration/WalletTransactionLifecycleTest.php
+++ b/tests/Integration/WalletTransactionLifecycleTest.php
@@ -18,22 +18,22 @@ beforeEach(function () {
     Queue::fake();
 });
 
-test('run wallet transaction action', function (bool $is_corporation = false) {
-    $wallet_transactionable_id = $is_corporation ? testCharacter()->corporation->corporation_id : testCharacter()->character_id;
+test('run wallet transaction action', function (bool $isCorporation = false) {
+    $walletTransactionableId = $isCorporation ? testCharacter()->corporation->corporation_id : testCharacter()->character_id;
 
     Queue::assertNothingPushed();
-    $mock_data = Event::fakeFor(fn () => WalletTransaction::factory()->count(5)->make([
-        'wallet_transactionable_id' => $wallet_transactionable_id,
-        'wallet_transactionable_type' => $is_corporation ? CorporationInfo::class : CharacterInfo::class,
-        'division' => $is_corporation ? 1 : null,
+    $mockData = Event::fakeFor(fn () => WalletTransaction::factory()->count(5)->make([
+        'wallet_transactionable_id' => $walletTransactionableId,
+        'wallet_transactionable_type' => $isCorporation ? CorporationInfo::class : CharacterInfo::class,
+        'division' => $isCorporation ? 1 : null,
     ]));
     Queue::assertNothingPushed();
 
-    runWalletTransactionJobWithMockData($mock_data->toArray());
+    runWalletTransactionJobWithMockData($mockData->toArray());
 
-    foreach ($mock_data as $data) {
+    foreach ($mockData as $data) {
         $this->assertDatabaseHas('wallet_transactions', [
-            'wallet_transactionable_id' => $wallet_transactionable_id,
+            'wallet_transactionable_id' => $walletTransactionableId,
             'transaction_id' => $data->transaction_id,
         ]);
     }
@@ -42,19 +42,19 @@ test('run wallet transaction action', function (bool $is_corporation = false) {
     'corporation' => [true],
 ]);
 
-test('it dispatches follow up jobs', function (string $job_class, array $configuration, bool $should_dispatch) {
-    $mock_data = WalletTransaction::factory()->make([
+test('it dispatches follow up jobs', function (string $jobClass, array $configuration, bool $shouldDispatch) {
+    $mockData = WalletTransaction::factory()->make([
         'wallet_transactionable_id' => testCharacter()->character_id,
         'wallet_transactionable_type' => CharacterInfo::class,
         ...$configuration,
     ]);
 
-    runWalletTransactionJobWithMockData([$mock_data]);
+    runWalletTransactionJobWithMockData([$mockData]);
 
-    if ($should_dispatch) {
-        Queue::assertPushedOn('high', $job_class);
+    if ($shouldDispatch) {
+        Queue::assertPushedOn('high', $jobClass);
     } else {
-        Queue::assertNotPushed($job_class);
+        Queue::assertNotPushed($jobClass);
     }
 })->with([
     'dispatching location job' => fn () => [ResolveLocationJob::class, [], true],
@@ -71,13 +71,13 @@ test('it dispatches follow up jobs', function (string $job_class, array $configu
     ],
 ]);
 
-function runWalletTransactionJobWithMockData(array $mock_data): void
+function runWalletTransactionJobWithMockData(array $mockData): void
 {
-    $division_id = Arr::get($mock_data, '0.division', null);
-    $is_corporation = ! is_null($division_id);
+    $divisionId = Arr::get($mockData, '0.division', null);
+    $isCorporation = ! is_null($divisionId);
 
-    $wallet_transactionable_id = Arr::get($mock_data, '0.wallet_transactionable_id');
-    $items = array_map(fn ($t) => (object) (is_array($t) ? $t : $t->toArray()), $mock_data);
+    $walletTransactionableId = Arr::get($mockData, '0.wallet_transactionable_id');
+    $items = array_map(fn ($t) => (object) (is_array($t) ? $t : $t->toArray()), $mockData);
 
     $esi = Mockery::mock(EsiClient::class);
     $esi->shouldReceive('withToken')->andReturnSelf();
@@ -85,16 +85,16 @@ function runWalletTransactionJobWithMockData(array $mock_data): void
     $esi->shouldReceive('invoke')
         ->andReturn(makeEsiRawResponse(makeEsiResult($items)), makeEsiRawResponse(makeEsiResult([])));
 
-    if ($is_corporation) {
-        updateRefreshTokenScopes(testCharacter()->refresh_token, ['esi-wallet.read_corporation_wallets.v1'])->save();
+    if ($isCorporation) {
+        updateRefreshTokenScopes(testCharacter()->refreshToken, ['esi-wallet.read_corporation_wallets.v1'])->save();
         updateCharacterRoles(['Director']);
 
-        $job = new CorporationWalletTransactionByDivisionJob($wallet_transactionable_id, $division_id);
+        $job = new CorporationWalletTransactionByDivisionJob($walletTransactionableId, $divisionId);
         $job->executeJob($esi);
 
         return;
     }
 
-    $job = new CharacterWalletTransactionJob($wallet_transactionable_id);
+    $job = new CharacterWalletTransactionJob($walletTransactionableId);
     $job->executeJob($esi);
 }

--- a/tests/Jobs/Alliance/AllianceInfoJobTest.php
+++ b/tests/Jobs/Alliance/AllianceInfoJobTest.php
@@ -16,13 +16,13 @@ test('if job is queued', function () {
 });
 
 test('retrieve test', function () {
-    $mock_data = AllianceInfo::factory()->make(['alliance_id' => 12345]);
+    $mockData = AllianceInfo::factory()->make(['alliance_id' => 12345]);
 
     $esi = Mockery::mock(EsiClient::class);
-    mockEsiTransport($esi, makeEsiResult((object) $mock_data->toArray()));
+    mockEsiTransport($esi, makeEsiResult((object) $mockData->toArray()));
 
     $job = new AllianceInfoJob(12345);
     $job->executeJob($esi);
 
-    expect(AllianceInfo::where('name', $mock_data->name)->exists())->toBeTrue();
+    expect(AllianceInfo::where('name', $mockData->name)->exists())->toBeTrue();
 });

--- a/tests/Jobs/Assets/CharacterAssetTest.php
+++ b/tests/Jobs/Assets/CharacterAssetTest.php
@@ -26,12 +26,12 @@ test('if job is queued', function () {
 
 test('retrieve test', function () {
     $esi = Mockery::mock(EsiClient::class);
-    $mock_data = buildAssetMockEsiData($esi);
+    $mockData = buildAssetMockEsiData($esi);
 
     $job = new CharacterAssetJob($this->test_character->character_id);
     $job->executeJob($esi);
 
-    foreach ($mock_data as $data) {
+    foreach ($mockData as $data) {
         expect(Asset::where('assetable_id', $this->test_character->character_id)
             ->where('item_id', $data->item_id)
             ->exists())->toBeTrue();
@@ -39,23 +39,23 @@ test('retrieve test', function () {
 });
 
 it('cleans up assets', function () {
-    $old_data = Asset::factory()->count(5)->create([
+    $oldData = Asset::factory()->count(5)->create([
         'assetable_id' => $this->test_character->character_id,
     ]);
 
     $esi = Mockery::mock(EsiClient::class);
-    $mock_data = buildAssetMockEsiData($esi);
+    $mockData = buildAssetMockEsiData($esi);
 
     $job = new CharacterAssetJob($this->test_character->character_id);
     $job->executeJob($esi);
 
-    foreach ($mock_data as $data) {
+    foreach ($mockData as $data) {
         expect(Asset::where('assetable_id', $this->test_character->character_id)
             ->where('item_id', $data->item_id)
             ->exists())->toBeTrue();
     }
 
-    foreach ($old_data as $data) {
+    foreach ($oldData as $data) {
         expect(Asset::where('assetable_id', $this->test_character->character_id)
             ->where('item_id', $data->item_id)
             ->count())->toBe(0);
@@ -119,13 +119,13 @@ it('does not dispatch ResolveLocationJob if location is known', function () {
 // Helpers
 function buildAssetMockEsiData(MockInterface $esi): Collection
 {
-    $mock_data = Asset::factory()->count(5)->make([
+    $mockData = Asset::factory()->count(5)->make([
         'assetable_id' => testCharacter()->character_id,
     ]);
 
-    mockEsiTransport($esi, makeEsiResult(array_map(fn ($a) => (object) $a, $mock_data->toArray())));
+    mockEsiTransport($esi, makeEsiResult(array_map(fn ($a) => (object) $a, $mockData->toArray())));
 
-    return $mock_data;
+    return $mockData;
 }
 
 it('returns the refresh token', function () {

--- a/tests/Jobs/Character/CharacterInfoTest.php
+++ b/tests/Jobs/Character/CharacterInfoTest.php
@@ -11,21 +11,21 @@ it('dispatches job on default queue by character_id', function () {
 
     Queue::assertNothingPushed();
 
-    CharacterInfoJob::dispatch(character_id: 123)->onQueue('default');
+    CharacterInfoJob::dispatch(characterId: 123)->onQueue('default');
 
     Queue::assertPushedOn('default', CharacterInfoJob::class);
 });
 
 test('retrieve test', function () {
-    $mock_data = CharacterInfo::factory()->make();
+    $mockData = CharacterInfo::factory()->make();
 
     Bus::fake();
 
     $esi = Mockery::mock(EsiClient::class);
-    mockEsiTransport($esi, makeEsiResult((object) $mock_data->toArray()));
+    mockEsiTransport($esi, makeEsiResult((object) $mockData->toArray()));
 
-    $job = new CharacterInfoJob($mock_data['character_id']);
+    $job = new CharacterInfoJob($mockData['character_id']);
     $job->executeJob($esi);
 
-    expect(CharacterInfo::where('name', $mock_data['name'])->exists())->toBeTrue();
+    expect(CharacterInfo::where('name', $mockData['name'])->exists())->toBeTrue();
 });

--- a/tests/Jobs/Character/CharacterRoleTest.php
+++ b/tests/Jobs/Character/CharacterRoleTest.php
@@ -17,18 +17,18 @@ test('if job is queued', function () {
 });
 
 test('retrieve test', function () {
-    $mock_data = CharacterRole::factory()->make([
+    $mockData = CharacterRole::factory()->make([
         'roles' => ['Personnel_Manager'],
         'character_id' => testCharacter()->character_id,
     ]);
 
     $esi = Mockery::mock(EsiClient::class);
-    mockEsiTransport($esi, makeEsiResult((object) $mock_data->toArray()));
+    mockEsiTransport($esi, makeEsiResult((object) $mockData->toArray()));
 
     $job = new CharacterRoleJob(testCharacter()->character_id);
     $job->executeJob($esi);
 
-    expect(CharacterRole::where('character_id', $mock_data->character_id)->exists())->toBeTrue();
+    expect(CharacterRole::where('character_id', $mockData->character_id)->exists())->toBeTrue();
 });
 
 it('returns the refresh token', function () {

--- a/tests/Jobs/Contacts/ContactJobTest.php
+++ b/tests/Jobs/Contacts/ContactJobTest.php
@@ -83,13 +83,13 @@ test('character contact label job', function () {
 test('ContactJob using ContactBaseJob and finds refresh_token', function (string $flavour) {
     Queue::fake();
 
-    $required_scopes = [
+    $requiredScopes = [
         'esi-characters.read_contacts.v1',
         'esi-corporations.read_contacts.v1',
         'esi-alliances.read_contacts.v1',
     ];
 
-    updateRefreshTokenScopes($this->test_character->refresh_token, $required_scopes)->save();
+    updateRefreshTokenScopes($this->test_character->refreshToken, $requiredScopes)->save();
 
     $job = match ($flavour) {
         'character' => new CharacterContactJob($this->test_character->character_id),

--- a/tests/Jobs/Contracts/ContractItemJobTest.php
+++ b/tests/Jobs/Contracts/ContractItemJobTest.php
@@ -14,9 +14,9 @@ test('job is being dispatched', function () {
 
     Queue::assertNothingPushed();
 
-    $mock_data = ContractItem::factory()->count(1)->make();
+    $mockData = ContractItem::factory()->count(1)->make();
 
-    CharacterContractItemsJob::dispatch(testCharacter()->character_id, $mock_data->first()->contract_id);
+    CharacterContractItemsJob::dispatch(testCharacter()->character_id, $mockData->first()->contract_id);
 
     Queue::assertNotPushed(ResolveUniverseTypeByIdJob::class);
 });
@@ -24,14 +24,14 @@ test('job is being dispatched', function () {
 it('dispatches resolve universe type job if type is unknown', function () {
     Queue::fake();
 
-    $mock_data = ContractItem::factory()->withoutType()->count(5)->make();
+    $mockData = ContractItem::factory()->withoutType()->count(5)->make();
 
     $contract = Event::fakeFor(fn () => Contract::factory()->create([
-        'contract_id' => $mock_data->first()->contract_id,
+        'contract_id' => $mockData->first()->contract_id,
     ]));
 
     $esi = Mockery::mock(EsiClient::class);
-    mockEsiTransport($esi, makeEsiResult(array_map(fn ($i) => (object) $i, $mock_data->toArray())));
+    mockEsiTransport($esi, makeEsiResult(array_map(fn ($i) => (object) $i, $mockData->toArray())));
 
     $job = new CharacterContractItemsJob(testCharacter()->character_id, $contract->contract_id);
     $job->executeJob($esi);

--- a/tests/Jobs/Contracts/ContractJobTest.php
+++ b/tests/Jobs/Contracts/ContractJobTest.php
@@ -29,10 +29,10 @@ it('runs with empty response', function () {
 });
 
 it('creates contract job', function () {
-    $mock_data = Contract::factory()->count(5)->make();
+    $mockData = Contract::factory()->count(5)->make();
 
     $esi = Mockery::mock(EsiClient::class);
-    mockEsiTransport($esi, makeEsiResult(array_map(fn ($c) => (object) $c, $mock_data->toArray())));
+    mockEsiTransport($esi, makeEsiResult(array_map(fn ($c) => (object) $c, $mockData->toArray())));
 
     Event::fakeFor(function () use ($esi) {
         $job = new CharacterContractsJob(testCharacter()->character_id);
@@ -44,10 +44,10 @@ it('creates contract job', function () {
 });
 
 it('creates contract job other way', function () {
-    $mock_data = Contract::factory()->count(5)->make();
+    $mockData = Contract::factory()->count(5)->make();
 
     $esi = Mockery::mock(EsiClient::class);
-    mockEsiTransport($esi, makeEsiResult(array_map(fn ($c) => (object) $c, $mock_data->toArray())));
+    mockEsiTransport($esi, makeEsiResult(array_map(fn ($c) => (object) $c, $mockData->toArray())));
 
     Event::fakeFor(function () use ($esi) {
         $job = new CharacterContractsJob(testCharacter()->character_id);

--- a/tests/Jobs/Corporation/CorporationDivisionsJobTest.php
+++ b/tests/Jobs/Corporation/CorporationDivisionsJobTest.php
@@ -45,7 +45,7 @@ it('runs the job', function () {
 
 it('returns the corporation refresh token for a director', function () {
     $scope = 'esi-corporations.read_divisions.v1';
-    $token = updateRefreshTokenScopes(testCharacter()->refresh_token, [$scope]);
+    $token = updateRefreshTokenScopes(testCharacter()->refreshToken, [$scope]);
     $token->save();
 
     CharacterRole::updateOrCreate(

--- a/tests/Jobs/Corporation/CorporationInfoJobTest.php
+++ b/tests/Jobs/Corporation/CorporationInfoJobTest.php
@@ -10,19 +10,19 @@ beforeEach(function () {
 });
 
 test('retrieve test', function () {
-    $mock_data = CorporationInfo::factory()->make([
+    $mockData = CorporationInfo::factory()->make([
         'date_founded' => now()->toDateString(),
     ]);
 
     Bus::fake();
 
     $esi = Mockery::mock(EsiClient::class);
-    mockEsiTransport($esi, makeEsiResult((object) $mock_data->toArray()));
+    mockEsiTransport($esi, makeEsiResult((object) $mockData->toArray()));
 
     $job = new CorporationInfoJob($this->corporation_id);
     $job->executeJob($esi);
 
-    expect(CorporationInfo::where('name', $mock_data->name)->exists())->toBeTrue();
+    expect(CorporationInfo::where('name', $mockData->name)->exists())->toBeTrue();
 });
 
 test('returns early if cached', function () {

--- a/tests/Jobs/Corporation/CorporationMemberTrackingJobTest.php
+++ b/tests/Jobs/Corporation/CorporationMemberTrackingJobTest.php
@@ -8,7 +8,7 @@ use Seatplus\Eveapi\Models\Corporation\CorporationMemberTracking;
 
 beforeEach(function () {
     Event::fakeFor(function () {
-        updateRefreshTokenScopes($this->test_character->refresh_token, ['esi-corporations.track_members.v1'])->save();
+        updateRefreshTokenScopes($this->test_character->refreshToken, ['esi-corporations.track_members.v1'])->save();
         $this->test_character->roles()->update(['roles' => ['Director']]);
         updateCharacterRoles(['Director']);
     });
@@ -27,7 +27,7 @@ test('if job is queued', function () {
 test('retrieve test', function () {
     Queue::fake();
 
-    $mock_data = CorporationMemberTracking::factory()->make([
+    $mockData = CorporationMemberTracking::factory()->make([
         'character_id' => testCharacter()->character_id,
         'corporation_id' => testCharacter()->corporation->corporation_id,
     ]);
@@ -35,10 +35,10 @@ test('retrieve test', function () {
     Bus::fake();
 
     expect(testCharacter()->roles->hasRole('roles', 'Director'))->toBeTrue()
-        ->and(testCharacter()->refresh_token->hasScope('esi-corporations.track_members.v1'))->toBeTrue();
+        ->and(testCharacter()->refreshToken->hasScope('esi-corporations.track_members.v1'))->toBeTrue();
 
     $esi = Mockery::mock(EsiClient::class);
-    mockEsiTransport($esi, makeEsiResult([(object) $mock_data->toArray()]));
+    mockEsiTransport($esi, makeEsiResult([(object) $mockData->toArray()]));
 
     $job = new CorporationMemberTrackingJob(testCharacter()->corporation->corporation_id);
     $job->executeJob($esi);

--- a/tests/Jobs/Seatplus/CharacterBatchJobTest.php
+++ b/tests/Jobs/Seatplus/CharacterBatchJobTest.php
@@ -32,7 +32,7 @@ use Seatplus\Eveapi\Models\RefreshToken;
 it('creates BatchUpdate entries', function () {
     Bus::fake();
 
-    expect(testCharacter())->refresh_token->not()->toBeNull();
+    expect(testCharacter())->refreshToken->not()->toBeNull();
 
     (new CharacterBatchJob(testCharacter()->character_id))->handle();
 
@@ -45,12 +45,12 @@ it('creates BatchUpdate entries', function () {
         ->started_at->toBeInstanceOf(Carbon::class);
 });
 
-it('contains public jobs in batch', function ($public_job) {
+it('contains public jobs in batch', function ($publicJob) {
     Bus::fake();
 
     (new CharacterBatchJob(testCharacter()->character_id))->handle();
 
-    Bus::assertBatched(fn ($batch) => isInstanceOfClassInArray($batch->jobs, $public_job));
+    Bus::assertBatched(fn ($batch) => isInstanceOfClassInArray($batch->jobs, $publicJob));
 })->with([
     CharacterInfoJob::class,
     CharacterAffiliationJob::class,
@@ -59,7 +59,7 @@ it('contains public jobs in batch', function ($public_job) {
 
 it('contains jobs if refresh_token has scope', function (string $scope, array $classes) {
     Queue::fake();
-    updateRefreshTokenScopes($this->test_character->refresh_token, [$scope])->save();
+    updateRefreshTokenScopes($this->test_character->refreshToken, [$scope])->save();
 
     Bus::fake();
 

--- a/tests/Jobs/Seatplus/CorporationUpdateTest.php
+++ b/tests/Jobs/Seatplus/CorporationUpdateTest.php
@@ -12,24 +12,24 @@ use Seatplus\Eveapi\Models\BatchStatistic;
 test('it dispatches jobs if token with role, scope and permission is present', function (
     string $role,
     string $scope,
-    array $job_classes,
-    ?int $corporation_id
+    array $jobClasses,
+    ?int $corporationId
 ) {
     Bus::fake();
 
-    updateRefreshTokenScopes($this->test_character->refresh_token, [$scope])->save();
+    updateRefreshTokenScopes($this->test_character->refreshToken, [$scope])->save();
     $this->test_character->roles()->update(['roles' => ['Director']]);
 
-    (new UpdateCorporation($corporation_id))->handle();
+    (new UpdateCorporation($corporationId))->handle();
 
     // loop through classes and check if jobs that are instance of class are in batch
-    foreach ($job_classes as $job_class) {
+    foreach ($jobClasses as $jobClass) {
         // if class is of type array
-        if (is_array($job_class)) {
-            Bus::assertBatched(function (PendingBatch $batch) use ($job_class) {
+        if (is_array($jobClass)) {
+            Bus::assertBatched(function (PendingBatch $batch) use ($jobClass) {
                 // get array inside the jobs array
                 $jobs = $batch->jobs->first(fn ($job) => is_array($job));
-                $classes = $job_class;
+                $classes = $jobClass;
 
                 // expect lenght of jobs to be equal to classes
                 if (count($jobs) !== count($classes)) {
@@ -37,8 +37,8 @@ test('it dispatches jobs if token with role, scope and permission is present', f
                 }
 
                 // loop through classes and check if jobs that are instance of class are in batch
-                foreach ($classes as $job_class) {
-                    if (! collect($jobs)->first(fn ($job) => $job instanceof $job_class)) {
+                foreach ($classes as $jobClass) {
+                    if (! collect($jobs)->first(fn ($job) => $job instanceof $jobClass)) {
                         return false;
                     }
                 }
@@ -46,7 +46,7 @@ test('it dispatches jobs if token with role, scope and permission is present', f
                 return true;
             });
         } else {
-            Bus::assertBatched(fn ($batch) => $batch->jobs->first(fn ($job) => $job instanceof $job_class));
+            Bus::assertBatched(fn ($batch) => $batch->jobs->first(fn ($job) => $job instanceof $jobClass));
         }
     }
 })->with([

--- a/tests/Jobs/Seatplus/MaintenanceJobTest.php
+++ b/tests/Jobs/Seatplus/MaintenanceJobTest.php
@@ -52,12 +52,12 @@ beforeEach(function () {
     // $this->job = new MaintenanceJob;
 });
 
-it('MaintenanceJob dispatches job: ', function ($hydrate_job) {
+it('MaintenanceJob dispatches job: ', function ($hydrateJob) {
     Bus::fake();
 
     (new MaintenanceJob)->handle();
 
-    Bus::assertBatched(fn ($batch) => $batch->jobs->first(fn ($job) => $job instanceof $hydrate_job));
+    Bus::assertBatched(fn ($batch) => $batch->jobs->first(fn ($job) => $job instanceof $hydrateJob));
 
 })->with([
     GetMissingGroups::class,
@@ -189,7 +189,7 @@ test('get missing location from assets pipe can handle non station or structure 
 
     expect(Location::all())->toHaveCount(0);
 
-    $non_structure_or_station_location = Location::factory()->create([
+    $nonStructureOrStationLocation = Location::factory()->create([
         'location_id' => $type->type_id,
         'locatable_id' => $type->type_id,
         'locatable_type' => Type::class,
@@ -216,7 +216,7 @@ test('get missing location from assets pipe can handle non station or structure 
 });
 
 it('fetches missing types from corporation member tracking', function () {
-    $corporation_member_tracking = Event::fakeFor(fn () => CorporationMemberTracking::factory()->create());
+    $corporationMemberTracking = Event::fakeFor(fn () => CorporationMemberTracking::factory()->create());
 
     $mock = Mockery::mock(GetMissingTypesFromCorporationMemberTracking::class)->makePartial();
 
@@ -224,14 +224,14 @@ it('fetches missing types from corporation member tracking', function () {
     $mock->shouldReceive('batch->add')
         ->once()
         ->with([
-            new ResolveUniverseTypeByIdJob($corporation_member_tracking->ship_type_id),
+            new ResolveUniverseTypeByIdJob($corporationMemberTracking->ship_type_id),
         ]);
 
     $mock->handle();
 });
 
 it('dispatch resolve location job for missing corporation member tracking location', function () {
-    $corporation_member_tracking = Event::fakeFor(fn () => CorporationMemberTracking::factory()->create([
+    $corporationMemberTracking = Event::fakeFor(fn () => CorporationMemberTracking::factory()->create([
         'character_id' => $this->test_character->character_id,
     ]));
 
@@ -241,7 +241,7 @@ it('dispatch resolve location job for missing corporation member tracking locati
     $mock->shouldReceive('batch->add')
         ->once()
         ->with([
-            new ResolveLocationJob($corporation_member_tracking->location_id),
+            new ResolveLocationJob($corporationMemberTracking->location_id),
         ]);
 
     $mock->handle();
@@ -252,7 +252,7 @@ test('get missing location from corporation member tracking pipe can handle non 
 
     expect(Location::all())->toHaveCount(0);
 
-    $non_structure_or_station_location = Location::factory()->create([
+    $nonStructureOrStationLocation = Location::factory()->create([
         'location_id' => $type->type_id,
         'locatable_id' => $type->type_id,
         'locatable_type' => Type::class,
@@ -260,7 +260,7 @@ test('get missing location from corporation member tracking pipe can handle non 
 
     expect(Location::all())->toHaveCount(1);
 
-    $corporation_member_tracking = Event::fakeFor(fn () => CorporationMemberTracking::factory()->create([
+    $corporationMemberTracking = Event::fakeFor(fn () => CorporationMemberTracking::factory()->create([
         'character_id' => $this->test_character->character_id,
         'location_id' => $type->type_id,
     ]));
@@ -274,7 +274,7 @@ test('get missing location from corporation member tracking pipe can handle non 
     $mock->shouldReceive('batch->add')
         ->once()
         ->with([
-            new ResolveLocationJob($corporation_member_tracking->location_id),
+            new ResolveLocationJob($corporationMemberTracking->location_id),
         ]);
 
     $mock->handle();
@@ -298,7 +298,7 @@ it('fetches missing types from wallet transaction', function () {
 });
 
 it('dispatch resolve location job for missing wallet transaction location', function () {
-    $wallet_transaction = Event::fakeFor(fn () => WalletTransaction::factory()->create([
+    $walletTransaction = Event::fakeFor(fn () => WalletTransaction::factory()->create([
         'wallet_transactionable_id' => $this->test_character->character_id,
     ]));
 
@@ -308,7 +308,7 @@ it('dispatch resolve location job for missing wallet transaction location', func
     $mock->shouldReceive('batch->add')
         ->once()
         ->with([
-            new ResolveLocationJob($wallet_transaction->location_id),
+            new ResolveLocationJob($walletTransaction->location_id),
         ]);
 
     $mock->handle();
@@ -319,7 +319,7 @@ test('get missing location from wallet transaction pipe can handle non station o
 
     expect(Location::all())->toHaveCount(0);
 
-    $non_structure_or_station_location = Location::factory()->create([
+    $nonStructureOrStationLocation = Location::factory()->create([
         'location_id' => $type->type_id,
         'locatable_id' => $type->type_id,
         'locatable_type' => Type::class,
@@ -345,7 +345,7 @@ test('get missing location from wallet transaction pipe can handle non station o
 });
 
 it('dispatches character info job for missing member tracking characters', function () {
-    $corporation_member_tracking = Event::fakeFor(fn () => CorporationMemberTracking::factory()->create([
+    $corporationMemberTracking = Event::fakeFor(fn () => CorporationMemberTracking::factory()->create([
         'character_id' => CharacterInfo::factory()->make(),
     ]));
 
@@ -355,14 +355,14 @@ it('dispatches character info job for missing member tracking characters', funct
     $mock->shouldReceive('batch->add')
         ->once()
         ->with([
-            new CharacterInfoJob($corporation_member_tracking->character_id),
+            new CharacterInfoJob($corporationMemberTracking->character_id),
         ]);
 
     $mock->handle();
 });
 
 it('dispatches resolve types job for missing contract item types', function () {
-    $contract_item = Event::fakeFor(function () {
+    $contractItem = Event::fakeFor(function () {
         $contract = Contract::factory()->create();
 
         return ContractItem::factory()->withoutType()->create([
@@ -376,7 +376,7 @@ it('dispatches resolve types job for missing contract item types', function () {
     $mock->shouldReceive('batch->add')
         ->once()
         ->with([
-            new ResolveUniverseTypeByIdJob($contract_item->type_id),
+            new ResolveUniverseTypeByIdJob($contractItem->type_id),
         ]);
 
     $mock->handle();
@@ -406,7 +406,7 @@ test('get missing start location from contracts pipe can handle non station or s
 
     expect(Location::all())->toHaveCount(0);
 
-    $non_structure_or_station_location = Location::factory()->create([
+    $nonStructureOrStationLocation = Location::factory()->create([
         'location_id' => $type->type_id,
         'locatable_id' => $type->type_id,
         'locatable_type' => Type::class,
@@ -505,8 +505,8 @@ it('dispatches resolve universe type by id job for missing types of skillqueue',
 
 it('dispatches mail body job for missing mail bodies', function () {
     Queue::fake();
-    $refresh_token = updateRefreshTokenScopes($this->test_character->refresh_token, ['esi-mail.read_mail.v1']);
-    $refresh_token->save();
+    $refreshToken = updateRefreshTokenScopes($this->test_character->refreshToken, ['esi-mail.read_mail.v1']);
+    $refreshToken->save();
 
     $mail = Event::fakeFor(fn () => Mail::factory(['body' => null])->create());
 

--- a/tests/Jobs/Universe/ResolveLocationJobTest.php
+++ b/tests/Jobs/Universe/ResolveLocationJobTest.php
@@ -12,13 +12,13 @@ beforeEach(function () {
 
 it('runs ResolveLocationService', function () {
     // Arrange
-    $location_id = 100; // use low number to avoid being a potential structure or station
+    $locationId = 100; // use low number to avoid being a potential structure or station
 
-    $refresh_token = updateRefreshTokenScopes($this->test_character->refresh_token, ['esi-universe.read_structures.v1']);
-    $refresh_token->save();
+    $refreshToken = updateRefreshTokenScopes($this->test_character->refreshToken, ['esi-universe.read_structures.v1']);
+    $refreshToken->save();
 
     // Act
-    $job = new ResolveLocationJob($location_id, $refresh_token);
+    $job = new ResolveLocationJob($locationId, $refreshToken);
 
     $job->handle();
 

--- a/tests/Jobs/Universe/ResolveUniverseCategoryByIdJobTest.php
+++ b/tests/Jobs/Universe/ResolveUniverseCategoryByIdJobTest.php
@@ -5,15 +5,15 @@ use Seatplus\Eveapi\Jobs\Universe\ResolveUniverseCategoryByIdJob;
 use Seatplus\Eveapi\Models\Universe\Category;
 
 it('creates category', function () {
-    $mock_data = Category::factory()->make();
+    $mockData = Category::factory()->make();
 
     $esi = Mockery::mock(EsiClient::class);
-    mockEsiTransport($esi, makeEsiResult((object) $mock_data->toArray()));
+    mockEsiTransport($esi, makeEsiResult((object) $mockData->toArray()));
 
-    $job = new ResolveUniverseCategoryByIdJob($mock_data->category_id);
+    $job = new ResolveUniverseCategoryByIdJob($mockData->category_id);
     $job->executeJob($esi);
 
-    expect(Category::where('category_id', $mock_data->category_id)->exists())->toBeTrue();
+    expect(Category::where('category_id', $mockData->category_id)->exists())->toBeTrue();
 });
 
 it('skips db write when response is a cached load', function () {

--- a/tests/Jobs/Universe/ResolveUniverseGroupByIdJobTest.php
+++ b/tests/Jobs/Universe/ResolveUniverseGroupByIdJobTest.php
@@ -5,15 +5,15 @@ use Seatplus\Eveapi\Jobs\Universe\ResolveUniverseGroupByIdJob;
 use Seatplus\Eveapi\Models\Universe\Group;
 
 it('creates group', function () {
-    $mock_data = Group::factory()->make();
+    $mockData = Group::factory()->make();
 
     $esi = Mockery::mock(EsiClient::class);
-    mockEsiTransport($esi, makeEsiResult((object) $mock_data->toArray()));
+    mockEsiTransport($esi, makeEsiResult((object) $mockData->toArray()));
 
-    $job = new ResolveUniverseGroupByIdJob($mock_data->group_id);
+    $job = new ResolveUniverseGroupByIdJob($mockData->group_id);
     $job->executeJob($esi);
 
-    expect(Group::where('group_id', $mock_data->group_id)->exists())->toBeTrue();
+    expect(Group::where('group_id', $mockData->group_id)->exists())->toBeTrue();
 });
 
 it('skips db write when response is a cached load', function () {

--- a/tests/Jobs/Universe/ResolveUniverseStationByIdJobTest.php
+++ b/tests/Jobs/Universe/ResolveUniverseStationByIdJobTest.php
@@ -14,39 +14,39 @@ beforeEach(function () {
 });
 
 it('creates station', function () {
-    $mock_data = Station::factory()->make();
+    $mockData = Station::factory()->make();
 
     $esi = Mockery::mock(EsiClient::class);
-    mockEsiTransport($esi, makeEsiResult((object) $mock_data->toArray()));
+    mockEsiTransport($esi, makeEsiResult((object) $mockData->toArray()));
 
-    $job = new ResolveUniverseStationByIdJob($mock_data->station_id);
+    $job = new ResolveUniverseStationByIdJob($mockData->station_id);
     $job->executeJob($esi);
 
-    expect(Station::where('station_id', $mock_data->station_id)->exists())->toBeTrue();
+    expect(Station::where('station_id', $mockData->station_id)->exists())->toBeTrue();
 });
 
 it('creates location', function () {
-    $mock_data = Station::factory()->make();
+    $mockData = Station::factory()->make();
 
     $esi = Mockery::mock(EsiClient::class);
-    mockEsiTransport($esi, makeEsiResult((object) $mock_data->toArray()));
+    mockEsiTransport($esi, makeEsiResult((object) $mockData->toArray()));
 
-    $job = new ResolveUniverseStationByIdJob($mock_data->station_id);
+    $job = new ResolveUniverseStationByIdJob($mockData->station_id);
     $job->executeJob($esi);
 
-    expect(Location::where('location_id', $mock_data->station_id)->exists())->toBeTrue();
+    expect(Location::where('location_id', $mockData->station_id)->exists())->toBeTrue();
 });
 
 it('creates polymorphic relationship', function () {
-    $mock_data = Station::factory()->make();
+    $mockData = Station::factory()->make();
 
     $esi = Mockery::mock(EsiClient::class);
-    mockEsiTransport($esi, makeEsiResult((object) $mock_data->toArray()));
+    mockEsiTransport($esi, makeEsiResult((object) $mockData->toArray()));
 
-    $job = new ResolveUniverseStationByIdJob($mock_data->station_id);
+    $job = new ResolveUniverseStationByIdJob($mockData->station_id);
     $job->executeJob($esi);
 
-    $location = Location::find($mock_data->station_id);
+    $location = Location::find($mockData->station_id);
 
     expect($location->locatable)->toBeInstanceOf(Station::class);
 });
@@ -61,13 +61,13 @@ it('does not create structure if location id is not in range', function () {
 });
 
 it('skips db write when response is a cached load', function () {
-    $mock_data = Station::factory()->make();
+    $mockData = Station::factory()->make();
 
     $esi = Mockery::mock(EsiClient::class);
     mockEsiTransport($esi, makeEsiResult([], isCachedLoad: true));
 
-    $job = new ResolveUniverseStationByIdJob($mock_data->station_id);
+    $job = new ResolveUniverseStationByIdJob($mockData->station_id);
     $job->executeJob($esi);
 
-    expect(Station::where('station_id', $mock_data->station_id)->exists())->toBeFalse();
+    expect(Station::where('station_id', $mockData->station_id)->exists())->toBeFalse();
 });

--- a/tests/Jobs/Universe/ResolveUniverseStructureByIdJobTest.php
+++ b/tests/Jobs/Universe/ResolveUniverseStructureByIdJobTest.php
@@ -17,39 +17,39 @@ beforeEach(function () {
 });
 
 it('creates structure', function () {
-    $mock_data = Structure::factory()->make();
+    $mockData = Structure::factory()->make();
 
     $esi = Mockery::mock(EsiClient::class);
-    mockEsiTransport($esi, makeEsiResult((object) $mock_data->only(['name', 'owner_id', 'solar_system_id', 'type_id'])));
+    mockEsiTransport($esi, makeEsiResult((object) $mockData->only(['name', 'owner_id', 'solar_system_id', 'type_id'])));
 
-    $job = new ResolveUniverseStructureByIdJob(12345, $mock_data->structure_id);
+    $job = new ResolveUniverseStructureByIdJob(12345, $mockData->structure_id);
     $job->executeJob($esi);
 
-    expect(Structure::where('structure_id', $mock_data->structure_id)->exists())->toBeTrue();
+    expect(Structure::where('structure_id', $mockData->structure_id)->exists())->toBeTrue();
 });
 
 it('creates location', function () {
-    $mock_data = Structure::factory()->make();
+    $mockData = Structure::factory()->make();
 
     $esi = Mockery::mock(EsiClient::class);
-    mockEsiTransport($esi, makeEsiResult((object) $mock_data->only(['name', 'owner_id', 'solar_system_id', 'type_id'])));
+    mockEsiTransport($esi, makeEsiResult((object) $mockData->only(['name', 'owner_id', 'solar_system_id', 'type_id'])));
 
-    $job = new ResolveUniverseStructureByIdJob(12345, $mock_data->structure_id);
+    $job = new ResolveUniverseStructureByIdJob(12345, $mockData->structure_id);
     $job->executeJob($esi);
 
-    expect(Location::where('location_id', $mock_data->structure_id)->exists())->toBeTrue();
+    expect(Location::where('location_id', $mockData->structure_id)->exists())->toBeTrue();
 });
 
 it('creates polymorphic relationship', function () {
-    $mock_data = Structure::factory()->make();
+    $mockData = Structure::factory()->make();
 
     $esi = Mockery::mock(EsiClient::class);
-    mockEsiTransport($esi, makeEsiResult((object) $mock_data->only(['name', 'owner_id', 'solar_system_id', 'type_id'])));
+    mockEsiTransport($esi, makeEsiResult((object) $mockData->only(['name', 'owner_id', 'solar_system_id', 'type_id'])));
 
-    $job = new ResolveUniverseStructureByIdJob(12345, $mock_data->structure_id);
+    $job = new ResolveUniverseStructureByIdJob(12345, $mockData->structure_id);
     $job->executeJob($esi);
 
-    $location = Location::find($mock_data->structure_id);
+    $location = Location::find($mockData->structure_id);
 
     expect($location->locatable)->toBeInstanceOf(Structure::class);
 });

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -127,25 +127,25 @@ function testCharacter()
 function updateRefreshTokenScopes(RefreshToken $refreshToken, array $scopes): RefreshToken
 {
     $jwt = $refreshToken->getRawOriginal('token');
-    $jwt_payload_base64_encoded = explode('.', (string) $jwt)[1];
+    $jwtPayloadBase64Encoded = explode('.', (string) $jwt)[1];
     // create an associative array
-    $jwt_payload = json_decode(JWT::urlsafeB64Decode($jwt_payload_base64_encoded), true);
+    $jwtPayload = json_decode(JWT::urlsafeB64Decode($jwtPayloadBase64Encoded), true);
     // update scopes
-    $jwt_payload['scp'] = $scopes;
+    $jwtPayload['scp'] = $scopes;
     // create a json object
-    $jwt_payload = json_encode($jwt_payload);
+    $jwtPayload = json_encode($jwtPayload);
 
-    $jwt_header = json_encode([
+    $jwtHeader = json_encode([
         'alg' => 'RS256',
         'kid' => 'JWT-Signature-Key',
         'typ' => 'JWT',
     ]);
 
-    $data = JWT::urlsafeB64Encode($jwt_header).'.'.JWT::urlsafeB64Encode($jwt_payload);
+    $data = JWT::urlsafeB64Encode($jwtHeader).'.'.JWT::urlsafeB64Encode($jwtPayload);
 
     $signature = hash_hmac(
         'sha256',
-        base64_encode($jwt_header).'.'.base64_encode($jwt_payload),
+        base64_encode($jwtHeader).'.'.base64_encode($jwtPayload),
         'test'
     );
 
@@ -156,8 +156,8 @@ function updateRefreshTokenScopes(RefreshToken $refreshToken, array $scopes): Re
 
 function updateCharacterRoles(array $roles)
 {
-    $character_roles = testCharacter()->roles;
+    $characterRoles = testCharacter()->roles;
 
-    $character_roles->roles = $roles;
-    $character_roles->save();
+    $characterRoles->roles = $roles;
+    $characterRoles->save();
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -16,7 +16,7 @@ abstract class TestCase extends OrchestraTestCase
 {
     use LazilyRefreshDatabase;
 
-    public CharacterInfo $test_character;
+    public CharacterInfo $testCharacter;
 
     #[\Override]
     protected function setUp(): void

--- a/tests/Unit/Commands/CheckJobsCommandTest.php
+++ b/tests/Unit/Commands/CheckJobsCommandTest.php
@@ -3,16 +3,16 @@
 use Seatplus\Eveapi\Commands\CheckJobsCommand;
 use Seatplus\Eveapi\Services\JobChecker;
 
-it('writes error, warning and success header', function (array $job_checker_result, bool $expectSuccess) {
+it('writes error, warning and success header', function (array $jobCheckerResult, bool $expectSuccess) {
 
-    $job_checker = mock(JobChecker::class, function ($mock) use ($job_checker_result) {
+    $jobChecker = mock(JobChecker::class, function ($mock) use ($jobCheckerResult) {
         $mock->shouldReceive('checkJob')
             ->andReturn(collect([
-                $job_checker_result,
+                $jobCheckerResult,
             ]));
     });
 
-    $this->app->instance(JobChecker::class, $job_checker);
+    $this->app->instance(JobChecker::class, $jobChecker);
 
     $artisan = $this->artisan(CheckJobsCommand::class);
 
@@ -39,7 +39,7 @@ it('writes error, warning and success header', function (array $job_checker_resu
 
 it('throws exception if status is unknown', function () {
 
-    $job_checker = mock(JobChecker::class, function ($mock) {
+    $jobChecker = mock(JobChecker::class, function ($mock) {
         $mock->shouldReceive('checkJob')
             ->andReturn(collect([
                 [
@@ -49,7 +49,7 @@ it('throws exception if status is unknown', function () {
             ]));
     });
 
-    $this->app->instance(JobChecker::class, $job_checker);
+    $this->app->instance(JobChecker::class, $jobChecker);
 
     $this->artisan(CheckJobsCommand::class);
 

--- a/tests/Unit/EveapiServiceProviderTest.php
+++ b/tests/Unit/EveapiServiceProviderTest.php
@@ -73,22 +73,22 @@ it('has no limits for character_batch if queue is high', function () {
 
     // arrange
 
-    $test_class = new RateLimitedTestJob(testCharacter()->refresh_token);
-    $test_class->queue = 'high';
+    $testClass = new RateLimitedTestJob(testCharacter()->refreshToken);
+    $testClass->queue = 'high';
 
-    assertJobRanSuccessfully($test_class);
-    assertJobRanSuccessfully($test_class);
+    assertJobRanSuccessfully($testClass);
+    assertJobRanSuccessfully($testClass);
 });
 
 it('has limits for character_batch if queue is not high', function () {
 
     // arrange
 
-    $test_class = new RateLimitedTestJob(testCharacter()->refresh_token);
-    $test_class->queue = 'default';
+    $testClass = new RateLimitedTestJob(testCharacter()->refreshToken);
+    $testClass->queue = 'default';
 
-    assertJobRanSuccessfully($test_class);
-    assertJobWasReleased($test_class);
+    assertJobRanSuccessfully($testClass);
+    assertJobWasReleased($testClass);
 });
 
 function assertJobRanSuccessfully($testJob)
@@ -135,7 +135,7 @@ class RateLimitedTestJob
 
     public static $handled = false;
 
-    public function __construct(public $refresh_token) {}
+    public function __construct(public $refreshToken) {}
 
     public function handle()
     {

--- a/tests/Unit/Jobs/AllianceContactJobTest.php
+++ b/tests/Unit/Jobs/AllianceContactJobTest.php
@@ -8,7 +8,7 @@ it('returns early if cached', function () {
     $esi = Mockery::mock(EsiClient::class);
     mockEsiTransport($esi, makeEsiResult([], isCachedLoad: true));
 
-    $job = new AllianceContactJob(alliance_id: 99, character_id: 123);
+    $job = new AllianceContactJob(allianceId: 99, characterId: 123);
     $job->executeJob($esi);
 
     expect(Contact::count())->toBe(0);
@@ -24,7 +24,7 @@ it('writes contacts to database on normal execution', function () {
     $esi = Mockery::mock(EsiClient::class);
     mockEsiTransport($esi, makeEsiResult([$contact]));
 
-    $job = new AllianceContactJob(alliance_id: 99, character_id: 123);
+    $job = new AllianceContactJob(allianceId: 99, characterId: 123);
     $job->executeJob($esi);
 
     expect(Contact::count())->toBe(1);
@@ -45,7 +45,7 @@ it('handles multiple pages and writes all contacts', function () {
     $esi->shouldReceive('assertScope')->andReturnNull();
     $esi->shouldReceive('invoke')->andReturn($page1, $page2);
 
-    $job = new AllianceContactJob(alliance_id: 99, character_id: 123);
+    $job = new AllianceContactJob(allianceId: 99, characterId: 123);
     $job->executeJob($esi);
 
     expect(Contact::count())->toBe(2);

--- a/tests/Unit/Jobs/AllianceContactLabelJobTest.php
+++ b/tests/Unit/Jobs/AllianceContactLabelJobTest.php
@@ -8,7 +8,7 @@ it('returns early if cached', function () {
     $esi = Mockery::mock(EsiClient::class);
     mockEsiTransport($esi, makeEsiResult([], isCachedLoad: true));
 
-    $job = new AllianceContactLabelJob(alliance_id: 99, character_id: 123);
+    $job = new AllianceContactLabelJob(allianceId: 99, characterId: 123);
     $job->executeJob($esi);
 
     expect(Label::count())->toBe(0);
@@ -20,7 +20,7 @@ it('writes labels to database on normal execution', function () {
     $esi = Mockery::mock(EsiClient::class);
     mockEsiTransport($esi, makeEsiResult([$label]));
 
-    $job = new AllianceContactLabelJob(alliance_id: 99, character_id: 123);
+    $job = new AllianceContactLabelJob(allianceId: 99, characterId: 123);
     $job->executeJob($esi);
 
     expect(Label::count())->toBe(1);
@@ -38,7 +38,7 @@ it('handles multiple pages and writes all labels', function () {
     $esi->shouldReceive('assertScope')->andReturnNull();
     $esi->shouldReceive('invoke')->andReturn($page1, $page2);
 
-    $job = new AllianceContactLabelJob(alliance_id: 99, character_id: 123);
+    $job = new AllianceContactLabelJob(allianceId: 99, characterId: 123);
     $job->executeJob($esi);
 
     expect(Label::count())->toBe(2);

--- a/tests/Unit/Jobs/CharacterBatchJobTest.php
+++ b/tests/Unit/Jobs/CharacterBatchJobTest.php
@@ -9,13 +9,13 @@ use Seatplus\Eveapi\Models\BatchUpdate;
 use Seatplus\Eveapi\Models\Character\CharacterInfo;
 
 it('discards update if still pending', function () {
-    $batch_update = new BatchUpdate;
+    $batchUpdate = new BatchUpdate;
 
-    $batch_update->is_pending = true;
-    $batch_update->started_at = now();
+    $batchUpdate->is_pending = true;
+    $batchUpdate->started_at = now();
 
     $job = mock(CharacterBatchJob::class)->makePartial();
-    $job->shouldReceive('getBatchUpdate')->andReturn($batch_update);
+    $job->shouldReceive('getBatchUpdate')->andReturn($batchUpdate);
 
     $job->handle();
 
@@ -31,7 +31,7 @@ it('does not discard update if finished long ago', function () {
         'finished_at' => now()->subHour(),
     ]);
 
-    $job = new CharacterBatchJob(testCharacter()->character_id, batch_jobs: [fn () => 'test']);
+    $job = new CharacterBatchJob(testCharacter()->character_id, batchJobs: [fn () => 'test']);
 
     Bus::fake();
 
@@ -52,7 +52,7 @@ it('finally creates BatchStatistices', function () {
         'finished_at' => now()->subDays(1),
     ]);
 
-    $job = new CharacterBatchJob(testCharacter()->character_id, batch_jobs: [fn () => 'test']);
+    $job = new CharacterBatchJob(testCharacter()->character_id, batchJobs: [fn () => 'test']);
 
     Bus::fake();
 
@@ -83,7 +83,7 @@ it('stores queue on batch update', function () {
 
     Bus::fake();
 
-    (new CharacterBatchJob(testCharacter()->character_id, 'high', batch_jobs: [fn () => 'test']))->handle();
+    (new CharacterBatchJob(testCharacter()->character_id, 'high', batchJobs: [fn () => 'test']))->handle();
 
     expect(BatchUpdate::first())->queue->toBe('high');
 });
@@ -93,33 +93,33 @@ it('does not add AllianceContactsJob if no alliance_id is present', function () 
     // Arrange
 
     // make sure refresh token has esi-alliances.read_contacts.v1 scope
-    $refresh_token = updateRefreshTokenScopes(testCharacter()->refresh_token, ['esi-alliances.read_contacts.v1']);
-    Event::fakeFor(fn () => $refresh_token->save());
+    $refreshToken = updateRefreshTokenScopes(testCharacter()->refreshToken, ['esi-alliances.read_contacts.v1']);
+    Event::fakeFor(fn () => $refreshToken->save());
 
     // delete alliance_id from character info
-    $character_affiliation = testCharacter()->character_affiliation;
-    $character_affiliation->alliance_id = null;
+    $characterAffiliation = testCharacter()->characterAffiliation;
+    $characterAffiliation->alliance_id = null;
 
-    Event::fakeFor(fn () => $character_affiliation->save());
+    Event::fakeFor(fn () => $characterAffiliation->save());
 
     // Act
-    $job = new CharacterBatchJob($character_affiliation->character_id);
+    $job = new CharacterBatchJob($characterAffiliation->character_id);
 
     // Assert
 
-    expect($character_affiliation->refresh()->alliance_id)->toBeNull();
+    expect($characterAffiliation->refresh()->alliance_id)->toBeNull();
 
     $reflection = new ReflectionClass($job);
     // get the protected property batch_jobs
-    $property = $reflection->getProperty('batch_jobs');
+    $property = $reflection->getProperty('batchJobs');
 
-    $batch_jobs = $property->getValue($job);
+    $batchJobs = $property->getValue($job);
 
     // flatten the array with nested arrays
-    $batch_jobs = Arr::flatten($batch_jobs);
+    $batchJobs = Arr::flatten($batchJobs);
 
-    foreach ($batch_jobs as $batch_job) {
-        expect($batch_job)->not->toBeInstanceOf(AllianceContactJob::class);
+    foreach ($batchJobs as $batchJob) {
+        expect($batchJob)->not->toBeInstanceOf(AllianceContactJob::class);
     }
 });
 

--- a/tests/Unit/Jobs/CharacterContactJobTest.php
+++ b/tests/Unit/Jobs/CharacterContactJobTest.php
@@ -8,7 +8,7 @@ it('returns early if cached', function () {
     $esi = Mockery::mock(EsiClient::class);
     mockEsiTransport($esi, makeEsiResult([], isCachedLoad: true));
 
-    $job = new CharacterContactJob(character_id: 123);
+    $job = new CharacterContactJob(characterId: 123);
     $job->executeJob($esi);
 
     expect(Contact::count())->toBe(0);
@@ -24,7 +24,7 @@ it('writes contacts to database on normal execution', function () {
     $esi = Mockery::mock(EsiClient::class);
     mockEsiTransport($esi, makeEsiResult([$contact]));
 
-    $job = new CharacterContactJob(character_id: 123);
+    $job = new CharacterContactJob(characterId: 123);
     $job->executeJob($esi);
 
     expect(Contact::count())->toBe(1);
@@ -45,7 +45,7 @@ it('handles multiple pages and writes all contacts', function () {
     $esi->shouldReceive('assertScope')->andReturnNull();
     $esi->shouldReceive('invoke')->andReturn($page1, $page2);
 
-    $job = new CharacterContactJob(character_id: 123);
+    $job = new CharacterContactJob(characterId: 123);
     $job->executeJob($esi);
 
     expect(Contact::count())->toBe(2);

--- a/tests/Unit/Jobs/CharacterContactLabelJobTest.php
+++ b/tests/Unit/Jobs/CharacterContactLabelJobTest.php
@@ -8,7 +8,7 @@ it('returns early if cached', function () {
     $esi = Mockery::mock(EsiClient::class);
     mockEsiTransport($esi, makeEsiResult([], isCachedLoad: true));
 
-    $job = new CharacterContactLabelJob(character_id: 123);
+    $job = new CharacterContactLabelJob(characterId: 123);
     $job->executeJob($esi);
 
     expect(Label::count())->toBe(0);
@@ -20,7 +20,7 @@ it('writes labels to database on normal execution', function () {
     $esi = Mockery::mock(EsiClient::class);
     mockEsiTransport($esi, makeEsiResult([$label]));
 
-    $job = new CharacterContactLabelJob(character_id: 123);
+    $job = new CharacterContactLabelJob(characterId: 123);
     $job->executeJob($esi);
 
     expect(Label::count())->toBe(1);
@@ -38,7 +38,7 @@ it('handles multiple pages and writes all labels', function () {
     $esi->shouldReceive('assertScope')->andReturnNull();
     $esi->shouldReceive('invoke')->andReturn($page1, $page2);
 
-    $job = new CharacterContactLabelJob(character_id: 123);
+    $job = new CharacterContactLabelJob(characterId: 123);
     $job->executeJob($esi);
 
     expect(Label::count())->toBe(2);

--- a/tests/Unit/Jobs/CharacterContractsJobTest.php
+++ b/tests/Unit/Jobs/CharacterContractsJobTest.php
@@ -57,7 +57,7 @@ it('adds follow up jobs to batch if batching', function () {
     ));
 
     $job = mock(CharacterContractsJob::class)->shouldAllowMockingProtectedMethods()->makePartial();
-    $job->character_id = 1;
+    $job->characterId = 1;
     $job->shouldReceive('batching')->once()->andReturnTrue();
     $job->shouldReceive('batch->add')->once();
 

--- a/tests/Unit/Jobs/ContractItemsJobTest.php
+++ b/tests/Unit/Jobs/ContractItemsJobTest.php
@@ -5,7 +5,7 @@ use Seatplus\Eveapi\Jobs\Contracts\CharacterContractItemsJob;
 use Seatplus\Eveapi\Models\Contracts\ContractItem;
 
 it('has tags', function () {
-    $job = new CharacterContractItemsJob(character_id: 1, contract_id: 42);
+    $job = new CharacterContractItemsJob(characterId: 1, contractId: 42);
 
     expect($job->tags())->toBeArray();
 });
@@ -14,7 +14,7 @@ it('stops executing when batch is cancelled', function () {
     $esi = Mockery::mock(EsiClient::class);
 
     $job = mock(CharacterContractItemsJob::class)->shouldAllowMockingProtectedMethods()->makePartial();
-    $job->contract_id = 1;
+    $job->contractId = 1;
     $job->shouldReceive('batching')->once()->andReturn(true);
     $job->shouldReceive('batch->cancelled')->once()->andReturn(true);
 
@@ -25,7 +25,7 @@ it('does stop executing if response is cached', function () {
     $esi = Mockery::mock(EsiClient::class);
     mockEsiTransport($esi, makeEsiResult([], isCachedLoad: true));
 
-    $job = new CharacterContractItemsJob(character_id: 1, contract_id: 1);
+    $job = new CharacterContractItemsJob(characterId: 1, contractId: 1);
     $job->executeJob($esi);
 
     expect(ContractItem::count())->toBe(0);

--- a/tests/Unit/Jobs/CorporationBalanceJobTest.php
+++ b/tests/Unit/Jobs/CorporationBalanceJobTest.php
@@ -30,7 +30,7 @@ it('does not upsert balances when response is cached', function () {
 
 it('returns the corporation refresh token for an accountant', function () {
     $scope = head(config('eveapi.scopes.corporation.wallet'));
-    updateRefreshTokenScopes(testCharacter()->refresh_token, [$scope])->save();
+    updateRefreshTokenScopes(testCharacter()->refreshToken, [$scope])->save();
 
     CharacterRole::updateOrCreate(
         ['character_id' => testCharacter()->character_id],

--- a/tests/Unit/Jobs/CorporationContactJobTest.php
+++ b/tests/Unit/Jobs/CorporationContactJobTest.php
@@ -8,7 +8,7 @@ it('returns early if cached', function () {
     $esi = Mockery::mock(EsiClient::class);
     mockEsiTransport($esi, makeEsiResult([], isCachedLoad: true));
 
-    $job = new CorporationContactJob(corporation_id: 456, character_id: 123);
+    $job = new CorporationContactJob(corporationId: 456, characterId: 123);
     $job->executeJob($esi);
 
     expect(Contact::count())->toBe(0);
@@ -24,7 +24,7 @@ it('writes contacts to database on normal execution', function () {
     $esi = Mockery::mock(EsiClient::class);
     mockEsiTransport($esi, makeEsiResult([$contact]));
 
-    $job = new CorporationContactJob(corporation_id: 456, character_id: 123);
+    $job = new CorporationContactJob(corporationId: 456, characterId: 123);
     $job->executeJob($esi);
 
     expect(Contact::count())->toBe(1);
@@ -45,7 +45,7 @@ it('handles multiple pages and writes all contacts', function () {
     $esi->shouldReceive('assertScope')->andReturnNull();
     $esi->shouldReceive('invoke')->andReturn($page1, $page2);
 
-    $job = new CorporationContactJob(corporation_id: 456, character_id: 123);
+    $job = new CorporationContactJob(corporationId: 456, characterId: 123);
     $job->executeJob($esi);
 
     expect(Contact::count())->toBe(2);

--- a/tests/Unit/Jobs/CorporationContactLabelJobTest.php
+++ b/tests/Unit/Jobs/CorporationContactLabelJobTest.php
@@ -8,7 +8,7 @@ it('returns early if cached', function () {
     $esi = Mockery::mock(EsiClient::class);
     mockEsiTransport($esi, makeEsiResult([], isCachedLoad: true));
 
-    $job = new CorporationContactLabelJob(corporation_id: 123, character_id: 456);
+    $job = new CorporationContactLabelJob(corporationId: 123, characterId: 456);
     $job->executeJob($esi);
 
     expect(Label::count())->toBe(0);
@@ -20,7 +20,7 @@ it('writes labels to database on normal execution', function () {
     $esi = Mockery::mock(EsiClient::class);
     mockEsiTransport($esi, makeEsiResult([$label]));
 
-    $job = new CorporationContactLabelJob(corporation_id: 123, character_id: 456);
+    $job = new CorporationContactLabelJob(corporationId: 123, characterId: 456);
     $job->executeJob($esi);
 
     expect(Label::count())->toBe(1);
@@ -38,7 +38,7 @@ it('handles multiple pages and writes all labels', function () {
     $esi->shouldReceive('assertScope')->andReturnNull();
     $esi->shouldReceive('invoke')->andReturn($page1, $page2);
 
-    $job = new CorporationContactLabelJob(corporation_id: 123, character_id: 456);
+    $job = new CorporationContactLabelJob(corporationId: 123, characterId: 456);
     $job->executeJob($esi);
 
     expect(Label::count())->toBe(2);

--- a/tests/Unit/Jobs/CorporationHistoryJobTest.php
+++ b/tests/Unit/Jobs/CorporationHistoryJobTest.php
@@ -8,19 +8,19 @@ it('checks if the response is cached', function () {
     $esi = Mockery::mock(EsiClient::class);
     mockEsiTransport($esi, makeEsiResult([], isCachedLoad: true));
 
-    $job = new CorporationHistoryJob($character_id = 1);
+    $job = new CorporationHistoryJob($characterId = 1);
     $job->executeJob($esi);
 
     expect(CorporationHistory::count())->toBe(0);
 });
 
 it('has tags', function () {
-    $job = new CorporationHistoryJob($character_id = 1);
+    $job = new CorporationHistoryJob($characterId = 1);
 
     expect($job->tags())->toBe([
         'character',
         'info',
-        'character_id:'.$character_id,
+        'character_id:'.$characterId,
         'corporationhistory',
     ]);
 });

--- a/tests/Unit/Jobs/CorporationWalletJournalByDivisionJobTest.php
+++ b/tests/Unit/Jobs/CorporationWalletJournalByDivisionJobTest.php
@@ -11,7 +11,7 @@ it('returns early if cached', function () {
     $esi = Mockery::mock(EsiClient::class);
     mockEsiTransport($esi, makeEsiResult([], isCachedLoad: true));
 
-    $job = new CorporationWalletJournalByDivisionJob(corporation_id: 456, division: 1);
+    $job = new CorporationWalletJournalByDivisionJob(corporationId: 456, division: 1);
     $job->executeJob($esi);
 
     expect(WalletJournal::count())->toBe(0);
@@ -37,7 +37,7 @@ it('handles multiple pages and writes all journal entries', function () {
     $esi->shouldReceive('assertScope')->andReturnNull();
     $esi->shouldReceive('invoke')->andReturn($page1, $page2);
 
-    $job = new CorporationWalletJournalByDivisionJob(corporation_id: 456, division: 1);
+    $job = new CorporationWalletJournalByDivisionJob(corporationId: 456, division: 1);
     $job->executeJob($esi);
 
     expect(WalletJournal::count())->toBe(2);
@@ -45,7 +45,7 @@ it('handles multiple pages and writes all journal entries', function () {
 
 it('returns the corporation refresh token for an accountant', function () {
     $scope = head(config('eveapi.scopes.corporation.wallet'));
-    updateRefreshTokenScopes(testCharacter()->refresh_token, [$scope])->save();
+    updateRefreshTokenScopes(testCharacter()->refreshToken, [$scope])->save();
 
     CharacterRole::updateOrCreate(
         ['character_id' => testCharacter()->character_id],

--- a/tests/Unit/Jobs/EsiJobTest.php
+++ b/tests/Unit/Jobs/EsiJobTest.php
@@ -42,7 +42,7 @@ it('does not apply auth for public endpoints', function () {
 });
 
 it('injects auth token when getRefreshToken returns a token', function () {
-    $refreshToken = testCharacter()->refresh_token;
+    $refreshToken = testCharacter()->refreshToken;
 
     $authenticatedEsi = Mockery::mock(EsiClient::class);
 
@@ -114,7 +114,7 @@ it('permanently fails the job when token service throws InvalidRefreshTokenExcep
         ->once()
         ->andThrow(new InvalidRefreshTokenException('Token is invalid', 400));
 
-    $refreshToken = testCharacter()->refresh_token;
+    $refreshToken = testCharacter()->refreshToken;
 
     $throttle = Mockery::mock(InvalidTokenThrottleService::class);
     $throttle->shouldReceive('hit')->with($refreshToken->character_id)->once()->andReturn(false);
@@ -144,7 +144,7 @@ it('calls setContext on RecordingEsiClient before executeJob', function () {
 it('does not soft-delete the token when failure count is below threshold', function () {
     $esi = Mockery::mock(EsiClient::class);
 
-    $refreshToken = testCharacter()->refresh_token;
+    $refreshToken = testCharacter()->refreshToken;
 
     $tokenService = Mockery::mock(GetUpToDateRefreshTokenService::class);
     $tokenService->shouldReceive('get')
@@ -165,7 +165,7 @@ it('does not soft-delete the token when failure count is below threshold', funct
 it('soft-deletes the token when failure count reaches the threshold', function () {
     $esi = Mockery::mock(EsiClient::class);
 
-    $refreshToken = testCharacter()->refresh_token;
+    $refreshToken = testCharacter()->refreshToken;
 
     $tokenService = Mockery::mock(GetUpToDateRefreshTokenService::class);
     $tokenService->shouldReceive('get')
@@ -205,7 +205,7 @@ it('rateLimitCharacterId returns null for public endpoints', function () {
 
 it('rateLimitCharacterId returns character_id from refresh token', function () {
     $job = new TestableEsiJob;
-    $job->refreshToken = testCharacter()->refresh_token;
+    $job->refreshToken = testCharacter()->refreshToken;
 
     expect($job->rateLimitCharacterId())->toBe(testCharacter()->character_id);
 });

--- a/tests/Unit/Jobs/KillmailJobTest.php
+++ b/tests/Unit/Jobs/KillmailJobTest.php
@@ -81,8 +81,8 @@ it('adds to batch', function () {
     mockEsiTransport($esi, $data);
 
     $job = mock(KillmailJob::class)->shouldAllowMockingProtectedMethods()->makePartial();
-    $job->killmail_id = $killmail->killmail_id;
-    $job->killmail_hash = $killmail->killmail_hash;
+    $job->killmailId = $killmail->killmail_id;
+    $job->killmailHash = $killmail->killmail_hash;
 
     $job->shouldReceive('batching')->twice()->andReturn(true);
     $job->shouldReceive('batch->add')->twice();

--- a/tests/Unit/Jobs/WalletJournalBaseTest.php
+++ b/tests/Unit/Jobs/WalletJournalBaseTest.php
@@ -43,7 +43,7 @@ it('handles multiple pages correctly', function () {
     expect(WalletJournal::count())->toBe(2);
 });
 
-it('handles contextable type', function ($context_id_type) {
+it('handles contextable type', function ($contextIdType) {
     $data = [CharactersCharacterIdWalletJournalGetItem::from((object) [
         'id' => 12345,
         'date' => now()->toIso8601String(),
@@ -52,7 +52,7 @@ it('handles contextable type', function ($context_id_type) {
         'amount' => 100.0,
         'balance' => 200.0,
         'context_id' => 12345,
-        'context_id_type' => $context_id_type,
+        'context_id_type' => $contextIdType,
     ])];
 
     $esi = Mockery::mock(EsiClient::class);

--- a/tests/Unit/Jobs/WalletTransactionBaseTest.php
+++ b/tests/Unit/Jobs/WalletTransactionBaseTest.php
@@ -8,20 +8,20 @@ use Seatplus\Eveapi\Models\Wallet\WalletTransaction;
 beforeEach(fn () => Queue::fake());
 
 it('sets from_id to latest transaction id minus one when latest transaction exists', function () {
-    $character_id = testCharacter()->character_id;
+    $characterId = testCharacter()->character_id;
 
     WalletTransaction::factory()->create([
-        'wallet_transactionable_id' => $character_id,
+        'wallet_transactionable_id' => $characterId,
         'transaction_id' => 100,
     ]);
 
     $esi = Mockery::mock(EsiClient::class);
     mockEsiTransport($esi, makeEsiResult([]));
 
-    $job = new CharacterWalletTransactionJob($character_id);
+    $job = new CharacterWalletTransactionJob($characterId);
     $job->executeJob($esi);
 
-    $property = (new ReflectionClass($job))->getProperty('from_id');
+    $property = (new ReflectionClass($job))->getProperty('fromId');
 
     expect($property->getValue($job))->toBe(99);
 });
@@ -33,16 +33,16 @@ it('keeps from_id as PHP_INT_MAX when no latest transaction exists', function ()
     $job = new CharacterWalletTransactionJob(testCharacter()->character_id);
     $job->executeJob($esi);
 
-    $property = (new ReflectionClass($job))->getProperty('from_id');
+    $property = (new ReflectionClass($job))->getProperty('fromId');
 
     expect($property->getValue($job))->toBe(PHP_INT_MAX);
 });
 
 it('breaks when transaction_id is equal to the from_id', function () {
-    $character_id = testCharacter()->character_id;
+    $characterId = testCharacter()->character_id;
 
     WalletTransaction::factory()->create([
-        'wallet_transactionable_id' => $character_id,
+        'wallet_transactionable_id' => $characterId,
         'transaction_id' => 100,
     ]);
 
@@ -62,10 +62,10 @@ it('breaks when transaction_id is equal to the from_id', function () {
     $esi = Mockery::mock(EsiClient::class);
     mockEsiTransport($esi, makeEsiResult($transactionData));
 
-    $job = new CharacterWalletTransactionJob($character_id);
+    $job = new CharacterWalletTransactionJob($characterId);
     $job->executeJob($esi);
 
-    $property = (new ReflectionClass($job))->getProperty('from_id');
+    $property = (new ReflectionClass($job))->getProperty('fromId');
 
     expect($property->getValue($job))->not()->toBe(100);
 });

--- a/tests/Unit/Listeners/DispatchGetConstellationByIdTest.php
+++ b/tests/Unit/Listeners/DispatchGetConstellationByIdTest.php
@@ -21,7 +21,7 @@ it('dispatches job when constellation is null', function () {
 
     Queue::assertPushedOn('default',
         ResolveUniverseConstellationByConstellationIdJob::class,
-        fn ($job) => $job->constellation_id === $system->constellation_id
+        fn ($job) => $job->constellationId === $system->constellation_id
     );
 });
 

--- a/tests/Unit/Models/AllianceInfoModelTest.php
+++ b/tests/Unit/Models/AllianceInfoModelTest.php
@@ -7,15 +7,15 @@ use Seatplus\Eveapi\Models\Corporation\CorporationInfo;
 use Seatplus\Eveapi\Models\SsoScopes;
 
 it('has morphable sso scope', function () {
-    $alliance_info = AllianceInfo::factory()->create();
+    $allianceInfo = AllianceInfo::factory()->create();
 
-    $alliance_info->ssoScopes()->save(SsoScopes::factory()->make());
+    $allianceInfo->ssoScopes()->save(SsoScopes::factory()->make());
 
-    expect($alliance_info->refresh()->ssoScopes)->toBeInstanceOf(SsoScopes::class);
+    expect($allianceInfo->refresh()->ssoScopes)->toBeInstanceOf(SsoScopes::class);
 });
 
 it('has character affiliation', function () {
-    $affiliation = $this->test_character->character_affiliation;
+    $affiliation = $this->test_character->characterAffiliation;
 
     if (! $affiliation->alliance_id) {
         $alliance = AllianceInfo::factory()->create();
@@ -34,12 +34,12 @@ it('has character affiliation', function () {
 });
 
 it('has corporations relation', function () {
-    $character_affiliation = $this->test_character->character_affiliation;
-    $character_affiliation->alliance_id = AllianceInfo::factory()->create()->alliance_id;
-    $character_affiliation->save();
+    $characterAffiliation = $this->test_character->characterAffiliation;
+    $characterAffiliation->alliance_id = AllianceInfo::factory()->create()->alliance_id;
+    $characterAffiliation->save();
 
     $corporation = $this->test_character->corporation;
-    $corporation->alliance_id = $character_affiliation->alliance_id;
+    $corporation->alliance_id = $characterAffiliation->alliance_id;
     $corporation->save();
 
     expect($this->test_character->alliance->corporations->first())->toBeInstanceOf(CorporationInfo::class);

--- a/tests/Unit/Models/ApplicationLogModelTest.php
+++ b/tests/Unit/Models/ApplicationLogModelTest.php
@@ -6,7 +6,7 @@ use Seatplus\Eveapi\Models\Character\CharacterInfo;
 it('has causer morph relationshio', function () {
     $application = Application::factory()->create();
 
-    $log = $application->log_entries()->create([
+    $log = $application->logEntries()->create([
         'causer_type' => CharacterInfo::class,
         'causer_id' => test()->test_character->character_id,
         'type' => faker()->randomElement(['decision', 'comment']),

--- a/tests/Unit/Models/ApplicationsModelTest.php
+++ b/tests/Unit/Models/ApplicationsModelTest.php
@@ -51,17 +51,17 @@ test('it has decision count attribute based on log entries', function () {
     ]);
 
     expect($application)
-        ->log_entries->toHaveCount(0)
+        ->logEntries->toHaveCount(0)
         ->decision_count->toBe(0);
 
-    $application->log_entries()->create([
+    $application->logEntries()->create([
         'causer_type' => User::class,
         'causer_id' => 1,
         'type' => 'decision',
         'comment' => 'test_comment',
     ]);
 
-    $application->log_entries()->create([
+    $application->logEntries()->create([
         'causer_type' => User::class,
         'causer_id' => 1,
         'type' => 'comment',
@@ -69,7 +69,7 @@ test('it has decision count attribute based on log entries', function () {
     ]);
 
     expect($application->refresh())
-        ->log_entries->toHaveCount(2)
+        ->logEntries->toHaveCount(2)
         ->decision_count->toBe(1);
 });
 

--- a/tests/Unit/Models/AssetModelTest.php
+++ b/tests/Unit/Models/AssetModelTest.php
@@ -14,75 +14,75 @@ beforeEach(function () {
 });
 
 test('model has types', function () {
-    $test_asset = Asset::factory()->withType()->create();
+    $testAsset = Asset::factory()->withType()->create();
 
     $assets = Asset::has('type')->get();
 
-    expect($assets->contains($test_asset))->toBeTrue();
+    expect($assets->contains($testAsset))->toBeTrue();
 });
 
 test('model misses types', function () {
-    $test_asset = Asset::factory()->create();
+    $testAsset = Asset::factory()->create();
 
     $assets = Asset::has('type')->get();
 
-    expect($assets->contains($test_asset))->toBeFalse();
+    expect($assets->contains($testAsset))->toBeFalse();
 });
 
 test('model has location', function () {
-    $test_asset = Asset::factory()->create();
+    $testAsset = Asset::factory()->create();
 
-    $test_asset->location()->save(Location::factory()->create());
+    $testAsset->location()->save(Location::factory()->create());
 
     $assets = Asset::has('location')->get();
 
-    expect($assets->contains($test_asset))->toBeTrue();
+    expect($assets->contains($testAsset))->toBeTrue();
 });
 
 it('has scope assets location ids', function () {
-    $test_asset = Asset::factory()->create([
+    $testAsset = Asset::factory()->create([
         'location_flag' => 'Hangar',
         'location_type' => 'other',
     ]);
 
     $assets = Asset::query()->assetsLocationIds()->first();
 
-    expect($test_asset->location_id)->toEqual($assets->location_id);
+    expect($testAsset->location_id)->toEqual($assets->location_id);
 });
 
 it('has assetable relationship', function () {
-    $test_asset = Asset::factory()->create([
+    $testAsset = Asset::factory()->create([
         'assetable_id' => $this->test_character->character_id, // CharacterInfo::factory(),
         'assetable_type' => CharacterInfo::class,
     ]);
 
-    expect($test_asset->assetable)->toBeInstanceOf(CharacterInfo::class);
+    expect($testAsset->assetable)->toBeInstanceOf(CharacterInfo::class);
 });
 
 it('has content relationship', function () {
-    $test_asset = Asset::factory()->create([
+    $testAsset = Asset::factory()->create([
         'location_flag' => 'Hangar',
     ]);
 
     // Create Content
-    $test_asset->content()->save(Asset::factory()->create([
+    $testAsset->content()->save(Asset::factory()->create([
         'location_flag' => 'cargo',
     ]));
 
-    expect($test_asset->content->first())->toBeInstanceOf(Asset::class);
+    expect($testAsset->content->first())->toBeInstanceOf(Asset::class);
 });
 
 it('has container relationship', function () {
-    $test_asset = Asset::factory()->create([
+    $testAsset = Asset::factory()->create([
         'location_flag' => 'Hangar',
     ]);
 
     // Create Content
-    $test_asset->content()->save(Asset::factory()->create([
+    $testAsset->content()->save(Asset::factory()->create([
         'location_flag' => 'cargo',
     ]));
 
-    expect($test_asset->content->first()->container)->toBeInstanceOf(Asset::class);
+    expect($testAsset->content->first()->container)->toBeInstanceOf(Asset::class);
 });
 
 it('has in scope', function (string $scope) {

--- a/tests/Unit/Models/BatchStatisticTest.php
+++ b/tests/Unit/Models/BatchStatisticTest.php
@@ -3,18 +3,18 @@
 use Seatplus\Eveapi\Models\BatchStatistic;
 
 it('has duration attribute', function () {
-    $batch_statistic = BatchStatistic::factory()->create([
+    $batchStatistic = BatchStatistic::factory()->create([
         'started_at' => now(),
         'finished_at' => now()->addMinutes(5),
     ]);
 
-    expect($batch_statistic->duration)->toBe(5 * 60);
+    expect($batchStatistic->duration)->toBe(5 * 60);
 });
 
 test('BatchStatistic factory has finished state ', function () {
-    $batch_statistic = BatchStatistic::factory()->finished()->create();
+    $batchStatistic = BatchStatistic::factory()->finished()->create();
 
-    expect($batch_statistic->started_at)->toBeInstanceOf(Carbon\Carbon::class)
-        ->and($batch_statistic->finished_at)->toBeInstanceOf(Carbon\Carbon::class)
-        ->and($batch_statistic->duration)->toBeGreaterThan(0);
+    expect($batchStatistic->started_at)->toBeInstanceOf(Carbon\Carbon::class)
+        ->and($batchStatistic->finished_at)->toBeInstanceOf(Carbon\Carbon::class)
+        ->and($batchStatistic->duration)->toBeGreaterThan(0);
 });

--- a/tests/Unit/Models/BatchUpdateTest.php
+++ b/tests/Unit/Models/BatchUpdateTest.php
@@ -4,7 +4,7 @@ use Carbon\Carbon;
 use Seatplus\Eveapi\Models\BatchUpdate;
 use Seatplus\Eveapi\Models\Character\CharacterInfo;
 
-dataset('batch_update', function () {
+dataset('batchUpdate', function () {
     yield fn () => BatchUpdate::create([
         'batchable_id' => CharacterInfo::first()->character_id,
         'batchable_type' => CharacterInfo::class,
@@ -13,18 +13,18 @@ dataset('batch_update', function () {
 
 it('has has batchable morph to relationship', function ($batch) {
     expect($batch)->batchable->toBeInstanceOf(CharacterInfo::class);
-})->with('batch_update');
+})->with('batchUpdate');
 
-test('character has batch_update relationship ', function ($batch) {
-    expect(CharacterInfo::first())->batch_update->toBeInstanceOf(BatchUpdate::class);
-})->with('batch_update');
+test('character has batchUpdate relationship ', function ($batch) {
+    expect(CharacterInfo::first())->batchUpdate->toBeInstanceOf(BatchUpdate::class);
+})->with('batchUpdate');
 
 it('has isPending attribute and scope', function ($batch) {
     expect($batch)->is_pending->toBeFalse();
 
     // check the scope
-    $query_result = BatchUpdate::query()->pending()->get();
-    expect($query_result)->toHaveCount(0);
+    $queryResult = BatchUpdate::query()->pending()->get();
+    expect($queryResult)->toHaveCount(0);
 
     // make it pending by adding a start at
     $batch->started_at = now()->subMinute();
@@ -33,8 +33,8 @@ it('has isPending attribute and scope', function ($batch) {
     expect($batch)->is_pending->toBeTrue();
 
     // now scope should return 1
-    $query_result = BatchUpdate::query()->pending()->get();
-    expect($query_result)->toHaveCount(1);
+    $queryResult = BatchUpdate::query()->pending()->get();
+    expect($queryResult)->toHaveCount(1);
 
     // now finish it
     $batch->started_at = now()->subMinutes(2);
@@ -47,9 +47,9 @@ it('has isPending attribute and scope', function ($batch) {
         ->finished_at->toBeInstanceOf(Carbon::class);
 
     // check the scope, should be 0
-    $query_result = BatchUpdate::query()->pending()->get();
-    expect($query_result)->toHaveCount(0);
-})->with('batch_update');
+    $queryResult = BatchUpdate::query()->pending()->get();
+    expect($queryResult)->toHaveCount(0);
+})->with('batchUpdate');
 
 it('filters by character scope', function (BatchUpdate $batchUpdate) {
 
@@ -57,4 +57,4 @@ it('filters by character scope', function (BatchUpdate $batchUpdate) {
 
     expect($result)->toHaveCount(1)
         ->and($result->first()->is($batchUpdate))->toBeTrue();
-})->with('batch_update');
+})->with('batchUpdate');

--- a/tests/Unit/Models/CharacterInfoTest.php
+++ b/tests/Unit/Models/CharacterInfoTest.php
@@ -19,22 +19,22 @@ beforeEach(function () {
 });
 
 test('character has refresh token relation test', function () {
-    expect($this->test_character->refresh_token)->toBeInstanceOf(RefreshToken::class);
+    expect($this->test_character->refreshToken)->toBeInstanceOf(RefreshToken::class);
 });
 
 test('character has alliance relation test', function () {
     $faker = Factory::create();
 
-    $alliance_id = $faker->numberBetween(99000000, 100000000);
+    $allianceId = $faker->numberBetween(99000000, 100000000);
 
     $affiliation = CharacterAffiliation::factory()->create([
-        'alliance_id' => $alliance_id,
+        'alliance_id' => $allianceId,
     ]);
 
     $character = $affiliation->character()->save(CharacterInfo::factory()->create());
 
     $affiliation->alliance()->associate(AllianceInfo::factory()->create([
-        'alliance_id' => $alliance_id,
+        'alliance_id' => $allianceId,
     ]));
 
     expect($character->alliance)->toBeInstanceOf(AllianceInfo::class);
@@ -90,10 +90,10 @@ test('character has balance relationship', function () {
     expect($this->test_character->refresh()->balance)->toBeInstanceOf(Balance::class);
 });
 
-it('has skill_queues relationship', function () {
+it('has skillQueues relationship', function () {
     SkillQueue::factory()->create([
         'character_id' => $this->test_character->character_id,
     ]);
 
-    expect($this->test_character->refresh()->skill_queues->first())->toBeInstanceOf(SkillQueue::class);
+    expect($this->test_character->refresh()->skillQueues->first())->toBeInstanceOf(SkillQueue::class);
 });

--- a/tests/Unit/Models/CharacterRolesTest.php
+++ b/tests/Unit/Models/CharacterRolesTest.php
@@ -8,41 +8,41 @@ test('character has character roles relation test', function () {
 });
 
 test('character role has character relation test', function () {
-    $character_role = $this->test_character->roles;
+    $characterRole = $this->test_character->roles;
 
-    expect($character_role->character)->toBeInstanceOf(CharacterInfo::class);
+    expect($characterRole->character)->toBeInstanceOf(CharacterInfo::class);
 });
 
 test('has role test', function () {
-    $character_role = CharacterRole::factory()->make([
+    $characterRole = CharacterRole::factory()->make([
         'roles' => ['Contract_Manager'],
     ]);
 
-    expect($character_role->hasRole('roles', 'Contract_Manager'))->toBeTrue();
+    expect($characterRole->hasRole('roles', 'Contract_Manager'))->toBeTrue();
 });
 
 test('has director role test', function () {
-    $character_role = CharacterRole::factory()->make([
+    $characterRole = CharacterRole::factory()->make([
         'roles' => ['Contract_Manager', 'Director'],
     ]);
 
-    expect($character_role->hasRole('roles', 'Hangar_Query_3'))->toBeTrue();
+    expect($characterRole->hasRole('roles', 'Hangar_Query_3'))->toBeTrue();
 });
 
 test('has no role in scope', function () {
-    $character_role = CharacterRole::factory()->make([
+    $characterRole = CharacterRole::factory()->make([
         'roles' => ['Contract_Manager', 'Director'],
         'roles_at_hq' => ['Hangar_Query_3'],
     ]);
 
-    expect($character_role->hasRole('roles_at_hq', 'Contract_Manager'))->toBeFalse();
+    expect($characterRole->hasRole('roles_at_hq', 'Contract_Manager'))->toBeFalse();
 });
 
 it('returns false if scope is null', function () {
-    $character_role = CharacterRole::factory()->make([
+    $characterRole = CharacterRole::factory()->make([
         'roles' => ['Contract_Manager', 'Director'],
         'roles_at_hq' => null,
     ]);
 
-    expect($character_role->hasRole('roles_at_hq', 'Contract_Manager'))->toBeFalse();
+    expect($characterRole->hasRole('roles_at_hq', 'Contract_Manager'))->toBeFalse();
 });

--- a/tests/Unit/Models/ContactTest.php
+++ b/tests/Unit/Models/ContactTest.php
@@ -12,9 +12,9 @@ use Seatplus\Eveapi\Models\Corporation\CorporationInfo;
 beforeEach(function () {
     $alliance = AllianceInfo::factory()->create();
 
-    $test_corporation = $this->test_character->corporation;
-    $test_corporation->alliance_id = $alliance->alliance_id;
-    $test_corporation->save();
+    $testCorporation = $this->test_character->corporation;
+    $testCorporation->alliance_id = $alliance->alliance_id;
+    $testCorporation->save();
 
     $this->test_character = $this->test_character->refresh();
 });
@@ -72,9 +72,9 @@ test('contact has label', function () {
 
     expect($contact->labels)->toHaveCount(0);
 
-    $contact_label = new ContactLabel(['contact_id' => $contact->id, 'label_id' => 1]);
+    $contactLabel = new ContactLabel(['contact_id' => $contact->id, 'label_id' => 1]);
 
-    $contact_label->save();
+    $contactLabel->save();
 
     $label = Label::factory()->create([
         'labelable_id' => $this->test_character->character_id,
@@ -85,13 +85,13 @@ test('contact has label', function () {
     $this->assertNotNull(ContactLabel::first()->label_name);
 });
 
-it('has has affiliation relationship', function (string $contact_type) {
+it('has has affiliation relationship', function (string $contactType) {
     $affiliation = CharacterAffiliation::factory()->create([
         'alliance_id' => faker()->numberBetween(99000000, 100000000),
         'faction_id' => faker()->numberBetween(500000, 1000000),
     ]);
 
-    $contact_id = match ($contact_type) {
+    $contactId = match ($contactType) {
         'character' => $affiliation->character_id,
         'corporation' => $affiliation->corporation_id,
         'alliance' => $affiliation->alliance_id,
@@ -99,8 +99,8 @@ it('has has affiliation relationship', function (string $contact_type) {
     };
 
     Contact::factory()->create([
-        'contact_id' => $contact_id,
-        'contact_type' => $contact_type,
+        'contact_id' => $contactId,
+        'contact_type' => $contactType,
         'standing' => 10.0,
         'contactable_id' => $this->test_character->character_id,
         'contactable_type' => CharacterInfo::class,

--- a/tests/Unit/Models/ContractModelTest.php
+++ b/tests/Unit/Models/ContractModelTest.php
@@ -11,11 +11,11 @@ use Seatplus\Eveapi\Models\Universe\Station;
 use Seatplus\Eveapi\Models\Universe\System;
 use Seatplus\Eveapi\Models\Universe\Type;
 
-it('has inRegionScope', function (string $location_id) {
+it('has inRegionScope', function (string $locationId) {
     expect(Contract::all())->toHaveCount(0);
 
-    $test_contract = Contract::factory()->create([
-        $location_id => Location::factory()->create([
+    $testContract = Contract::factory()->create([
+        $locationId => Location::factory()->create([
             'locatable_type' => Station::class,
             'locatable_id' => Station::factory()->create([
                 'system_id' => System::factory()->create([
@@ -27,23 +27,23 @@ it('has inRegionScope', function (string $location_id) {
         ]),
     ]);
 
-    $region_id = match ($location_id) {
-        'start_location_id' => $test_contract->start_location->locatable->system->region->region_id,
-        'end_location_id' => $test_contract->end_location->locatable->system->region->region_id
+    $regionId = match ($locationId) {
+        'start_location_id' => $testContract->startLocation->locatable->system->region->region_id,
+        'end_location_id' => $testContract->endLocation->locatable->system->region->region_id
     };
 
-    expect(Contract::query()->filterByRegionIds($region_id)->get())->toHaveCount(1)
-        ->and(Contract::query()->filterByRegionIds($region_id + 1)->get())->toHaveCount(0);
+    expect(Contract::query()->filterByRegionIds($regionId)->get())->toHaveCount(1)
+        ->and(Contract::query()->filterByRegionIds($regionId + 1)->get())->toHaveCount(0);
 })->with([
     'start_location_id',
     'end_location_id',
 ]);
 
-it('has inSystemScope', function (string $location_id) {
+it('has inSystemScope', function (string $locationId) {
     expect(Contract::all())->toHaveCount(0);
 
-    $test_contract = Contract::factory()->create([
-        $location_id => Location::factory()->create([
+    $testContract = Contract::factory()->create([
+        $locationId => Location::factory()->create([
             'locatable_type' => Station::class,
             'locatable_id' => Station::factory()->create([
                 'system_id' => System::factory(),
@@ -51,13 +51,13 @@ it('has inSystemScope', function (string $location_id) {
         ]),
     ]);
 
-    $system_id = match ($location_id) {
-        'start_location_id' => $test_contract->start_location->locatable->system->system_id,
-        'end_location_id' => $test_contract->end_location->locatable->system->system_id
+    $systemId = match ($locationId) {
+        'start_location_id' => $testContract->startLocation->locatable->system->system_id,
+        'end_location_id' => $testContract->endLocation->locatable->system->system_id
     };
 
-    expect(Contract::query()->filterBySystemIds($system_id)->get())->toHaveCount(1)
-        ->and(Contract::query()->filterBySystemIds($system_id + 1)->get())->toHaveCount(0);
+    expect(Contract::query()->filterBySystemIds($systemId)->get())->toHaveCount(1)
+        ->and(Contract::query()->filterBySystemIds($systemId + 1)->get())->toHaveCount(0);
 })->with([
     'start_location_id',
     'end_location_id',
@@ -112,9 +112,9 @@ it('has ofCategories scope', function () {
 
 });
 
-it('has assignee', function (int $assignee_id) {
+it('has assignee', function (int $assigneeId) {
     $contract = Contract::factory()->create([
-        'assignee_id' => $assignee_id,
+        'assignee_id' => $assigneeId,
     ]);
 
     expect($contract->assignee)->not()->toBeNull();

--- a/tests/Unit/Models/CorporationInfoTest.php
+++ b/tests/Unit/Models/CorporationInfoTest.php
@@ -32,10 +32,10 @@ test('database row is created', function () {
 test('create character corporation releation', function () {
     $character = CharacterInfo::factory()->make();
 
-    $character_affiliation = $character->character_affiliation()->save(CharacterAffiliation::factory()->make());
+    $characterAffiliation = $character->characterAffiliation()->save(CharacterAffiliation::factory()->make());
 
-    $character_affiliation->corporation()->associate(CorporationInfo::factory()->create([
-        'corporation_id' => $character_affiliation->corporation_id,
+    $characterAffiliation->corporation()->associate(CorporationInfo::factory()->create([
+        'corporation_id' => $characterAffiliation->corporation_id,
     ]));
 
     $this->assertEquals(
@@ -60,39 +60,39 @@ test('create many character relation', function () {
 });
 
 it('has morphable sso scope', function () {
-    $corporation_info = CorporationInfo::factory()
+    $corporationInfo = CorporationInfo::factory()
         ->hasSsoScopes()
         ->create();
 
-    // $corporation_info->ssoScopes()->save(SsoScopes::factory()->make());
+    // $corporationInfo->ssoScopes()->save(SsoScopes::factory()->make());
 
-    expect($corporation_info->refresh()->ssoScopes)->toBeInstanceOf(SsoScopes::class);
+    expect($corporationInfo->refresh()->ssoScopes)->toBeInstanceOf(SsoScopes::class);
 });
 
 it('has recruits relationship', function () {
-    $corporation_info = CorporationInfo::factory()->create();
+    $corporationInfo = CorporationInfo::factory()->create();
 
     $app = Application::factory()->count(5)->create([
-        'corporation_id' => $corporation_info->corporation_id,
+        'corporation_id' => $corporationInfo->corporation_id,
     ]);
 
-    foreach ($corporation_info->refresh()->candidates as $candidate) {
+    foreach ($corporationInfo->refresh()->candidates as $candidate) {
         expect($candidate)->toBeInstanceOf(Application::class);
     }
 
-    expect($corporation_info->refresh()->candidates->count())->toEqual(5);
+    expect($corporationInfo->refresh()->candidates->count())->toEqual(5);
 });
 
 it('has alliance relationship', function () {
-    $corporation_info = CorporationInfo::factory()->create([
+    $corporationInfo = CorporationInfo::factory()->create([
         'alliance_id' => AllianceInfo::factory(),
     ]);
 
-    expect($corporation_info->alliance)->toBeInstanceOf(AllianceInfo::class);
+    expect($corporationInfo->alliance)->toBeInstanceOf(AllianceInfo::class);
 });
 
 it('has members relationship', function () {
-    $member_tracking = CorporationMemberTracking::factory()->create([
+    $memberTracking = CorporationMemberTracking::factory()->create([
         'character_id' => $this->test_character->character_id,
         'corporation_id' => $this->test_character->corporation->corporation_id,
     ]);
@@ -124,5 +124,5 @@ it('has wallet transactions relationship', function () {
         'wallet_transactionable_type' => CorporationInfo::class,
     ]);
 
-    expect($this->test_character->corporation->refresh()->wallet_transactions->first())->toBeInstanceOf(WalletTransaction::class);
+    expect($this->test_character->corporation->refresh()->walletTransactions->first())->toBeInstanceOf(WalletTransaction::class);
 });

--- a/tests/Unit/Models/GlobalSettingsTest.php
+++ b/tests/Unit/Models/GlobalSettingsTest.php
@@ -3,18 +3,18 @@
 use Seatplus\Eveapi\Exceptions\SettingException;
 
 test('set global setting', function () {
-    $test_value = 'settingTest';
-    setting(['test', $test_value]);
+    $testValue = 'settingTest';
+    setting(['test', $testValue]);
 
     $this->assertDatabaseHas('global_settings', [
         'name' => 'test',
     ]);
 
-    expect(setting('test'))->toEqual($test_value);
+    expect(setting('test'))->toEqual($testValue);
 });
 
 test('get global setting', function () {
-    $testing_value = bin2hex(random_bytes(10));
+    $testingValue = bin2hex(random_bytes(10));
 
     // 1. try to get a non set setting, returning null
     $value = setting('test');
@@ -23,11 +23,11 @@ test('get global setting', function () {
 
     // 2. set setting and expect the setting to return the previously set value.
 
-    $value = setting(['test', $testing_value]);
+    $value = setting(['test', $testingValue]);
 
     $this->assertNotNull($value);
 
-    expect($testing_value)->toEqual($value);
+    expect($testingValue)->toEqual($value);
 
     $this->assertDatabaseHas('global_settings', [
         'name' => 'test',

--- a/tests/Unit/Models/KillmailItemModelTest.php
+++ b/tests/Unit/Models/KillmailItemModelTest.php
@@ -3,49 +3,49 @@
 use Seatplus\Eveapi\Models\Killmails\KillmailItem;
 
 it('has a has_content attribute', function () {
-    $killmail_item = KillmailItem::query()->create([
+    $killmailItem = KillmailItem::query()->create([
         'location_id' => 123,
         'location_flag' => 'everything_else',
         'quantity' => 1,
         'type_id' => 123,
     ]);
 
-    expect($killmail_item->has_content)->toBeFalse();
+    expect($killmailItem->has_content)->toBeFalse();
 
     // create content
     KillmailItem::query()->create([
-        'location_id' => $killmail_item->id,
+        'location_id' => $killmailItem->id,
         'location_flag' => 'everything_else',
         'quantity' => 1,
         'type_id' => 123,
     ]);
 
-    expect($killmail_item->refresh()->has_content)->toBeTrue();
+    expect($killmailItem->refresh()->has_content)->toBeTrue();
 });
 
 it('has a content relationship', function () {
-    $killmail_item = KillmailItem::query()->create([
+    $killmailItem = KillmailItem::query()->create([
         'location_id' => 123,
         'location_flag' => 'everything_else',
         'quantity' => 1,
         'type_id' => 123,
     ]);
 
-    expect($killmail_item->content)->toBeEmpty();
+    expect($killmailItem->content)->toBeEmpty();
 
     // create content
     KillmailItem::query()->create([
-        'location_id' => $killmail_item->id,
+        'location_id' => $killmailItem->id,
         'location_flag' => 'everything_else',
         'quantity' => 1,
         'type_id' => 123,
     ]);
 
-    expect($killmail_item->refresh()->content)->toHaveCount(1);
+    expect($killmailItem->refresh()->content)->toHaveCount(1);
 });
 
 it('deletes content', function () {
-    $killmail_item = KillmailItem::query()->create([
+    $killmailItem = KillmailItem::query()->create([
         'location_id' => 123,
         'location_flag' => 'everything_else',
         'quantity' => 1,
@@ -54,15 +54,15 @@ it('deletes content', function () {
 
     // create content
     $content = KillmailItem::query()->create([
-        'location_id' => $killmail_item->id,
+        'location_id' => $killmailItem->id,
         'location_flag' => 'everything_else',
         'quantity' => 1,
         'type_id' => 123,
     ]);
 
-    expect($killmail_item->refresh()->content)->toHaveCount(1);
+    expect($killmailItem->refresh()->content)->toHaveCount(1);
 
-    $killmail_item->delete();
+    $killmailItem->delete();
 
     expect(KillmailItem::count())->toBe(0);
 });

--- a/tests/Unit/Models/LocationRefreshTokenModelTest.php
+++ b/tests/Unit/Models/LocationRefreshTokenModelTest.php
@@ -33,5 +33,5 @@ it('belongs to a refresh token', function () {
             'resolved' => true,
         ]);
 
-    expect($locationRefreshToken->refresh_token->character_id)->toBe(testCharacter()->character_id);
+    expect($locationRefreshToken->refreshToken->character_id)->toBe(testCharacter()->character_id);
 });

--- a/tests/Unit/Models/MailTest.php
+++ b/tests/Unit/Models/MailTest.php
@@ -9,14 +9,14 @@ test('character has mails test', function () {
     expect($this->test_character->mails)->toHaveCount(0);
 
     $mail = Event::fakeFor(fn () => Mail::factory()->create());
-    $mail_receipient = Event::fakeFor(fn () => MailRecipients::factory()->create([
+    $mailReceipient = Event::fakeFor(fn () => MailRecipients::factory()->create([
         'mail_id' => $mail->id,
         'receivable_id' => $this->test_character->character_id,
         'receivable_type' => CharacterInfo::class,
     ]));
 
-    expect($mail_receipient->mail)->toBeInstanceOf(Mail::class);
-    expect($mail_receipient->receivable)->toBeInstanceOf(CharacterInfo::class);
+    expect($mailReceipient->mail)->toBeInstanceOf(Mail::class);
+    expect($mailReceipient->receivable)->toBeInstanceOf(CharacterInfo::class);
 
     $character = $this->test_character->refresh();
 

--- a/tests/Unit/Models/RefreshTokenModelTest.php
+++ b/tests/Unit/Models/RefreshTokenModelTest.php
@@ -6,23 +6,23 @@ use Seatplus\Eveapi\Models\Corporation\CorporationInfo;
 use Seatplus\Eveapi\Models\RefreshToken;
 
 it('has character relationship', function () {
-    expect($this->test_character->refresh_token->character)->toBeInstanceOf(CharacterInfo::class);
+    expect($this->test_character->refreshToken->character)->toBeInstanceOf(CharacterInfo::class);
 });
 
 it('has corporation relationship', function () {
-    expect($this->test_character->refresh_token->corporation)->toBeInstanceOf(CorporationInfo::class);
+    expect($this->test_character->refreshToken->corporation)->toBeInstanceOf(CorporationInfo::class);
 });
 
 it('only returns token if it is not already considered expired', function () {
-    $refresh_token = RefreshToken::factory()->make();
+    $refreshToken = RefreshToken::factory()->make();
 
-    expect($refresh_token)
+    expect($refreshToken)
         ->expires_on->timestamp->toBeGreaterThan(Illuminate\Support\Carbon::now()->timestamp)
         ->token->toBeString();
 
-    $refresh_token->expires_on = Carbon::now()->subMinutes(2);
+    $refreshToken->expires_on = Carbon::now()->subMinutes(2);
 
-    expect($refresh_token)
+    expect($refreshToken)
         ->expires_on->timestamp->toBeLessThan(Illuminate\Support\Carbon::now()->timestamp)
         ->token->toBeNull();
 });

--- a/tests/Unit/Models/SsoScopesModelTest.php
+++ b/tests/Unit/Models/SsoScopesModelTest.php
@@ -4,13 +4,13 @@ use Seatplus\Eveapi\Models\Alliance\AllianceInfo;
 use Seatplus\Eveapi\Models\SsoScopes;
 
 test('one can set an alliance relationship from sso scope model', function () {
-    $alliance_info = AllianceInfo::factory()->create();
+    $allianceInfo = AllianceInfo::factory()->create();
 
-    $alliance_info->ssoScopes()->save(SsoScopes::factory()->make());
+    $allianceInfo->ssoScopes()->save(SsoScopes::factory()->make());
 
     $sso = SsoScopes::factory()->create([
         'morphable_type' => AllianceInfo::class,
-        'morphable_id' => $alliance_info->alliance_id,
+        'morphable_id' => $allianceInfo->alliance_id,
     ]);
 
     expect($sso->refresh()->morphable)->toBeInstanceOf(AllianceInfo::class);

--- a/tests/Unit/Models/WalletJournalTest.php
+++ b/tests/Unit/Models/WalletJournalTest.php
@@ -5,16 +5,16 @@ use Seatplus\Eveapi\Models\Character\CharacterInfo;
 use Seatplus\Eveapi\Models\Wallet\WalletJournal;
 
 test('character has wallet journal test', function () {
-    expect($this->test_character->wallet_journals)->toHaveCount(0);
+    expect($this->test_character->walletJournals)->toHaveCount(0);
 
-    $wallet_journal = Event::fakeFor(fn () => WalletJournal::factory()->create([
+    $walletJournal = Event::fakeFor(fn () => WalletJournal::factory()->create([
         'wallet_journable_id' => $this->test_character->character_id,
         'wallet_journable_type' => CharacterInfo::class,
     ]));
 
-    expect($wallet_journal->wallet_journable)->toBeInstanceOf(CharacterInfo::class);
+    expect($walletJournal->walletJournable)->toBeInstanceOf(CharacterInfo::class);
 
     $character = $this->test_character->refresh();
-    expect($character->wallet_journals)->toHaveCount(1);
-    expect($character->wallet_journals->first())->toBeInstanceOf(WalletJournal::class);
+    expect($character->walletJournals)->toHaveCount(1);
+    expect($character->walletJournals->first())->toBeInstanceOf(WalletJournal::class);
 });

--- a/tests/Unit/Models/WalletTransactionTest.php
+++ b/tests/Unit/Models/WalletTransactionTest.php
@@ -7,30 +7,30 @@ use Seatplus\Eveapi\Models\Universe\Type;
 use Seatplus\Eveapi\Models\Wallet\WalletTransaction;
 
 test('character has wallet journal test', function () {
-    expect($this->test_character->wallet_transactions)->toHaveCount(0);
+    expect($this->test_character->walletTransactions)->toHaveCount(0);
 
-    $wallet_transaction = Event::fakeFor(fn () => WalletTransaction::factory()->create([
+    $walletTransaction = Event::fakeFor(fn () => WalletTransaction::factory()->create([
         'wallet_transactionable_id' => $this->test_character->character_id,
         'wallet_transactionable_type' => CharacterInfo::class,
     ]));
 
-    expect($wallet_transaction->wallet_transactionable)->toBeInstanceOf(CharacterInfo::class);
+    expect($walletTransaction->walletTransactionable)->toBeInstanceOf(CharacterInfo::class);
 
     $character = $this->test_character->refresh();
-    expect($character->wallet_transactions)->toHaveCount(1);
-    expect($character->wallet_transactions->first())->toBeInstanceOf(WalletTransaction::class);
+    expect($character->walletTransactions)->toHaveCount(1);
+    expect($character->walletTransactions->first())->toBeInstanceOf(WalletTransaction::class);
 });
 
 test('corporation has relationships test', function () {
-    expect($this->test_character->wallet_transactions)->toHaveCount(0);
+    expect($this->test_character->walletTransactions)->toHaveCount(0);
 
-    $wallet_transaction = Event::fakeFor(fn () => WalletTransaction::factory()->create([
+    $walletTransaction = Event::fakeFor(fn () => WalletTransaction::factory()->create([
         'wallet_transactionable_id' => $this->test_character->character_id,
         'wallet_transactionable_type' => CharacterInfo::class,
         'type_id' => Type::factory()->create(),
         'location_id' => Location::factory()->create(),
     ]));
 
-    expect($wallet_transaction->type)->toBeInstanceOf(Type::class);
-    expect($wallet_transaction->location)->toBeInstanceOf(Location::class);
+    expect($walletTransaction->type)->toBeInstanceOf(Type::class);
+    expect($walletTransaction->location)->toBeInstanceOf(Location::class);
 });

--- a/tests/Unit/Services/DispatchIndividualUpdateServiceTest.php
+++ b/tests/Unit/Services/DispatchIndividualUpdateServiceTest.php
@@ -4,16 +4,16 @@ use Illuminate\Support\Facades\Queue;
 use Seatplus\Eveapi\Services\DispatchIndividualUpdate;
 
 it('dispatches job', function (string $job) {
-    $refresh_token = $this->test_character->refresh_token;
+    $refreshToken = $this->test_character->refreshToken;
     // $job = 'character.assets';
 
     Queue::fake();
 
-    (new DispatchIndividualUpdate($refresh_token))->execute($job);
+    (new DispatchIndividualUpdate($refreshToken))->execute($job);
 
-    $job_class = config('eveapi.jobs')[$job];
+    $jobClass = config('eveapi.jobs')[$job];
 
-    Queue::assertPushedOn('high', $job_class);
+    Queue::assertPushedOn('high', $jobClass);
 })->with([
     'character.assets',
     'corporation.member_tracking',

--- a/tests/Unit/Services/FindCorporationRefreshTokenTest.php
+++ b/tests/Unit/Services/FindCorporationRefreshTokenTest.php
@@ -4,52 +4,52 @@ use Seatplus\Eveapi\Models\Character\CharacterRole;
 use Seatplus\Eveapi\Services\FindCorporationRefreshToken;
 
 it('returns no RefreshToken if character has no role', function () {
-    $corporation_id = testCharacter()->corporation_id;
+    $corporationId = testCharacter()->corporation_id;
     $scope = 'esi-corporations.read_corporation_membership.v1';
     $role = 'Director';
 
-    updateRefreshTokenScopes(testCharacter()->refresh_token, [$scope])->save();
+    updateRefreshTokenScopes(testCharacter()->refreshToken, [$scope])->save();
 
-    $refresh_token = (new FindCorporationRefreshToken)($corporation_id, $scope, $role);
+    $refreshToken = (new FindCorporationRefreshToken)($corporationId, $scope, $role);
 
-    expect($refresh_token)->toBeNull();
+    expect($refreshToken)->toBeNull();
 });
 
 it('returns RefreshToken when character has matching scope and role', function () {
-    $corporation_id = testCharacter()->corporation_id;
+    $corporationId = testCharacter()->corporation_id;
     $scope = 'esi-corporations.read_corporation_membership.v1';
 
-    updateRefreshTokenScopes(testCharacter()->refresh_token, [$scope])->save();
+    updateRefreshTokenScopes(testCharacter()->refreshToken, [$scope])->save();
 
     CharacterRole::updateOrCreate(
         ['character_id' => testCharacter()->character_id],
         ['roles' => ['Director']],
     );
 
-    $refresh_token = (new FindCorporationRefreshToken)($corporation_id, $scope, 'Director');
+    $refreshToken = (new FindCorporationRefreshToken)($corporationId, $scope, 'Director');
 
-    expect($refresh_token)->not->toBeNull();
+    expect($refreshToken)->not->toBeNull();
 });
 
 it('returns RefreshToken when roles array is empty', function () {
-    $corporation_id = testCharacter()->corporation_id;
+    $corporationId = testCharacter()->corporation_id;
     $scope = 'esi-corporations.read_corporation_membership.v1';
 
-    updateRefreshTokenScopes(testCharacter()->refresh_token, [$scope])->save();
+    updateRefreshTokenScopes(testCharacter()->refreshToken, [$scope])->save();
 
-    $refresh_token = (new FindCorporationRefreshToken)($corporation_id, $scope, []);
+    $refreshToken = (new FindCorporationRefreshToken)($corporationId, $scope, []);
 
-    expect($refresh_token)->not->toBeNull();
+    expect($refreshToken)->not->toBeNull();
 });
 
 it('returns null when no token has the required scope', function () {
-    $corporation_id = testCharacter()->corporation_id;
+    $corporationId = testCharacter()->corporation_id;
 
-    $refresh_token = (new FindCorporationRefreshToken)(
-        $corporation_id,
+    $refreshToken = (new FindCorporationRefreshToken)(
+        $corporationId,
         'esi-some.scope.that.does.not.exist.v1',
         []
     );
 
-    expect($refresh_token)->toBeNull();
+    expect($refreshToken)->toBeNull();
 });

--- a/tests/Unit/Services/GetUpToDateRefreshTokenServiceTest.php
+++ b/tests/Unit/Services/GetUpToDateRefreshTokenServiceTest.php
@@ -34,14 +34,14 @@ it('updates refresh token if expiry is near', function () {
 
     $updateRefreshTokenService = mock(UpdateRefreshTokenService::class, function (MockInterface $mock) use ($refreshToken) {
 
-        $new_token = RefreshToken::factory()->make([
+        $newToken = RefreshToken::factory()->make([
             'character_id' => $refreshToken->character_id,
             'expires_on' => now()->addMinutes(5),
         ]);
 
         $mock->shouldReceive('update')
             ->with($refreshToken)
-            ->andReturn($new_token);
+            ->andReturn($newToken);
     });
 
     $service = new GetUpToDateRefreshTokenService($updateRefreshTokenService);

--- a/tests/Unit/Services/ResolveLocation/Finders/ThroughCorporationMemberTrackingFinderTest.php
+++ b/tests/Unit/Services/ResolveLocation/Finders/ThroughCorporationMemberTrackingFinderTest.php
@@ -13,26 +13,26 @@ it('finds Director Token', function () {
     $scope = 'esi-corporations.track_members.v1';
     $role = 'Director';
 
-    $refresh_token = testCharacter()->refresh_token;
-    updateRefreshTokenScopes($refresh_token, [$scope])->save();
+    $refreshToken = testCharacter()->refreshToken;
+    updateRefreshTokenScopes($refreshToken, [$scope])->save();
 
-    $character_roles = $refresh_token->refresh()->character->roles;
-    $character_roles->roles = [$role];
-    $character_roles->save();
+    $characterRoles = $refreshToken->refresh()->character->roles;
+    $characterRoles->roles = [$role];
+    $characterRoles->save();
 
-    $corporation_member_tracking = CorporationMemberTracking::factory()->create([
-        'corporation_id' => $refresh_token->corporation_id,
+    $corporationMemberTracking = CorporationMemberTracking::factory()->create([
+        'corporation_id' => $refreshToken->corporation_id,
         'location_id' => 1,
     ]);
 
-    expect($refresh_token->hasScope($scope))->toBeTrue()
-        ->and($refresh_token->character->roles->hasRole('roles', $role))->toBeTrue();
+    expect($refreshToken->hasScope($scope))->toBeTrue()
+        ->and($refreshToken->character->roles->hasRole('roles', $role))->toBeTrue();
 
     $tracking = Collection::make();
 
     // act
     $finder = new ThroughCorporationMemberTrackingFinder;
-    $result = $finder->handle($corporation_member_tracking->location_id, $tracking);
+    $result = $finder->handle($corporationMemberTracking->location_id, $tracking);
 
     // assert
     expect($result)->not()->toBeNull();

--- a/tests/Unit/Services/ResolveLocation/Finders/ThroughPreviouslyFailedRefreshTokenFinderTest.php
+++ b/tests/Unit/Services/ResolveLocation/Finders/ThroughPreviouslyFailedRefreshTokenFinderTest.php
@@ -6,13 +6,13 @@ use Seatplus\Eveapi\Services\ResolveLocation\Finders\ThroughPreviouslyFailedRefr
 
 it('returns null when no valid record is found', function () {
     $finder = new ThroughPreviouslyFailedRefreshTokenFinder;
-    $location_id = 1;
+    $locationId = 1;
     $tracings = new Collection([
         createLocationRefreshToken(6),
         createLocationRefreshToken(7),
     ]);
 
-    $result = $finder->handle($location_id, $tracings);
+    $result = $finder->handle($locationId, $tracings);
 
     expect($result)->toBeNull();
 });

--- a/tests/Unit/Services/ResolveLocation/ResolveLocationServiceTest.php
+++ b/tests/Unit/Services/ResolveLocation/ResolveLocationServiceTest.php
@@ -12,15 +12,15 @@ it('runs through resolvers', function () {
     Queue::fake();
 
     // Arrange
-    $location_id = 100; // use low number to avoid being a potential structure or station
+    $locationId = 100; // use low number to avoid being a potential structure or station
 
-    ResolveLocationService::make()->handle($location_id);
+    ResolveLocationService::make()->handle($locationId);
 
     expect(Location::count())->toBe(0);
 });
 
 it('breaks the loop on successful resolution', function () {
-    $location_id = 12345;
+    $locationId = 12345;
 
     // Mock the Location model
     $locationMock = mock(Location::class)->makePartial();
@@ -33,9 +33,9 @@ it('breaks the loop on successful resolution', function () {
     });
 
     // Create the service with the mocked dependencies
-    $service = Mockery::mock(ResolveLocationService::class, [testCharacter()->refresh_token, [$resolverMock]])
+    $service = Mockery::mock(ResolveLocationService::class, [testCharacter()->refreshToken, [$resolverMock]])
         ->makePartial();
 
     // Call the handle method
-    $service->handle($location_id);
+    $service->handle($locationId);
 });

--- a/tests/Unit/Services/ResolveLocation/StationResolverTest.php
+++ b/tests/Unit/Services/ResolveLocation/StationResolverTest.php
@@ -102,10 +102,10 @@ describe('is potential station', function () {
     it('creates location', function () {
 
         // Arrange
-        $location_id = 60_005_617;
+        $locationId = 60_005_617;
 
         $location = Location::firstOrNew([
-            'location_id' => $location_id,
+            'location_id' => $locationId,
         ]);
 
         Log::shouldReceive('info')
@@ -123,10 +123,10 @@ describe('is potential station', function () {
     it('logs successfully resolved station', function () {
 
         // Arrange
-        $location_id = 60_005_617;
+        $locationId = 60_005_617;
 
         $location = Location::firstOrNew([
-            'location_id' => $location_id,
+            'location_id' => $locationId,
         ]);
 
         Log::shouldReceive('info')->once();
@@ -143,16 +143,16 @@ describe('is potential station', function () {
     it('throws error if resolving station fails', function () {
 
         // Arrange
-        $location_id = 60_005_617;
+        $locationId = 60_005_617;
 
         expect(Location::count())->toBe(0)
             ->and(Structure::count())->toBe(0);
 
         $location = Location::firstOrNew([
-            'location_id' => $location_id,
+            'location_id' => $locationId,
         ]);
 
-        $test_class = new class extends StationResolver
+        $testClass = new class extends StationResolver
         {
             protected function dispatchStationResolutionJob(Location $location): void
             {
@@ -163,7 +163,7 @@ describe('is potential station', function () {
         Log::shouldReceive('error')->once(); // once for the error
 
         // Act
-        $result = $test_class->handle($location);
+        $result = $testClass->handle($location);
 
         // Assert
         expect($result)->toBeTrue();

--- a/tests/Unit/Services/ResolveLocation/StructureRefreshTokenFinderTest.php
+++ b/tests/Unit/Services/ResolveLocation/StructureRefreshTokenFinderTest.php
@@ -25,8 +25,8 @@ beforeEach(function () {
     Queue::fake();
     Event::fake();
 
-    $refresh_token = updateRefreshTokenScopes($this->test_character->refresh_token, ['esi-universe.read_structures.v1']);
-    $refresh_token->save();
+    $refreshToken = updateRefreshTokenScopes($this->test_character->refreshToken, ['esi-universe.read_structures.v1']);
+    $refreshToken->save();
 
     CharacterRole::query()
         ->updateOrCreate([
@@ -164,7 +164,7 @@ function executeFindStructureRefreshTokenTest(FinderInterface $instance)
 }
 
 it('allows shortcut findValidToken method', function () {
-    $instance = new StructureRefreshTokenFinder(testCharacter()->refresh_token);
+    $instance = new StructureRefreshTokenFinder(testCharacter()->refreshToken);
 
     $result = $instance->findValidToken(test()->location_id);
 
@@ -173,12 +173,12 @@ it('allows shortcut findValidToken method', function () {
 });
 
 it('increments and resets attempts', function () {
-    $refresh_token = test()->test_character->refresh_token;
-    $location_id = test()->location_id;
+    $refreshToken = test()->test_character->refreshToken;
+    $locationId = test()->location_id;
 
-    $instance = new StructureRefreshTokenFinder($refresh_token);
+    $instance = new StructureRefreshTokenFinder($refreshToken);
 
-    $instance->findValidToken($location_id);
+    $instance->findValidToken($locationId);
 
     $instance->markAsFailed();
 
@@ -189,7 +189,7 @@ it('increments and resets attempts', function () {
 
     $instance->markAsResolved();
 
-    $location_refresh_token = LocationRefreshToken::query()
+    $locationRefreshToken = LocationRefreshToken::query()
         ->where('location_id', test()->location_id)
         ->where('character_id', test()->test_character->character_id)
         ->first();
@@ -214,12 +214,12 @@ it('goes through all finder classes', function () {
     $instance = new StructureRefreshTokenFinder;
 
     // make sure the ThrougRandomRefreshTokenFinder did not result positively
-    $random_token = (new ThroughRandomRefreshTokenFinder)->handle(test()->location_id, LocationRefreshToken::all());
+    $randomToken = (new ThroughRandomRefreshTokenFinder)->handle(test()->location_id, LocationRefreshToken::all());
 
     // Act
     $result = $instance->findValidToken(test()->location_id);
 
     // Assert
-    expect($random_token)->toBeNull()
+    expect($randomToken)->toBeNull()
         ->and($result)->toBeInstanceOf(RefreshToken::class);
 });

--- a/tests/Unit/Services/ResolveLocation/StructureResolverTest.php
+++ b/tests/Unit/Services/ResolveLocation/StructureResolverTest.php
@@ -14,8 +14,8 @@ beforeEach(function () {
     Queue::fake();
     Event::fake();
 
-    $refresh_token = updateRefreshTokenScopes($this->test_character->refresh_token, ['esi-universe.read_structures.v1']);
-    $refresh_token->save();
+    $refreshToken = updateRefreshTokenScopes($this->test_character->refreshToken, ['esi-universe.read_structures.v1']);
+    $refreshToken->save();
 });
 
 describe('isStation or recently updated structure', function () {
@@ -88,20 +88,20 @@ describe('is potential structure', function () {
     it('checks structure if location has not recently been updated', function () {
 
         // Arrange
-        $location_id = 832_949_394;
+        $locationId = 832_949_394;
 
         Structure::factory()->make([
             'updated_at' => carbon()->subDays(8),
-            'structure_id' => $location_id,
+            'structure_id' => $locationId,
         ])->save();
 
         $location = Location::firstOrNew([
-            'location_id' => $location_id,
-            'locatable_id' => $location_id,
+            'location_id' => $locationId,
+            'locatable_id' => $locationId,
             'locatable_type' => Structure::class,
         ]);
 
-        $resolveStructurePipe = new StructureResolver($this->test_character->refresh_token);
+        $resolveStructurePipe = new StructureResolver($this->test_character->refreshToken);
 
         Log::shouldReceive('info')->once();
 
@@ -115,7 +115,7 @@ describe('is potential structure', function () {
     it('creates location and returns early without refresh token', function () {
 
         // Arrange
-        $location_id = 832_949_394;
+        $locationId = 832_949_394;
 
         // Delete all RefreshTokens
         RefreshToken::truncate();
@@ -123,16 +123,16 @@ describe('is potential structure', function () {
         expect(Location::count())->toBe(0);
 
         $location = Location::firstOrNew([
-            'location_id' => $location_id,
+            'location_id' => $locationId,
         ]);
 
-        $mocked_refresh_token_finder = mock(StructureRefreshTokenFinder::class)
+        $mockedRefreshTokenFinder = mock(StructureRefreshTokenFinder::class)
             ->shouldReceive('findValidToken')
             ->once()
             ->andReturnNull()
             ->getMock();
 
-        $resolveStructurePipe = new StructureResolver($mocked_refresh_token_finder);
+        $resolveStructurePipe = new StructureResolver($mockedRefreshTokenFinder);
 
         Log::shouldReceive('warning')
             ->once();
@@ -148,16 +148,16 @@ describe('is potential structure', function () {
     it('logs successfully resolved structure', function () {
 
         // Arrange
-        $location_id = 832_949_394;
+        $locationId = 832_949_394;
 
         expect(Location::count())->toBe(0)
             ->and(Structure::count())->toBe(0);
 
         $location = Location::firstOrNew([
-            'location_id' => $location_id,
+            'location_id' => $locationId,
         ]);
 
-        $resolveStructurePipe = new StructureResolver($this->test_character->refresh_token);
+        $resolveStructurePipe = new StructureResolver($this->test_character->refreshToken);
 
         Log::shouldReceive('info')->once();
 
@@ -173,32 +173,32 @@ describe('is potential structure', function () {
     it('throws error if resolving structure fails', function () {
 
         // Arrange
-        $location_id = 832_949_394;
+        $locationId = 832_949_394;
 
         expect(Location::count())->toBe(0)
             ->and(Structure::count())->toBe(0);
 
         $location = Location::firstOrNew([
-            'location_id' => $location_id,
+            'location_id' => $locationId,
         ]);
 
-        $mocked_refresh_token_finder = mock(StructureRefreshTokenFinder::class)->makePartial();
+        $mockedRefreshTokenFinder = mock(StructureRefreshTokenFinder::class)->makePartial();
 
-        $mocked_refresh_token_finder
+        $mockedRefreshTokenFinder
             ->shouldReceive('findValidToken')
             ->once()
-            ->andReturn($this->test_character->refresh_token);
+            ->andReturn($this->test_character->refreshToken);
 
-        $mocked_refresh_token_finder
+        $mockedRefreshTokenFinder
             ->shouldReceive('markAsResolved')
             ->once()
             ->andThrow(new Exception('test'));
 
-        $mocked_refresh_token_finder
+        $mockedRefreshTokenFinder
             ->shouldReceive('markAsFailed')
             ->once();
 
-        $resolveStructurePipe = new StructureResolver($mocked_refresh_token_finder);
+        $resolveStructurePipe = new StructureResolver($mockedRefreshTokenFinder);
 
         Log::shouldReceive('error')->once(); // once for the error and once for the exception
 


### PR DESCRIPTION
## What
Make eveapi idiomatic per Laravel + Spatie guidelines:
- **Relation methods → camelCase** (`refresh_token`→`refreshToken`, `wallet_journals`→`walletJournals`, `character_affiliation`→`characterAffiliation`, `wallet_journable` MorphTo pinned with an explicit morph name, etc. — 19 relations).
- **Local variables + class/promoted properties → camelCase**.

## Stays snake_case (correct, per Laravel/Spatie)
DB columns, Eloquent attribute keys, `$casts`/`$fillable`, config keys, morph type/id columns and morph **names**, and `@property` docblocks documenting column attributes.

## Why it's safe for consumers' JSON
Eloquent serializes relations to **snake_case** in JSON regardless of the camelCase method name, so API/Inertia payloads are unchanged. Only **PHP-side** access changes (`$model->refreshToken`, `with('refreshToken')`).

## Breaking (intentional, coordinated)
This is a breaking change to eveapi's relation API. `auth` and `web` will be updated to match in follow-up PRs and should land together. Tracked in seatplus/core#235.

## Validation
- ✅ Pint
- ✅ PHPStan / Larastan (`src`)
- ✅ 578 tests pass
- ⚠️ `test:type-coverage` fails on a **pre-existing** ParseError (reproduces on `4.x` without these changes; not introduced here).

## Note / follow-up
Test-side regressions here were mostly *runtime* (mock partials, `ReflectionClass::getProperty('snake')`, named arguments) that static analysis can't catch — adding `tests/` to PHPStan would need the Pest extension to suppress DSL noise and still wouldn't catch the runtime cases. Worth a separate look.