### PR TITLE
perf: cut redundant writes/scans in the character update batch (P1 + P4)

### DIFF
--- a/src/Jobs/Contracts/ContractItemsBase.php
+++ b/src/Jobs/Contracts/ContractItemsBase.php
@@ -44,7 +44,11 @@ abstract class ContractItemsBase extends EsiJob implements ShouldBeUnique
 
         ContractItem::upsert($contractItems->toArray(), ['record_id']);
 
-        ContractItem::doesntHave('type')
+        // Scope to the contract just written — an unscoped doesntHave() scans every contract's
+        // items in the system on every run.
+        ContractItem::query()
+            ->where('contract_id', $this->contractId)
+            ->doesntHave('type')
             ->pluck('type_id')
             ->unique()
             ->each(fn (int $typeId) => ResolveUniverseTypeByIdJob::dispatch($typeId)->onQueue('high'));

--- a/src/Jobs/Hydrate/Maintenance/EnrichAssetTypeGroupCategoryJob.php
+++ b/src/Jobs/Hydrate/Maintenance/EnrichAssetTypeGroupCategoryJob.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Seatplus\Eveapi\Jobs\Hydrate\Maintenance;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\DB;
 use Seatplus\Eveapi\Models\Assets\Asset;
@@ -50,7 +51,7 @@ class EnrichAssetTypeGroupCategoryJob extends HydrateMaintenanceBase
 
         // Bulk enrich: one UPDATE per distinct type (assets that share a type share their
         // group/category), instead of one UPDATE per asset row.
-        DB::transaction(fn () => $this->getAssetsWithMissingGroupAndCategoryInfo()
+        DB::transaction(fn () => $this->getAssetsToEnrich()
             ->groupBy('type_id')
             ->each(function (Collection $assets): void {
                 /** @var Asset $first */
@@ -69,11 +70,11 @@ class EnrichAssetTypeGroupCategoryJob extends HydrateMaintenanceBase
             }));
     }
 
-    private function getAssetsWithMissingGroupAndCategoryInfo(): Collection
+    private function getAssetsToEnrich(): Collection
     {
         return Asset::query()
             ->needsUniverseEnrichment()
-            ->when($this->characterId, fn ($query) => $query->where('assetable_id', $this->characterId))
+            ->when($this->characterId, fn (Builder $query) => $query->where('assetable_id', $this->characterId))
             ->with('type.group.category')
             ->get();
     }

--- a/src/Jobs/Hydrate/Maintenance/EnrichAssetTypeGroupCategoryJob.php
+++ b/src/Jobs/Hydrate/Maintenance/EnrichAssetTypeGroupCategoryJob.php
@@ -5,35 +5,57 @@ declare(strict_types=1);
 namespace Seatplus\Eveapi\Jobs\Hydrate\Maintenance;
 
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\DB;
 use Seatplus\Eveapi\Models\Assets\Asset;
 
 class EnrichAssetTypeGroupCategoryJob extends HydrateMaintenanceBase
 {
+    // $characterId scopes the enrichment to a single character's assets — the per-character
+    // update chain only ever adds that character's rows. Left null (MaintenanceJob) it enriches
+    // every unenriched asset globally. Scoping avoids re-scanning the whole assets table (all
+    // characters) on every character batch. Declared (not promoted) with a default so it stays
+    // initialised even when a test builds the job via a partial mock (no constructor call).
+    public ?int $characterId = null;
+
+    public function __construct(?int $characterId = null)
+    {
+        $this->characterId = $characterId;
+    }
+
     #[\Override]
     public function handle(): void
     {
-
         // check if batch is running
         if ($this->batch()?->cancelled()) {
             return;
         }
 
-        // get all assets with missing group_id and category_id
-        $assets = $this->getAssetsWithMissingGroupAndCategoryInfo();
+        // Bulk enrich: one UPDATE per distinct type (assets that share a type share their
+        // group/category), instead of one UPDATE per asset row.
+        DB::transaction(fn () => $this->getAssetsWithMissingGroupAndCategoryInfo()
+            ->groupBy('type_id')
+            ->each(function (Collection $assets): void {
+                /** @var Asset $first */
+                $first = $assets->first();
+                $type = $first->type;
 
-        $assets->each(fn (Asset $asset) => $asset->update([
-            'type_name_normalized' => $asset->type->name_normalized,
-            'group_id' => $asset->type->group->group_id,
-            'group_name_normalized' => $asset->type->group->name_normalized,
-            'category_id' => $asset->type->group->category->category_id,
-            'category_name_normalized' => $asset->type->group->category->name_normalized,
-        ]));
+                Asset::query()
+                    ->whereIn('item_id', $assets->pluck('item_id')->all())
+                    ->update([
+                        'type_name_normalized' => $type->name_normalized,
+                        'group_id' => $type->group->group_id,
+                        'group_name_normalized' => $type->group->name_normalized,
+                        'category_id' => $type->group->category->category_id,
+                        'category_name_normalized' => $type->group->category->name_normalized,
+                    ]);
+            }));
     }
 
     private function getAssetsWithMissingGroupAndCategoryInfo(): Collection
     {
         return Asset::query()
             ->whereNull('group_id')
+            ->when($this->characterId, fn ($query) => $query->where('assetable_id', $this->characterId))
             ->has('type.group.category')
             ->with('type.group.category')
             ->get();

--- a/src/Jobs/Seatplus/Batch/CharacterBatchJob.php
+++ b/src/Jobs/Seatplus/Batch/CharacterBatchJob.php
@@ -146,7 +146,7 @@ class CharacterBatchJob implements ShouldBeUnique, ShouldQueue
             [
                 new CharacterAssetJob($this->characterId),
                 new CharacterAssetsNameJob($this->characterId),
-                new EnrichAssetTypeGroupCategoryJob,
+                new EnrichAssetTypeGroupCategoryJob($this->characterId),
             ],
         ];
     }

--- a/src/Jobs/Wallet/WalletTransactionBase.php
+++ b/src/Jobs/Wallet/WalletTransactionBase.php
@@ -83,7 +83,11 @@ abstract class WalletTransactionBase extends EsiJob
 
     private function dispatchFollowUpJobs(): void
     {
+        // Scope the unresolved-type/location scans to this wallet's own transactions — an
+        // unscoped doesntHave() is a NOT EXISTS over every character's transactions on every run.
         WalletTransaction::query()
+            ->where('wallet_transactionable_id', $this->transactionableId())
+            ->where('wallet_transactionable_type', $this->transactionableType())
             ->doesntHave('type')
             ->pluck('type_id')
             ->unique()
@@ -91,6 +95,8 @@ abstract class WalletTransactionBase extends EsiJob
 
         $refreshToken = $this->getRefreshToken();
         WalletTransaction::query()
+            ->where('wallet_transactionable_id', $this->transactionableId())
+            ->where('wallet_transactionable_type', $this->transactionableType())
             ->doesntHave('location')
             ->pluck('location_id')
             ->unique()

--- a/tests/Jobs/Assets/EnrichAssetTypeGroupCategoryJobTest.php
+++ b/tests/Jobs/Assets/EnrichAssetTypeGroupCategoryJobTest.php
@@ -34,6 +34,25 @@ it('does not enrich asset if category is missing', function () {
         ->type_name_normalized->toBeNull();
 });
 
+it('only enriches the scoped character assets', function () {
+    $category = Event::fakeFor(fn () => Category::factory()->create());
+    $group = Event::fakeFor(fn () => Group::factory()->create(['category_id' => $category->category_id]));
+    $type = Event::fakeFor(fn () => Type::factory()->create(['group_id' => $group->group_id]));
+
+    $mine = Event::fakeFor(fn () => Asset::factory()->create(['type_id' => $type->type_id, 'assetable_id' => 100]));
+    $other = Event::fakeFor(fn () => Asset::factory()->create(['type_id' => $type->type_id, 'assetable_id' => 200]));
+
+    // Scoped to character 100. Not dispatched in a batch, so batch()?->cancelled() is null → proceeds.
+    (new EnrichAssetTypeGroupCategoryJob(100))->handle();
+
+    expect($mine->refresh()->type_name_normalized)->not->toBeNull()
+        ->and($mine->refresh()->group_id)->not->toBeNull();
+
+    // the other character's asset is left untouched — the scan no longer spans all characters
+    expect($other->refresh()->group_id)->toBeNull()
+        ->and($other->refresh()->type_name_normalized)->toBeNull();
+});
+
 it('enriches asset if category is present', function () {
 
     // Prepare data

--- a/tests/Unit/Jobs/WalletTransactionBaseTest.php
+++ b/tests/Unit/Jobs/WalletTransactionBaseTest.php
@@ -2,10 +2,31 @@
 
 use Seatplus\EsiClient\EsiClient;
 use Seatplus\EsiSchema\Responses\CharactersCharacterIdWalletTransactionsGetItem;
+use Seatplus\Eveapi\Jobs\Universe\ResolveUniverseTypeByIdJob;
 use Seatplus\Eveapi\Jobs\Wallet\CharacterWalletTransactionJob;
+use Seatplus\Eveapi\Models\Character\CharacterInfo;
 use Seatplus\Eveapi\Models\Wallet\WalletTransaction;
 
 beforeEach(fn () => Queue::fake());
+
+it('only resolves types for its own transactions, not another owner', function () {
+    $characterId = testCharacter()->character_id;
+
+    // An unresolved-type transaction belonging to a DIFFERENT character. Before the scope fix
+    // the follow-up scan was global and would resolve this; now it must be ignored.
+    WalletTransaction::factory()->create([
+        'wallet_transactionable_id' => 999999,
+        'wallet_transactionable_type' => CharacterInfo::class,
+        'type_id' => 8888,
+    ]);
+
+    $esi = Mockery::mock(EsiClient::class);
+    mockEsiTransport($esi, makeEsiResult([])); // this character has no transactions
+
+    (new CharacterWalletTransactionJob($characterId))->executeJob($esi);
+
+    Queue::assertNotPushed(ResolveUniverseTypeByIdJob::class);
+});
 
 it('sets from_id to latest transaction id minus one when latest transaction exists', function () {
     $characterId = testCharacter()->character_id;


### PR DESCRIPTION
## Summary

Two profiled write/scan bottlenecks in the per-character update batch. (P2 — bulk asset-name writes — deferred: a correct bulk update there needs a Postgres `UPDATE … FROM (VALUES …)` since the names endpoint can return ids we hold no row for; a naive upsert inserts orphans.)

### P1 — `EnrichAssetTypeGroupCategoryJob`: whole-table scan + per-row updates (the big one)
It scanned the **entire assets table across every character** (`whereNull('group_id')->get()`) and issued **one `UPDATE` per row with no transaction**, on *every* character's batch. Now:
- optional `characterId` — `CharacterBatchJob` passes it so the scan is scoped to that character's own assets; `MaintenanceJob` still runs it globally (`null`);
- bulk enrich — **one `UPDATE` per distinct type**, inside a transaction, instead of one per asset row.

### P4 — unscoped `doesntHave()` follow-up scans
`WalletTransactionBase` and `ContractItemsBase` dispatched resolver jobs off an unscoped `doesntHave()` — a `NOT EXISTS` over **every** character's transactions / **every** contract's items on each run. Scoped to the owner (`wallet_transactionable_id` + type) and the contract just written, mirroring `CharacterAssetJob`'s already-scoped pattern.

## Tests
New: enrich only touches the scoped character's assets (leaves another character's untouched); wallet follow-up resolves types only for its own transactions, not another owner's. Existing enrich / wallet / contract-item / maintenance / batch tests stay green — Pint + PHPStan clean.

> Independent of eveapi #695 (both branch off `4.x`; they touch different parts of `CharacterBatchJob`, so expect a trivial merge either way).

🤖 Generated with [Claude Code](https://claude.com/claude-code)