### PR TITLE
fix: correct ESI proactive rate-limiting (real quota; throttling never fails a job)

### DIFF
--- a/src/Jobs/EsiJob.php
+++ b/src/Jobs/EsiJob.php
@@ -51,10 +51,27 @@ abstract class EsiJob implements ShouldBeUnique, ShouldQueue
     use Queueable;
 
     /**
-     * The number of times the job may be attempted.
-     * Higher than default to allow for rate-limit releases.
+     * Absolute deadline, in minutes from first dispatch, for retrying a job — including
+     * time spent waiting out rate-limit releases.
      */
-    public int $tries = 10;
+    private const int RETRY_UNTIL_MINUTES = 30;
+
+    /**
+     * No fixed attempt cap. Rate-limit releases — from EsiProactiveRateLimitMiddleware, the
+     * ThrottlesExceptions circuit breaker, and the EsiRateLimited/ErrorLimited catch in
+     * handle() — are flow control, not failures; bounding them by a fixed $tries turned
+     * "waiting for tokens" into MaxAttemptsExceeded (and cancelled batches). Retries are
+     * instead bounded by retryUntil() (time) and $maxExceptions (genuine errors).
+     */
+    public int $tries = 0;
+
+    /**
+     * Genuine, uncaught exceptions tolerated before the job is failed. Only the rethrowing
+     * `catch (Exception)` in handle() decrements this — caught paths (rate-limit release,
+     * InvalidRefreshToken fail) and middleware releases do not — so throttling can never
+     * fail a job, while a real ESI error still stops it after three attempts.
+     */
+    public int $maxExceptions = 3;
 
     /**
      * Calculate the number of seconds to wait before retrying the job.
@@ -62,6 +79,16 @@ abstract class EsiJob implements ShouldBeUnique, ShouldQueue
     public function backoff(): array
     {
         return [1 * 60, 5 * 60, 10 * 60, 15 * 60, 15 * 60, 15 * 60, 15 * 60, 15 * 60, 15 * 60];
+    }
+
+    /**
+     * Retry deadline. Laravel computes this once on first dispatch and persists it across
+     * attempts, so a throttled job keeps retrying until its tokens refill without ever
+     * failing on attempt count.
+     */
+    public function retryUntil(): \DateTimeInterface
+    {
+        return now()->addMinutes(self::RETRY_UNTIL_MINUTES);
     }
 
     /**

--- a/src/Jobs/EsiJob.php
+++ b/src/Jobs/EsiJob.php
@@ -240,11 +240,9 @@ abstract class EsiJob implements ShouldBeUnique, ShouldQueue
             return null;
         }
 
-        return (int) $matches[1] * match ($matches[2]) {
-            's' => 1,
-            'm' => 60,
-            'h' => 3600,
-        };
+        $unitSeconds = ['s' => 1, 'm' => 60, 'h' => 3600];
+
+        return (int) $matches[1] * $unitSeconds[$matches[2]];
     }
 
     /**

--- a/src/Jobs/EsiJob.php
+++ b/src/Jobs/EsiJob.php
@@ -74,11 +74,13 @@ abstract class EsiJob implements ShouldBeUnique, ShouldQueue
     public int $maxExceptions = 3;
 
     /**
-     * Calculate the number of seconds to wait before retrying the job.
+     * Seconds to wait between retries of a *genuine* (rethrown) exception. Rate-limit
+     * releases pass their own explicit delay and never use this, so only maxExceptions
+     * worth of entries are ever consumed.
      */
     public function backoff(): array
     {
-        return [1 * 60, 5 * 60, 10 * 60, 15 * 60, 15 * 60, 15 * 60, 15 * 60, 15 * 60, 15 * 60];
+        return [1 * 60, 5 * 60, 10 * 60];
     }
 
     /**

--- a/src/Jobs/EsiJob.php
+++ b/src/Jobs/EsiJob.php
@@ -117,7 +117,12 @@ abstract class EsiJob implements ShouldBeUnique, ShouldQueue
             }
 
             if ($esi instanceof RecordingEsiClient) {
-                $esi->setContext($this->rateLimitGroup(), $this->rateLimitCharacterId());
+                $esi->setContext(
+                    $this->rateLimitGroup(),
+                    $this->rateLimitCharacterId(),
+                    $this->rateLimitMaxTokens(),
+                    $this->rateLimitWindowSeconds(),
+                );
             }
 
             DB::transaction(fn () => $this->executeJob($esi));
@@ -170,6 +175,49 @@ abstract class EsiJob implements ShouldBeUnique, ShouldQueue
     public function rateLimitCharacterId(): ?int
     {
         return $this->getRefreshToken()?->character_id;
+    }
+
+    /**
+     * The bucket capacity for this endpoint, from OPERATION_CLASS::RATE_LIMIT_MAX_TOKENS
+     * (e.g. 150 for char-wallet). Null when the endpoint declares no quota — such jobs
+     * are never proactively throttled rather than measured against a wrong denominator.
+     */
+    public function rateLimitMaxTokens(): ?int
+    {
+        $op = static::OPERATION_CLASS;
+
+        if ($op === '') {
+            return null;
+        }
+
+        $value = defined("{$op}::RATE_LIMIT_MAX_TOKENS") ? constant("{$op}::RATE_LIMIT_MAX_TOKENS") : null;
+
+        return is_int($value) ? $value : null;
+    }
+
+    /**
+     * The refill window in seconds, parsed from OPERATION_CLASS::RATE_LIMIT_WINDOW
+     * (e.g. '15m' → 900). Null when unknown or unparseable.
+     */
+    public function rateLimitWindowSeconds(): ?int
+    {
+        $op = static::OPERATION_CLASS;
+
+        if ($op === '') {
+            return null;
+        }
+
+        $window = defined("{$op}::RATE_LIMIT_WINDOW") ? constant("{$op}::RATE_LIMIT_WINDOW") : null;
+
+        if (! is_string($window) || ! preg_match('/^(\d+)([smh])$/', $window, $matches)) {
+            return null;
+        }
+
+        return (int) $matches[1] * match ($matches[2]) {
+            's' => 1,
+            'm' => 60,
+            'h' => 3600,
+        };
     }
 
     /**

--- a/src/Jobs/Middleware/EsiProactiveRateLimitMiddleware.php
+++ b/src/Jobs/Middleware/EsiProactiveRateLimitMiddleware.php
@@ -73,15 +73,25 @@ class EsiProactiveRateLimitMiddleware
      * RecordingEsiClient before calling executeJob(), so the correct
      * (group, characterId) pair is always available here.
      *
-     * @param  string  $group  ESI rate-limit group (e.g. 'characters', 'alliances').
+     * The real quota (limit + window) is endpoint-specific and comes from the
+     * operation class (RATE_LIMIT_MAX_TOKENS / RATE_LIMIT_WINDOW), threaded through
+     * EsiJob::handle() → RecordingEsiClient. It must NOT be hardcoded: e.g. the
+     * char-wallet group is 150/15m, so a hardcoded 1800 would read 147 remaining as
+     * 8 % (throttle) instead of 98 % (fine). A null limit means the endpoint has no
+     * known quota and is never proactively throttled.
+     *
+     * @param  int|null  $limit  Bucket capacity (RATE_LIMIT_MAX_TOKENS), or null if unknown.
+     * @param  int|null  $windowSeconds  Refill window in seconds, or null if unknown.
+     * @param  string  $group  ESI rate-limit group (e.g. 'char-wallet', 'characters').
      * @param  string  $characterId  Character ID string, or 'public' for unauthenticated endpoints.
      */
-    public static function recordResponse(int $remaining, string $group = 'global', string $characterId = 'public'): void
+    public static function recordResponse(int $remaining, ?int $limit, ?int $windowSeconds, string $group = 'global', string $characterId = 'public'): void
     {
         Redis::setex(self::KEY_PREFIX."{$group}:{$characterId}", self::TTL_SECONDS, json_encode([
             'remaining' => $remaining,
-            'limit' => 1800,
-            'window_seconds' => 900,
+            'limit' => $limit ?? 0,
+            'window_seconds' => $windowSeconds ?? 0,
+            'recorded_at' => now()->timestamp,
         ]));
     }
 
@@ -110,22 +120,34 @@ class EsiProactiveRateLimitMiddleware
         $remaining = (int) ($state['remaining'] ?? 0);
         $limit = (int) ($state['limit'] ?? 0);
         $windowSeconds = (int) ($state['window_seconds'] ?? 0);
+        $recordedAt = (int) ($state['recorded_at'] ?? 0);
 
         if ($limit === 0 || $windowSeconds === 0) {
             return 0;
         }
 
-        if (($remaining / $limit) >= self::LOW_THRESHOLD) {
+        // ESI refills the bucket at limit/window tokens per second. The stored value is
+        // a snapshot; age it by the refill accrued since it was recorded. Without this a
+        // brief dip below the threshold would starve the group forever — the release
+        // prevents the very ESI call that would refresh the snapshot, so it never rises.
+        // Integer-first math (multiply before divide) keeps the boundaries exact.
+        $elapsed = max(0, now()->timestamp - $recordedAt);
+        $refilled = (int) floor(($elapsed * $limit) / $windowSeconds);
+        $effectiveRemaining = (int) min($limit, $remaining + $refilled);
+
+        $threshold = (int) ceil(self::LOW_THRESHOLD * $limit);
+
+        if ($effectiveRemaining >= $threshold) {
             return 0;
         }
 
-        // Calculate delay: refill enough tokens for one request (costs 2 tokens).
-        // refill_rate = limit / windowSeconds tokens/sec
-        // delay = tokens_needed / refill_rate = 2 / (limit / windowSeconds)
-        $refillRate = $limit / $windowSeconds; // tokens per second
-        $tokensNeeded = 2; // cost of a 2xx response
+        // Hold the job just long enough to refill back to the threshold — a single
+        // release, rather than re-checking a stale value every second and exhausting
+        // the job's retry budget (which is what turned throttling into MaxAttemptsExceeded).
+        // delay = deficit / refillRate = deficit * window / limit.
+        $deficit = $threshold - $effectiveRemaining;
 
-        return (int) ceil($tokensNeeded / $refillRate);
+        return max(1, (int) ceil(($deficit * $windowSeconds) / $limit));
     }
 
     private function computeErrorLimitDelay(): int

--- a/src/Services/Esi/RecordingEsiClient.php
+++ b/src/Services/Esi/RecordingEsiClient.php
@@ -24,17 +24,25 @@ class RecordingEsiClient extends EsiClient
 
     private ?int $characterId = null;
 
+    private ?int $rateLimitMaxTokens = null;
+
+    private ?int $rateLimitWindowSeconds = null;
+
     /**
      * Set the rate-limit context for the upcoming job execution.
      * Called by EsiJob::handle() before executeJob() is invoked.
      *
      * @param  string  $group  ESI rate-limit group (from OPERATION_CLASS::RATE_LIMIT_GROUP).
      * @param  int|null  $characterId  JWT character ID, or null for public/unauthenticated endpoints.
+     * @param  int|null  $maxTokens  Bucket capacity (OPERATION_CLASS::RATE_LIMIT_MAX_TOKENS), or null if unknown.
+     * @param  int|null  $windowSeconds  Refill window in seconds (from RATE_LIMIT_WINDOW), or null if unknown.
      */
-    public function setContext(string $group, ?int $characterId): void
+    public function setContext(string $group, ?int $characterId, ?int $maxTokens = null, ?int $windowSeconds = null): void
     {
         $this->ratelimitGroup = $group;
         $this->characterId = $characterId;
+        $this->rateLimitMaxTokens = $maxTokens;
+        $this->rateLimitWindowSeconds = $windowSeconds;
     }
 
     #[\Override]
@@ -52,6 +60,8 @@ class RecordingEsiClient extends EsiClient
         if ($response->rateLimitRemaining !== null) {
             EsiProactiveRateLimitMiddleware::recordResponse(
                 $response->rateLimitRemaining,
+                $this->rateLimitMaxTokens,
+                $this->rateLimitWindowSeconds,
                 $this->ratelimitGroup,
                 $charId,
             );

--- a/tests/Unit/JobMiddleware/EsiProactiveRateLimitMiddlewareTest.php
+++ b/tests/Unit/JobMiddleware/EsiProactiveRateLimitMiddlewareTest.php
@@ -1,8 +1,10 @@
 <?php
 
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Redis;
 use Seatplus\EsiClient\EsiClient;
 use Seatplus\Eveapi\Jobs\Middleware\EsiProactiveRateLimitMiddleware;
+use Seatplus\Eveapi\Jobs\Wallet\CharacterBalanceJob;
 use Seatplus\Eveapi\Services\Esi\RecordingEsiClient;
 
 // ---------------------------------------------------------------------------
@@ -33,7 +35,7 @@ it('RecordingEsiClient overrides invoke method', function (): void {
 it('recordResponse writes rate-limit state to Redis keyed by group:charId', function (): void {
     Redis::flushdb();
 
-    EsiProactiveRateLimitMiddleware::recordResponse(1200, 'characters', '12345678');
+    EsiProactiveRateLimitMiddleware::recordResponse(1200, 1800, 900, 'characters', '12345678');
 
     $stored = json_decode((string) Redis::get('esi_ratelimit:characters:12345678'), true);
 
@@ -45,7 +47,7 @@ it('recordResponse writes rate-limit state to Redis keyed by group:charId', func
 it('recordResponse defaults to global:public when no group/charId given', function (): void {
     Redis::flushdb();
 
-    EsiProactiveRateLimitMiddleware::recordResponse(900);
+    EsiProactiveRateLimitMiddleware::recordResponse(900, 1800, 900);
 
     $stored = json_decode((string) Redis::get('esi_ratelimit:global:public'), true);
 
@@ -55,7 +57,7 @@ it('recordResponse defaults to global:public when no group/charId given', functi
 
 it('middleware passes job through when rate-limit is healthy', function (): void {
     Redis::flushdb();
-    EsiProactiveRateLimitMiddleware::recordResponse(1800, 'characters', '12345678');
+    EsiProactiveRateLimitMiddleware::recordResponse(1800, 1800, 900, 'characters', '12345678');
 
     $middleware = new EsiProactiveRateLimitMiddleware;
     $passed = false;
@@ -84,7 +86,7 @@ it('middleware passes job through when rate-limit is healthy', function (): void
 
 it('middleware releases job when rate-limit is critically low', function (): void {
     Redis::flushdb();
-    EsiProactiveRateLimitMiddleware::recordResponse(1, 'characters', '12345678');
+    EsiProactiveRateLimitMiddleware::recordResponse(1, 1800, 900, 'characters', '12345678');
 
     $middleware = new EsiProactiveRateLimitMiddleware;
     $passed = false;
@@ -165,7 +167,7 @@ it('middleware passes job without rateLimitGroup() through (legacy jobs)', funct
 
 it('middleware uses public as charId when rateLimitCharacterId() returns null', function (): void {
     Redis::flushdb();
-    EsiProactiveRateLimitMiddleware::recordResponse(1, 'alliances', 'public');
+    EsiProactiveRateLimitMiddleware::recordResponse(1, 1800, 900, 'alliances', 'public');
 
     $middleware = new EsiProactiveRateLimitMiddleware;
 
@@ -196,7 +198,7 @@ it('middleware uses public as charId when rateLimitCharacterId() returns null', 
 
 it('middleware releases job when rate-limit is critically low and job has no rateLimitCharacterId()', function (): void {
     Redis::flushdb();
-    EsiProactiveRateLimitMiddleware::recordResponse(1, 'characters', 'public');
+    EsiProactiveRateLimitMiddleware::recordResponse(1, 1800, 900, 'characters', 'public');
 
     $middleware = new EsiProactiveRateLimitMiddleware;
 
@@ -313,4 +315,106 @@ it('middleware releases job for the reset window when error budget is critically
 
     expect($job->released)->toBeTrue()
         ->and($job->releasedDelay)->toBe(42);
+});
+
+// ---------------------------------------------------------------------------
+// Real endpoint quota — regression for the hardcoded-1800 bug
+// ---------------------------------------------------------------------------
+
+it('does not throttle when remaining is healthy against the real (small) endpoint limit', function (): void {
+    Redis::flushdb();
+
+    // char-wallet is 150/15m. 147 remaining is 98% — healthy. The old code hardcoded
+    // limit=1800, turning this into 8% and throttling the job to MaxAttemptsExceeded.
+    EsiProactiveRateLimitMiddleware::recordResponse(147, 150, 900, 'char-wallet', '95725047');
+
+    $middleware = new EsiProactiveRateLimitMiddleware;
+    $passed = false;
+
+    $job = new class
+    {
+        public bool $released = false;
+
+        public function rateLimitGroup(): string
+        {
+            return 'char-wallet';
+        }
+
+        public function rateLimitCharacterId(): ?int
+        {
+            return 95725047;
+        }
+
+        public function release(int $delay): void
+        {
+            $this->released = true;
+        }
+    };
+
+    $middleware->handle($job, function () use (&$passed): void {
+        $passed = true;
+    });
+
+    expect($passed)->toBeTrue()
+        ->and($job->released)->toBeFalse();
+});
+
+it('ages the stored snapshot by refill so a genuine dip self-heals after one release', function (): void {
+    Redis::flushdb();
+    Carbon::setTestNow(now());
+
+    // Genuinely low: 5/150 = 3.3% (threshold is 15). Refill = 150/900 = 1 token / 6s.
+    EsiProactiveRateLimitMiddleware::recordResponse(5, 150, 900, 'char-wallet', '95725047');
+
+    $makeJob = fn () => new class
+    {
+        public bool $released = false;
+
+        public int $releasedDelay = 0;
+
+        public function rateLimitGroup(): string
+        {
+            return 'char-wallet';
+        }
+
+        public function rateLimitCharacterId(): ?int
+        {
+            return 95725047;
+        }
+
+        public function release(int $delay): void
+        {
+            $this->released = true;
+            $this->releasedDelay = $delay;
+        }
+    };
+
+    // Immediately: released just long enough to refill from 5 back to the threshold (15).
+    $first = $makeJob();
+    (new EsiProactiveRateLimitMiddleware)->handle($first, fn () => null);
+    expect($first->released)->toBeTrue()
+        ->and($first->releasedDelay)->toBe(60); // (15 - 5) tokens / (1/6 per sec) = 60s
+
+    // After that delay the aged snapshot has refilled to the threshold — job passes,
+    // instead of re-checking a frozen value and exhausting its retries.
+    Carbon::setTestNow(now()->addSeconds(60));
+    $second = $makeJob();
+    $passed = false;
+    (new EsiProactiveRateLimitMiddleware)->handle($second, function () use (&$passed): void {
+        $passed = true;
+    });
+
+    expect($passed)->toBeTrue()
+        ->and($second->released)->toBeFalse();
+
+    Carbon::setTestNow();
+});
+
+it('EsiJob derives the real quota from the operation class constants', function (): void {
+    $job = new CharacterBalanceJob(95725047);
+
+    // GetCharactersCharacterIdWallet: RATE_LIMIT_GROUP=char-wallet, MAX_TOKENS=150, WINDOW=15m
+    expect($job->rateLimitGroup())->toBe('char-wallet')
+        ->and($job->rateLimitMaxTokens())->toBe(150)
+        ->and($job->rateLimitWindowSeconds())->toBe(900);
 });

--- a/tests/Unit/Jobs/EsiJobTest.php
+++ b/tests/Unit/Jobs/EsiJobTest.php
@@ -221,7 +221,7 @@ it('uniqueId returns tags joined with comma and space', function () {
 it('backoff returns array of delay values in seconds', function () {
     $job = new TestableEsiJob;
 
-    expect($job->backoff())->toBe([60, 300, 600, 900, 900, 900, 900, 900, 900]);
+    expect($job->backoff())->toBe([60, 300, 600]);
 });
 
 it('bounds retries by time and genuine errors, not a fixed attempt count', function () {

--- a/tests/Unit/Jobs/EsiJobTest.php
+++ b/tests/Unit/Jobs/EsiJobTest.php
@@ -3,6 +3,7 @@
 use GuzzleHttp\Exception\ServerException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use Illuminate\Support\Carbon;
 use Mockery\MockInterface;
 use Seatplus\EsiClient\DataTransferObjects\EsiResponse;
 use Seatplus\EsiClient\EsiClient;
@@ -220,4 +221,23 @@ it('backoff returns array of delay values in seconds', function () {
     $job = new TestableEsiJob;
 
     expect($job->backoff())->toBe([60, 300, 600, 900, 900, 900, 900, 900, 900]);
+});
+
+it('bounds retries by time and genuine errors, not a fixed attempt count', function () {
+    $job = new TestableEsiJob;
+
+    // No fixed attempt cap: rate-limit releases (flow control) must never accumulate into
+    // MaxAttemptsExceeded. Failure is bounded by genuine errors + a time deadline instead.
+    expect($job->tries)->toBe(0)
+        ->and($job->maxExceptions)->toBe(3);
+});
+
+it('retryUntil returns a deadline 30 minutes out', function () {
+    Carbon::setTestNow('2026-07-11 12:00:00');
+
+    $job = new TestableEsiJob;
+
+    expect($job->retryUntil())->toEqual(now()->addMinutes(30));
+
+    Carbon::setTestNow();
 });

--- a/tests/Unit/Jobs/EsiJobTest.php
+++ b/tests/Unit/Jobs/EsiJobTest.php
@@ -17,6 +17,7 @@ use Seatplus\Eveapi\Services\Esi\InvalidTokenThrottleService;
 use Seatplus\Eveapi\Services\Esi\RecordingEsiClient;
 use Seatplus\Eveapi\Tests\Unit\Jobs\Support\TestableEsiJob;
 use Seatplus\Eveapi\Tests\Unit\Jobs\Support\TestableEsiJobWithOperation;
+use Seatplus\Eveapi\Tests\Unit\Jobs\Support\TestableEsiJobWithoutRateLimit;
 
 it('calls executeJob via handle', function () {
     $esi = Mockery::mock(EsiClient::class);
@@ -240,4 +241,12 @@ it('retryUntil returns a deadline 30 minutes out', function () {
     expect($job->retryUntil())->toEqual(now()->addMinutes(30));
 
     Carbon::setTestNow();
+});
+
+it('degrades to null quota and the global group for endpoints without rate-limit metadata', function () {
+    $job = new TestableEsiJobWithoutRateLimit;
+
+    expect($job->rateLimitMaxTokens())->toBeNull()
+        ->and($job->rateLimitWindowSeconds())->toBeNull()
+        ->and($job->rateLimitGroup())->toBe('global');
 });

--- a/tests/Unit/Jobs/EsiJobTest.php
+++ b/tests/Unit/Jobs/EsiJobTest.php
@@ -129,7 +129,7 @@ it('permanently fails the job when token service throws InvalidRefreshTokenExcep
 
 it('calls setContext on RecordingEsiClient before executeJob', function () {
     $esi = Mockery::mock(RecordingEsiClient::class, function (MockInterface $mock) {
-        $mock->shouldReceive('setContext')->with('global', null)->once();
+        $mock->shouldReceive('setContext')->with('global', null, null, null)->once();
     });
 
     $tokenService = Mockery::mock(GetUpToDateRefreshTokenService::class);

--- a/tests/Unit/Jobs/Support/TestableEsiJob.php
+++ b/tests/Unit/Jobs/Support/TestableEsiJob.php
@@ -72,3 +72,22 @@ class TestableEsiJobWithOperation extends TestableEsiJob
 {
     protected const string OPERATION_CLASS = GetCharactersCharacterIdMail::class;
 }
+
+/**
+ * Stand-in operation class for an ESI endpoint that declares no rate-limit metadata
+ * (62 of the generated resources have null constants). Verifies the quota accessors
+ * degrade to null / 'global' instead of throttling against unknown limits.
+ */
+class OperationWithoutRateLimit
+{
+    public const ?string RATE_LIMIT_GROUP = null;
+
+    public const ?int RATE_LIMIT_MAX_TOKENS = null;
+
+    public const ?string RATE_LIMIT_WINDOW = null;
+}
+
+class TestableEsiJobWithoutRateLimit extends TestableEsiJob
+{
+    protected const string OPERATION_CLASS = OperationWithoutRateLimit::class;
+}


### PR DESCRIPTION
Two related fixes so ESI rate-limiting stops killing healthy jobs (`CharacterBalanceJob` failing with `MaxAttemptsExceeded` and cancelling the web **Update** batch).

## 1. Real endpoint quota, not a hardcoded 1800
`EsiProactiveRateLimitMiddleware::recordResponse()` hardcoded `limit = 1800 / window = 900` for every rate-limit group. But groups differ — `char-wallet` is **150/15m**. So `147` remaining (a healthy **98 %**) was stored as `147/1800 = 8 %`, tripping the 10 % throttle and releasing the job until it exhausted its tries.

The real quota is already declared statically on each generated operation class (`RATE_LIMIT_MAX_TOKENS` / `RATE_LIMIT_WINDOW`). Thread it through instead of hardcoding:
- **`EsiJob`** — `rateLimitMaxTokens()` / `rateLimitWindowSeconds()` (parses `'15m'→900`), read from `OPERATION_CLASS` like `rateLimitGroup()` already does, passed via `setContext()`. A **null** quota (62/208 resources) → *never proactively throttled*, rather than measured against a wrong denominator.
- **`RecordingEsiClient`** — carries the quota, forwards it to `recordResponse()`.
- **`recordResponse()`** — stores the real `limit`/`window` + a `recorded_at` timestamp.

Also fixes the **starvation deadlock**: the stored snapshot never refreshed while throttling (the release prevents the ESI call that would update it). `computeReleaseDelay()` now ages the snapshot by the refill accrued since `recorded_at` (integer-first math), and releases *just long enough* to cross the threshold — one release, not a churn.

## 2. Throttle-releases no longer consume the failure budget
Even with (1), `EsiJob` bounded genuine-error retries **and** flow-control releases with a single `tries = 10`. Every `release()` increments the attempt counter, so a job merely *waiting for tokens* could still hit `MaxAttemptsExceeded` — which cancels the `ManualDispatchedJob` batch (no `allowFailures()`), silently dropping journal/transaction updates.

Split the budget along Laravel's two axes:
- **`tries = 0`** — no fixed attempt cap; releases can't accumulate into a failure.
- **`maxExceptions = 3`** — only *uncaught* (genuine) errors count; the caught release/`fail()` paths and middleware releases don't. Real ESI errors still stop after 3.
- **`retryUntil() = now()+30m`** — absolute deadline bounding a throttled job's lifetime.

A throttled job now retries until tokens refill, then runs — it never lands in `failed_jobs`, and the manual batch completes.

## Tests
- `147/150` (char-wallet) is **not** throttled; a genuine `5/150` dip self-heals after one timed release; `EsiJob` derives `char-wallet/150/900` from the operation class.
- `tries = 0`, `maxExceptions = 3`, `retryUntil()` = +30m; existing release/fail/backoff behaviour unchanged.
- 36 green across the EsiJob + middleware suites; PHPStan + Pint clean.

> `pest --type-coverage` Parse-errors on clean `4.x` too (PHP-8.5/plugin issue in this env), unrelated to this change — CI runs it separately.

## Rollout
`local:on` + `php artisan horizon:terminate` to reload. Stale `esi_ratelimit:*` keys self-heal (missing `recorded_at` → treated as fully refilled).