### PR TITLE
fix: SDE import NOT NULL crash + esi-client log path + local Horizon tries

### DIFF
--- a/config/eveapi.config.php
+++ b/config/eveapi.config.php
@@ -1,6 +1,6 @@
 <?php
 
-use Monolog\Logger;
+use Monolog\Level;
 
 /*
  * MIT License
@@ -39,7 +39,7 @@ return [
         'sso_host' => env('EVE_SSO_HOST', 'login.eveonline.com'),
         'sso_port' => env('EVE_SSO_PORT', 443),
         // Loging
-        'logger_level' => Logger::INFO, // valid entries are RFC 5424 levels ('debug', 'info', 'warn', 'error')
+        'logger_level' => Level::Info->value, // Monolog\Level case (Debug/Info/Warning/Error/…)
         'logfile_location' => storage_path('logs'),
     ],
 

--- a/src/Commands/SdeImportCommand.php
+++ b/src/Commands/SdeImportCommand.php
@@ -111,7 +111,7 @@ class SdeImportCommand extends Command
             primaryKey: 'category_id',
             mapper: fn (array $row): array => [
                 'category_id' => $row['_key'],
-                'name' => $row['name']['en'] ?? null,
+                'name' => $row['name']['en'] ?? '',
                 'published' => $row['published'] ?? false,
             ],
             uniqueBy: ['category_id'],
@@ -128,7 +128,7 @@ class SdeImportCommand extends Command
             mapper: fn (array $row): array => [
                 'group_id' => $row['_key'],
                 'category_id' => $row['categoryID'],
-                'name' => $row['name']['en'] ?? null,
+                'name' => $row['name']['en'] ?? '',
                 'published' => $row['published'] ?? false,
             ],
             uniqueBy: ['group_id'],
@@ -145,8 +145,8 @@ class SdeImportCommand extends Command
             mapper: fn (array $row): array => [
                 'type_id' => $row['_key'],
                 'group_id' => $row['groupID'],
-                'name' => $row['name']['en'] ?? null,
-                'description' => $row['description']['en'] ?? null,
+                'name' => $row['name']['en'] ?? '',
+                'description' => $row['description']['en'] ?? '',
                 'published' => $row['published'] ?? false,
             ],
             uniqueBy: ['type_id'],
@@ -162,8 +162,8 @@ class SdeImportCommand extends Command
             primaryKey: 'region_id',
             mapper: fn (array $row): array => [
                 'region_id' => $row['_key'],
-                'name' => $row['name']['en'] ?? null,
-                'description' => $row['description']['en'] ?? null,
+                'name' => $row['name']['en'] ?? '',
+                'description' => $row['description']['en'] ?? '',
             ],
             uniqueBy: ['region_id'],
         );
@@ -179,7 +179,7 @@ class SdeImportCommand extends Command
             mapper: fn (array $row): array => [
                 'constellation_id' => $row['_key'],
                 'region_id' => $row['regionID'],
-                'name' => $row['name']['en'] ?? null,
+                'name' => $row['name']['en'] ?? '',
             ],
             uniqueBy: ['constellation_id'],
         );
@@ -195,7 +195,7 @@ class SdeImportCommand extends Command
             mapper: fn (array $row): array => [
                 'system_id' => $row['_key'],
                 'constellation_id' => $row['constellationID'],
-                'name' => $row['name']['en'] ?? null,
+                'name' => $row['name']['en'] ?? '',
                 'security_class' => $row['securityClass'] ?? null,
                 'security_status' => $row['securityStatus'] ?? 0.0,
             ],

--- a/src/EveapiServiceProvider.php
+++ b/src/EveapiServiceProvider.php
@@ -69,7 +69,14 @@ class EveapiServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $version = InstalledVersions::getPrettyVersion('seatplus/eveapi') ?? 'dev';
-        EsiConfiguration::getInstance()->http_user_agent .= " seatplus/eveapi/{$version} +https://github.com/seatplus/eveapi";
+        $esiConfiguration = EsiConfiguration::getInstance();
+        $esiConfiguration->http_user_agent .= " seatplus/eveapi/{$version} +https://github.com/seatplus/eveapi";
+
+        // Wire the esi-client logging config so its RotatingFileLogger writes alongside
+        // the Laravel logs. Without this it falls back to its relative-path default
+        // ('logs/'), which resolves to the process CWD (e.g. /workspace/logs) instead.
+        $esiConfiguration->logfile_location = config('eveapi.config.esi-client.logfile_location');
+        $esiConfiguration->logger_level = config('eveapi.config.esi-client.logger_level');
 
         Model::preventLazyLoading(! app()->isProduction());
 
@@ -145,6 +152,7 @@ class EveapiServiceProvider extends ServiceProvider
                     'processes' => config('eveapi.config.queue.workers'),
                     'block_for' => 5,
                     'timeout' => 120, // 2 minutes
+                    'tries' => 1, // a failing job lands in failed_jobs instead of retrying forever (Horizon defaults to unlimited)
                     'nice' => 10, // Allowed values are between 0 and 19
                     'maxTime' => 3600,
                     'maxJobs' => 1000,


### PR DESCRIPTION
Three independent fixes surfaced while running the assembled app:

1. **SDE import crash-loop** — CCP's SDE has rows without `name.en`/`description.en` (e.g. type 0 `#System`); the importer inserted `null` into the `NOT NULL` `universe_*` `name`/`description` columns, so `seatplus:sde-import` failed every ~2s. Default to `''`.
2. **esi-client logs** — wire `config('eveapi.config.esi-client.logfile_location')` into `EsiConfiguration` so esi-client writes to `storage/logs` instead of its relative-path default (process CWD).
3. **Local Horizon `tries`** — the `local` supervisor had no `tries` (Horizon defaults to unlimited), so a failing job retried forever and never hit `failed_jobs`. Set `tries=1` to match `production`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)