### PR TITLE
fix: default mail is_read to false when ESI omits it

### DIFF
--- a/src/Jobs/Mail/MailHeaderJob.php
+++ b/src/Jobs/Mail/MailHeaderJob.php
@@ -51,7 +51,7 @@ final class MailHeaderJob extends EsiJob
                 'subject' => $item->subject,
                 'from' => $item->from,
                 'timestamp' => carbon($item->timestamp),
-                'is_read' => $item->is_read ?? null,
+                'is_read' => $item->is_read ?? false,
                 'recipients' => $item->recipients ?? [],
             ])
             ->tap(function (Collection $mails) {


### PR DESCRIPTION
ESI leaves `is_read` out of some mail headers, but `mails.is_read` is NOT NULL. `MailHeaderJob` mapped it as `$item->is_read ?? null`, so the header upsert threw a not-null violation and **no mail persisted**. An absent `is_read` means unread → default to `false`.

Surfaced once the esi-client `withToken` expiry bug (seatplus/esi-client#…) was fixed and the mail fetch actually reached the DB.