### PR TITLE
feat: reliable character updates on scope change + force-update command (+ dev-DB test guard)

### DIFF
--- a/src/Commands/UpdateCharacterCommand.php
+++ b/src/Commands/UpdateCharacterCommand.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Seatplus\Eveapi\Commands;
+
+use Illuminate\Console\Command;
+use Seatplus\Eveapi\Jobs\Seatplus\UpdateCharacter;
+use Seatplus\Eveapi\Models\RefreshToken;
+
+class UpdateCharacterCommand extends Command
+{
+    protected $signature = 'seatplus:update-character {character_id : The character_id to force an update for}';
+
+    protected $description = 'Force-dispatch a high-priority update batch for a single character (bypasses the 30-minute schedule).';
+
+    public function handle(): int
+    {
+        $characterId = (int) $this->argument('character_id');
+
+        $refreshToken = RefreshToken::find($characterId);
+
+        if (! $refreshToken) {
+            $this->error("No refresh token for character {$characterId} — add or re-authenticate the character first.");
+
+            return self::FAILURE;
+        }
+
+        UpdateCharacter::dispatch($refreshToken, force: true)->onQueue('high');
+
+        $this->info("Dispatched a high-priority update batch for character {$characterId}.");
+
+        return self::SUCCESS;
+    }
+}

--- a/src/EveapiServiceProvider.php
+++ b/src/EveapiServiceProvider.php
@@ -44,6 +44,7 @@ use Seatplus\EsiClient\EsiConfiguration;
 use Seatplus\Eveapi\Commands\CheckJobsCommand;
 use Seatplus\Eveapi\Commands\ClearCache;
 use Seatplus\Eveapi\Commands\SdeImportCommand;
+use Seatplus\Eveapi\Commands\UpdateCharacterCommand;
 use Seatplus\Eveapi\Events\RefreshTokenCreated;
 use Seatplus\Eveapi\Events\UniverseConstellationCreated;
 use Seatplus\Eveapi\Events\UniverseSystemCreated;
@@ -255,6 +256,7 @@ class EveapiServiceProvider extends ServiceProvider
             ClearCache::class,
             CheckJobsCommand::class,
             SdeImportCommand::class,
+            UpdateCharacterCommand::class,
         ]);
     }
 

--- a/src/Jobs/Seatplus/Batch/CharacterBatchJob.php
+++ b/src/Jobs/Seatplus/Batch/CharacterBatchJob.php
@@ -11,6 +11,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Queue\Middleware\RateLimitedWithRedis;
 use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\DB;
 use Seatplus\Eveapi\Jobs\Assets\CharacterAssetJob;
 use Seatplus\Eveapi\Jobs\Assets\CharacterAssetsNameJob;
 use Seatplus\Eveapi\Jobs\Character\CharacterAffiliationJob;
@@ -52,6 +53,7 @@ class CharacterBatchJob implements ShouldBeUnique, ShouldQueue
         public $queue = 'default', // @pest-ignore-type
         array $batchJobs = [],
         public bool $reschedule = false,
+        public bool $force = false,
     ) {
         $this->refreshToken = RefreshToken::find($this->characterId);
         $this->batchJobs = $batchJobs ?: $this->createBatchJobs();
@@ -74,7 +76,9 @@ class CharacterBatchJob implements ShouldBeUnique, ShouldQueue
         // 1. Get BatchUpdate Entry
         $batchUpdate = $this->getBatchUpdate();
 
-        if ($this->shouldDiscardUpdate($batchUpdate)) {
+        // Force paths (scope change, seatplus:update-character) always run; only the scheduled
+        // catch-up defers to a previous batch that is genuinely still in flight.
+        if (! $this->force && $this->shouldDiscardUpdate($batchUpdate)) {
             return;
         }
         $this->resetBatchUpdate($batchUpdate);
@@ -304,9 +308,22 @@ class CharacterBatchJob implements ShouldBeUnique, ShouldQueue
         ]);
     }
 
-    private function shouldDiscardUpdate(mixed $batchUpdate): bool
+    private function shouldDiscardUpdate(BatchUpdate $batchUpdate): bool
     {
-        return $batchUpdate->is_pending;
+        if (! $batchUpdate->is_pending) {
+            return false;
+        }
+
+        // No time cap — a batch can legitimately run for a long time on large installs, so we
+        // never interrupt one by the clock. Skip only while the previous batch genuinely still
+        // exists and is in flight (neither finished nor cancelled). A crashed/pruned batch — or
+        // a force dispatch — falls through and re-runs, so a character is never silenced forever.
+        return $batchUpdate->batch_id !== null
+            && DB::table('job_batches')
+                ->where('id', $batchUpdate->batch_id)
+                ->whereNull('finished_at')
+                ->whereNull('cancelled_at')
+                ->exists();
     }
 
     public function resetBatchUpdate(BatchUpdate $batchUpdate): void

--- a/src/Jobs/Seatplus/UpdateCharacter.php
+++ b/src/Jobs/Seatplus/UpdateCharacter.php
@@ -42,7 +42,8 @@ class UpdateCharacter implements ShouldQueue
     use Queueable;
 
     public function __construct(
-        public ?RefreshToken $refreshToken = null
+        public ?RefreshToken $refreshToken = null,
+        public bool $force = false,
     ) {}
 
     public function handle(): void
@@ -56,7 +57,7 @@ class UpdateCharacter implements ShouldQueue
 
     private function updateSingleCharacter(): void
     {
-        CharacterBatchJob::dispatch($this->refreshToken->character_id)->onQueue('high');
+        CharacterBatchJob::dispatch($this->refreshToken->character_id, force: $this->force)->onQueue('high');
     }
 
     private function updateNextIncrementOfCharacters(): void

--- a/src/Listeners/UpdatingRefreshTokenListener.php
+++ b/src/Listeners/UpdatingRefreshTokenListener.php
@@ -42,7 +42,9 @@ class UpdatingRefreshTokenListener
         $newScopes = $this->getScopes($refreshToken->token);
 
         if (array_diff($newScopes, $originalScopes)) {
-            UpdateCharacter::dispatch($refreshToken)->onQueue('high');
+            // force: the scopes just changed — run a fresh batch even if a previous one is
+            // in flight (or stuck), so the newly-granted endpoint (e.g. assets) is fetched now.
+            UpdateCharacter::dispatch($refreshToken, force: true)->onQueue('high');
 
             $corporationId = data_get($refreshToken, 'character.corporation.corporation_id');
 

--- a/src/Models/BatchUpdate.php
+++ b/src/Models/BatchUpdate.php
@@ -14,8 +14,10 @@ use Illuminate\Support\Carbon;
 use Seatplus\Eveapi\Models\Character\CharacterInfo;
 
 /**
+ * @property string|null $batch_id
  * @property Carbon|null $started_at
  * @property Carbon|null $finished_at
+ * @property bool $is_pending
  */
 #[Unguarded]
 class BatchUpdate extends Model

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -21,6 +21,15 @@ abstract class TestCase extends OrchestraTestCase
     #[\Override]
     protected function setUp(): void
     {
+        // Hard stop: never run the suite against the dev database. The phpunit
+        // <env DB_DATABASE="laravel" force="true"> override has been observed to be bypassed
+        // in the local dev container (the shell exports DB_DATABASE=seatplus), in which case
+        // LazilyRefreshDatabase would migrate:fresh the dev DB and wipe it. Abort loudly
+        // before parent::setUp() boots anything or a factory touches the connection.
+        if (env('DB_DATABASE') === 'seatplus') {
+            throw new \RuntimeException('Test suite resolved DB_DATABASE=seatplus (the dev database) — aborting to avoid wiping dev data. The phpunit force override did not hold.');
+        }
+
         parent::setUp();
 
         // Setup factories

--- a/tests/Unit/Commands/UpdateCharacterCommandTest.php
+++ b/tests/Unit/Commands/UpdateCharacterCommandTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Support\Facades\Queue;
+use Seatplus\Eveapi\Jobs\Seatplus\UpdateCharacter;
+
+it('dispatches a high-priority UpdateCharacter for the given character', function () {
+    Queue::fake();
+
+    $characterId = testCharacter()->character_id;
+
+    $this->artisan('seatplus:update-character', ['character_id' => $characterId])
+        ->assertExitCode(0);
+
+    Queue::assertPushedOn('high', UpdateCharacter::class);
+});
+
+it('fails when no refresh token exists for the character', function () {
+    Queue::fake();
+
+    $this->artisan('seatplus:update-character', ['character_id' => 999999999])
+        ->assertExitCode(1);
+
+    Queue::assertNotPushed(UpdateCharacter::class);
+});

--- a/tests/Unit/Jobs/CharacterBatchJobTest.php
+++ b/tests/Unit/Jobs/CharacterBatchJobTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Seatplus\Eveapi\Jobs\Contacts\AllianceContactJob;
 use Seatplus\Eveapi\Jobs\Seatplus\Batch\CharacterBatchJob;
@@ -8,18 +9,86 @@ use Seatplus\Eveapi\Models\BatchStatistic;
 use Seatplus\Eveapi\Models\BatchUpdate;
 use Seatplus\Eveapi\Models\Character\CharacterInfo;
 
-it('discards update if still pending', function () {
-    $batchUpdate = new BatchUpdate;
+if (! function_exists('insertJobBatch')) {
+    // Minimal job_batches row so CharacterBatchJob's progress check has a batch to inspect.
+    // finished_at/cancelled_at null = still in flight.
+    function insertJobBatch(?int $finishedAt = null, ?int $cancelledAt = null): string
+    {
+        $id = (string) str()->uuid();
 
-    $batchUpdate->is_pending = true;
-    $batchUpdate->started_at = now();
+        DB::table('job_batches')->insert([
+            'id' => $id,
+            'name' => 'test',
+            'total_jobs' => 5,
+            'pending_jobs' => 3,
+            'failed_jobs' => 0,
+            'failed_job_ids' => '[]',
+            'options' => null,
+            'created_at' => now()->timestamp,
+            'finished_at' => $finishedAt,
+            'cancelled_at' => $cancelledAt,
+        ]);
 
-    $job = mock(CharacterBatchJob::class)->makePartial();
-    $job->shouldReceive('getBatchUpdate')->andReturn($batchUpdate);
+        return $id;
+    }
+}
 
-    $job->handle();
+it('discards update while the previous batch is still in flight', function () {
+    // in flight: no finished_at / cancelled_at
+    $batchId = insertJobBatch();
 
-    expect(BatchStatistic::all())->toHaveCount(0);
+    BatchUpdate::create([
+        'batchable_id' => testCharacter()->character_id,
+        'batchable_type' => CharacterInfo::class,
+        'started_at' => now(),
+        'finished_at' => null,
+        'batch_id' => $batchId,
+    ]);
+
+    Bus::fake();
+
+    (new CharacterBatchJob(testCharacter()->character_id, batchJobs: [fn () => 'test']))->handle();
+
+    Bus::assertNothingBatched();
+});
+
+it('re-runs when the pending batch is no longer in flight (finished but never recorded)', function () {
+    // is_pending on the BatchUpdate (started, its finished_at never got recorded) but the Bus
+    // batch has actually finished — the character must not stay silenced. No time cap involved.
+    $batchId = insertJobBatch(finishedAt: now()->timestamp);
+
+    BatchUpdate::create([
+        'batchable_id' => testCharacter()->character_id,
+        'batchable_type' => CharacterInfo::class,
+        'started_at' => now(),
+        'finished_at' => null,
+        'batch_id' => $batchId,
+    ]);
+
+    Bus::fake();
+
+    (new CharacterBatchJob(testCharacter()->character_id, batchJobs: [fn () => 'test']))->handle();
+
+    Bus::assertBatched(fn ($batch) => true);
+});
+
+it('runs even while a batch is in flight when forced', function () {
+    $batchId = insertJobBatch();
+
+    BatchUpdate::create([
+        'batchable_id' => testCharacter()->character_id,
+        'batchable_type' => CharacterInfo::class,
+        'started_at' => now(),
+        'finished_at' => null,
+        'batch_id' => $batchId,
+    ]);
+
+    Bus::fake();
+
+    (new CharacterBatchJob(testCharacter()->character_id, force: true, batchJobs: [fn () => 'test']))->handle();
+
+    // force bypasses the in-flight guard
+    Bus::assertBatched(fn ($batch) => true);
 });
 
 it('does not discard update if finished long ago', function () {


### PR DESCRIPTION
## Summary

Makes "add a scope → the matching update job runs" reliable, adds an on-demand force-update, and hard-guards the test suite against wiping the dev DB.

### 1. Don't let a stuck or in-flight batch block updates
The scope-change pipeline already works (`UpdatingRefreshTokenListener` dispatches `UpdateCharacter` on a scope diff → `CharacterBatchJob` → scope-gated jobs). The break was downstream: `CharacterBatchJob::shouldDiscardUpdate()` discarded **any** pending `BatchUpdate`. A batch that starts but never records `finished_at` (worker down, crash, DB reset) leaves `is_pending` true **forever**, so every later batch (scheduled *and* scope-triggered) early-returns and dispatches nothing — one stuck batch silences a character permanently.

**No time cap** — a batch legitimately runs a long time on large installs, so we never interrupt one by the clock. Instead the guard is **progress-based**: skip only while the previous Bus batch genuinely still exists and is *in flight* (a `job_batches` row with no `finished_at`/`cancelled_at`). A finished/pruned/crashed batch falls through and re-runs.

**Force flag** (threaded `UpdateCharacter` → `CharacterBatchJob`): the scope-change listener and the manual command dispatch `force=true`, so a newly-granted scope or an explicit refresh always runs a fresh batch — and un-sticks an abandoned one. Scheduled catch-up keeps the guard to avoid stampedes.

### 2. `seatplus:update-character {character_id}` command
Force-dispatches a high-priority `UpdateCharacter` for one character (bypasses the 30-min schedule and any in-flight/stuck batch). Errors cleanly when the character has no refresh token.

### 3. Dev-DB guard in `TestCase`
`setUp()` aborts (before `parent::setUp()`) if `env('DB_DATABASE') === 'seatplus'`. This surfaced — and stops — a real hazard: in the local dev container the phpunit `<env … force="true">` override does **not** win over the shell's exported `DB_DATABASE=seatplus`, so `vendor/bin/pest` was silently targeting and wiping the dev DB. Run locally with `DB_DATABASE=laravel` prefixed; CI unaffected.

## Tests
`CharacterBatchJobTest`: discards while a batch is in flight; re-runs when the pending batch is no longer in flight (finished but unrecorded); force bypasses the guard. `UpdateCharacterCommandTest`: dispatches on `high`, errors on unknown id. Existing `RefreshTokenLifeCycleTest`/`CharacterUpdateTest` stay green — 22 passed locally; Pint + PHPStan clean.

> Follow-up (separate PR): the update-path **write bottleneck** — `EnrichAssetTypeGroupCategoryJob` scans the whole assets table with per-row updates on every character batch, plus a few other per-row loops / unscoped `doesntHave()` scans. Profiled; fixes pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)