### PR TITLE
fix: dedup UpdateCorporation dispatches and fix rate-limiter key

### DIFF
--- a/src/EveapiServiceProvider.php
+++ b/src/EveapiServiceProvider.php
@@ -263,7 +263,7 @@ class EveapiServiceProvider extends ServiceProvider
         RateLimiter::for(
             'corporation_batch',
             fn ($job) => Limit::perHour(1) // @pest-ignore-type
-                ->by($job->corporation_id ?? 'corporation_batch')
+                ->by($job->corporationId ?? 'corporation_batch')
         );
 
         RateLimiter::for(

--- a/src/Jobs/Seatplus/UpdateCorporation.php
+++ b/src/Jobs/Seatplus/UpdateCorporation.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 namespace Seatplus\Eveapi\Jobs\Seatplus;
 
 use Illuminate\Bus\Batch;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Queue\Middleware\RateLimitedWithRedis;
@@ -42,7 +43,7 @@ use Seatplus\Eveapi\Models\Corporation\CorporationInfo;
 use Seatplus\Eveapi\Models\RefreshToken;
 use Seatplus\Eveapi\Services\FindCorporationRefreshToken;
 
-class UpdateCorporation implements ShouldQueue
+class UpdateCorporation implements ShouldBeUnique, ShouldQueue
 {
     use Queueable;
 
@@ -59,6 +60,11 @@ class UpdateCorporation implements ShouldQueue
         return [
             (new RateLimitedWithRedis('corporation_batch'))->dontRelease(),
         ];
+    }
+
+    public function uniqueId(): string
+    {
+        return (string) ($this->corporationId ?? 'all');
     }
 
     public function handle(): void

--- a/tests/Jobs/Seatplus/CorporationUpdateTest.php
+++ b/tests/Jobs/Seatplus/CorporationUpdateTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Bus\PendingBatch;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Support\Facades\Bus;
 use Seatplus\Eveapi\Jobs\Corporation\CorporationDivisionsJob;
 use Seatplus\Eveapi\Jobs\Corporation\CorporationMemberTrackingJob;
@@ -71,4 +72,11 @@ it('Batch Statistics entry has been made', function () {
 
 it('has middleware', function () {
     expect((new UpdateCorporation)->middleware())->toBeArray();
+});
+
+it('is unique per corporation so duplicate dispatches collapse', function () {
+    expect(new UpdateCorporation(90000001))->toBeInstanceOf(ShouldBeUnique::class)
+        ->and((new UpdateCorporation(90000001))->uniqueId())->toBe('90000001')
+        ->and((new UpdateCorporation(90000002))->uniqueId())->toBe('90000002')
+        ->and((new UpdateCorporation)->uniqueId())->toBe('all');
 });


### PR DESCRIPTION
## Problem

`UpdateCorporation` shows up in Horizon dispatched many times in the same second, each completing in ~2ms without doing work. Two defects compound:

1. **No deduplication.** The job only implemented `ShouldQueue`. `UpdatingRefreshTokenListener` dispatches `UpdateCorporation::dispatch($corporationId)` **once per refresh token** whose scopes changed, with no dedup across characters that share a corporation. Re-auth of an account with several characters in the same corp → many identical dispatches at once.

2. **Broken rate-limiter key.** The `corporation_batch` limiter partitioned by `$job->corporation_id`, but the job property is `$corporationId`. The mismatched key was always `null`, so *every* corporation update fell into a single global bucket capped at `1/hour`. Combined with `->dontRelease()`, the surplus jobs were silently discarded — the flood of instant `DONE` entries.

## Fix

- Implement `ShouldBeUnique`, keyed on the corporation id (falling back to `"all"` for the scheduled parameterless fan-out job), so duplicate per-corporation dispatches collapse while one is queued/running.
- Correct the rate-limiter key to `$job->corporationId`, so the `1/hour` limit applies **per corporation** as originally intended rather than globally.

## Tests

- Added a test asserting `UpdateCorporation` is `ShouldBeUnique` and that `uniqueId()` returns the per-corporation key (and `"all"` for the scheduled job).
- Full `CorporationUpdateTest` suite passes (11/11).
- Pint ✓, type coverage 100% ✓, PHPStan ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)