### PR TITLE
test: use unique ids in AllianceInfo/CorporationInfo factories

### DIFF
--- a/database/factories/AllianceInfoFactory.php
+++ b/database/factories/AllianceInfoFactory.php
@@ -40,7 +40,7 @@ class AllianceInfoFactory extends Factory
     public function definition()
     {
         return [
-            'alliance_id' => fake()->numberBetween(99000000, 100000000),
+            'alliance_id' => fake()->unique()->numberBetween(99000000, 100000000),
             'creator_corporation_id' => fake()->numberBetween(98000000, 99000000),
             'creator_id' => fake()->numberBetween(90000000, 98000000),
             'date_founded' => fake()->date('Y-m-d', 'now'),

--- a/database/factories/CorporationInfoFactory.php
+++ b/database/factories/CorporationInfoFactory.php
@@ -41,7 +41,7 @@ class CorporationInfoFactory extends Factory
     public function definition()
     {
         return [
-            'corporation_id' => fake()->numberBetween(98000000, 99000000),
+            'corporation_id' => fake()->unique()->numberBetween(98000000, 99000000),
             'ticker' => fake()->bothify('[##??]'),
             'name' => fake()->name,
             'member_count' => fake()->randomDigitNotNull,


### PR DESCRIPTION
`alliance_id` and `corporation_id` are primary keys, but their factories generated them with a plain random `fake()->numberBetween()`. Since `CharacterInfo::factory()` spawns an alliance (and corporation) per character, creating several characters in one test could collide on the PK — an intermittent `UniqueConstraintViolationException` (`alliance_infos_pkey` / `corporation_infos_pkey`).

This surfaced as a flaky test downstream (`web RecruitmentLifeCycleTest > "can delete enlistment"`, which passed on CI rerun).

Fix: add `fake()->unique()`, consistent with the existing `character_id` generator. 578 tests green.