### PR TITLE
fix: make the SDE import reliable (no migrate-time import, streamed download)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -302,7 +302,7 @@ Schedules::cursor()->each(function (Schedules $entry) use ($schedule) {
 });
 ```
 
-Migrations seed the initial entries (e.g. `SdeImportJob` weekly). The `seatplus:sde-import` command can also be run ad-hoc or pointed at a local zip file.
+Migrations seed the initial schedule entries (e.g. `SdeImportJob` weekly). They deliberately do **not** trigger the work itself — the SDE-schedule migration registers the weekly cadence but does not import: a migration must not download tens of thousands of rows as a side effect, and dispatching the queued job at migrate time would make a fresh install (and CI's `migrate:fresh`) depend on Horizon running. Initial population is an explicit step — `php artisan seatplus:sde-import` (`--source=<sde.zip>` to skip the download) — and the scheduled `SdeImportJob` (a thin wrapper that just `Artisan::call`s that command) keeps it current thereafter.
 
 A small number of schedules that must never be disabled are still hardcoded (e.g. `RefreshCharacterAffiliationsService` every 5 minutes, `horizon:snapshot` every 5 minutes, `horizon:terminate` hourly).
 

--- a/database/migrations/2026_05_26_150000_seed_sde_import_schedule.php
+++ b/database/migrations/2026_05_26_150000_seed_sde_import_schedule.php
@@ -8,11 +8,15 @@ return new class extends Migration
 {
     public function up(): void
     {
+        // Only register the weekly recurring refresh. We deliberately do NOT import the SDE
+        // here: a migration must not download tens of thousands of rows as a side effect, and
+        // dispatching a queued job at migrate time makes a fresh install depend on Horizon
+        // running (and blocks/breaks CI's migrate:fresh). Initial population is an explicit
+        // step: `php artisan seatplus:sde-import` (add `--source=<sde.zip>` to skip the
+        // download). The scheduled job then keeps it up to date.
         Schedules::query()->firstOrCreate(
             ['job' => SdeImportJob::class],
             ['expression' => '0 0 * * 0'],
         );
-
-        SdeImportJob::dispatch();
     }
 };

--- a/src/Commands/SdeImportCommand.php
+++ b/src/Commands/SdeImportCommand.php
@@ -66,13 +66,15 @@ class SdeImportCommand extends Command
     {
         $this->info('Downloading SDE…');
 
-        $response = Http::timeout(300)->get(self::SDE_URL);
+        // Stream the response straight to disk (sink) instead of buffering the full
+        // multi-hundred-MB body in memory via $response->body(), which exhausts the default
+        // 128 MB CLI / Horizon-worker memory limit — a second cause of the SdeImportJob
+        // failures, independent of the queue retry_after window.
+        $response = Http::timeout(300)->sink($destination)->get(self::SDE_URL);
 
         if (! $response->successful()) {
             $this->fail("Download failed: HTTP {$response->status()}");
         }
-
-        file_put_contents($destination, $response->body());
     }
 
     private function extractSde(string $zipPath, string $targetDir): void

--- a/tests/Unit/Commands/SdeImportCommandTest.php
+++ b/tests/Unit/Commands/SdeImportCommandTest.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Queue;
 use Seatplus\Eveapi\Jobs\Seatplus\SdeImportJob;
+use Seatplus\Eveapi\Models\Schedules;
 use Seatplus\Eveapi\Models\Universe\Category;
 use Seatplus\Eveapi\Models\Universe\Constellation;
 use Seatplus\Eveapi\Models\Universe\Group;
@@ -234,10 +235,14 @@ it('removes nested subdirectories during cleanup', function () {
     expect(Category::find(6))->not->toBeNull();
 });
 
-it('seeds the SDE import schedule and dispatches SdeImportJob on migration', function () {
+it('seeds the SDE import schedule without importing on migration', function () {
     Queue::fake();
 
     (new (require __DIR__.'/../../../database/migrations/2026_05_26_150000_seed_sde_import_schedule.php'))->up();
 
-    Queue::assertPushed(SdeImportJob::class);
+    // Registers the weekly cadence but must not trigger the import itself — dispatching a
+    // queued job at migrate time would make a fresh install (and CI's migrate:fresh) depend
+    // on Horizon and download the SDE as a side effect.
+    expect(Schedules::where('job', SdeImportJob::class)->exists())->toBeTrue();
+    Queue::assertNotPushed(SdeImportJob::class);
 });


### PR DESCRIPTION
## Summary

Two related fixes so the SDE import stops failing and stops depending on Horizon at install time.

### 1. Don't import the SDE from the schedule migration
`2026_05_26_150000_seed_sde_import_schedule` called `SdeImportJob::dispatch()` in `up()`, so a fresh install imported the full CCP SDE **as a migration side effect**. That made `migrate:fresh` (including CI's) depend on a running Horizon worker and inherit the queue's failure modes (it was reliably dying with `MaxAttemptsExceeded`).

Now the migration only registers the weekly `Schedules` row. Initial population is an explicit step — `php artisan seatplus:sde-import` (`--source=<sde.zip>` to skip the download) — and the scheduled `SdeImportJob` keeps it current thereafter. The migration test now asserts the schedule row is seeded and that **no** job is pushed.

### 2. Stream the download instead of buffering it in memory
`downloadSde()` did `file_put_contents($dest, $response->body())`, loading the entire multi-hundred-MB zip into a string and exhausting the default 128 MB CLI/Horizon-worker memory limit — a second, independent cause of the `SdeImportJob` failures. Switched to the Http client's `sink()` to stream the response straight to disk; the import is already line-streamed, so peak memory is bounded regardless of SDE size. Covered by the existing `Http::fake` download test.

## Tests
`tests/Unit/Commands/SdeImportCommandTest.php` — all 10 pass (incl. the faked-download path exercising `sink`, the HTTP-error path, and the updated migration test). Pint + PHPStan clean.

> Companion fix in core (`config/queue.php`): `retry_after` raised above the longest Horizon worker timeout — a separate PR, since queue config lives in the app, not the package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)