### PR TITLE
fix: force test DB isolation (never wipe the dev database)

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,7 +19,7 @@
     <env name="DB_CONNECTION" value="pgsql"/>
     <env name="DB_HOST" value="127.0.0.1"/>
     <env name="DB_PORT" value="5432"/>
-    <env name="DB_DATABASE" value="laravel"/>
+    <env name="DB_DATABASE" value="laravel" force="true"/>
     <env name="DB_USERNAME" value="seatplus"/>
     <env name="DB_PASSWORD" value="secret"/>
   </php>


### PR DESCRIPTION
`phpunit.xml` pinned `DB_DATABASE=laravel` **without `force="true"`**, so an exported `DB_DATABASE=seatplus` (dev container / shell) overrode it and `RefreshDatabase` ran the suite against the **dev** database — wiping it. Add `force="true"` to pin the test DB regardless of the environment (the guard core got in #240; the package configs never did).