### PR TITLE
feat: denormalize root_location_id on assets (flat nested-asset filtering)

### DIFF
--- a/database/migrations/2026_07_13_120000_add_root_location_id_and_index_to_assets.php
+++ b/database/migrations/2026_07_13_120000_add_root_location_id_and_index_to_assets.php
@@ -1,0 +1,61 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('assets', function (Blueprint $table) {
+            // The top-level location an asset ultimately sits in. Lets the assets view filter
+            // "location contains a matching asset at any depth" as a single flat, indexed
+            // whereHas instead of a 3-level whereHas + PHP tree recursion.
+            // (location_id is already indexed via assets_location_id_index.)
+            $table->bigInteger('root_location_id')->nullable()->index();
+        });
+
+        $this->backfillRootLocationIds();
+    }
+
+    public function down(): void
+    {
+        Schema::table('assets', function (Blueprint $table) {
+            $table->dropColumn('root_location_id'); // drops its index too
+        });
+    }
+
+    /**
+     * Set root_location_id for every existing asset. Roots are assets whose location_id is not
+     * another of the same owner's item_ids (i.e. it points at a real Location); children
+     * (location_id == parent item_id) inherit the root's location_id. Scoped by owner so
+     * item_id / location_id ranges cannot collide across characters/corporations.
+     */
+    private function backfillRootLocationIds(): void
+    {
+        DB::statement(<<<'SQL'
+            WITH RECURSIVE tree AS (
+                SELECT a.item_id, a.assetable_id, a.assetable_type, a.location_id AS root_location_id
+                FROM assets a
+                WHERE NOT EXISTS (
+                    SELECT 1 FROM assets p
+                    WHERE p.item_id = a.location_id
+                      AND p.assetable_id = a.assetable_id
+                      AND p.assetable_type = a.assetable_type
+                )
+                UNION ALL
+                SELECT c.item_id, c.assetable_id, c.assetable_type, t.root_location_id
+                FROM assets c
+                JOIN tree t
+                  ON c.location_id = t.item_id
+                 AND c.assetable_id = t.assetable_id
+                 AND c.assetable_type = t.assetable_type
+            )
+            UPDATE assets SET root_location_id = tree.root_location_id
+            FROM tree
+            WHERE assets.item_id = tree.item_id
+        SQL);
+    }
+};

--- a/src/Jobs/Assets/CharacterAssetJob.php
+++ b/src/Jobs/Assets/CharacterAssetJob.php
@@ -13,6 +13,7 @@ use Seatplus\Eveapi\Jobs\Universe\ResolveUniverseTypeByIdJob;
 use Seatplus\Eveapi\Models\Assets\Asset;
 use Seatplus\Eveapi\Models\Character\CharacterInfo;
 use Seatplus\Eveapi\Models\RefreshToken;
+use Seatplus\Eveapi\Services\Assets\ResolveAssetRootLocations;
 
 final class CharacterAssetJob extends EsiJob
 {
@@ -74,12 +75,25 @@ final class CharacterAssetJob extends EsiJob
             ->whereNotIn('item_id', $this->assets->pluck('item_id')->toArray())
             ->delete();
 
+        $this->updateRootLocationIds();
+
         $this->resolveUnknownLocations();
         $this->resolveUnknownTypes();
 
         if (app()->bound('queue.worker')) {
             app('queue.worker')->shouldQuit = true;
         }
+    }
+
+    /**
+     * Set root_location_id (the top-level location an asset ultimately sits in) for this
+     * character's assets, resolved in-memory from the set just upserted — no extra query.
+     */
+    private function updateRootLocationIds(): void
+    {
+        $resolver = new ResolveAssetRootLocations;
+
+        $resolver->persist($resolver->resolve($this->assets));
     }
 
     private function resolveUnknownLocations(): void

--- a/src/Models/Assets/Asset.php
+++ b/src/Models/Assets/Asset.php
@@ -130,6 +130,7 @@ class Asset extends Model implements TypeWatchListInterface
         return [
             'assetable_id' => 'integer',
             'type_id' => 'integer',
+            'root_location_id' => 'integer',
         ];
     }
 }

--- a/src/Models/Universe/Location.php
+++ b/src/Models/Universe/Location.php
@@ -67,6 +67,16 @@ class Location extends Model implements LocationWatchListInterface
         return $this->hasMany(Asset::class, 'location_id', 'location_id');
     }
 
+    /**
+     * Every asset that ultimately sits in this location, at any nesting depth (flattened via the
+     * denormalized root_location_id). Lets "location contains a matching asset at any depth" be a
+     * single flat whereHas instead of the recursive assets/content/content.content traversal.
+     */
+    public function descendantAssets(): HasMany
+    {
+        return $this->hasMany(Asset::class, 'root_location_id', 'location_id');
+    }
+
     #[\Override]
     #[Scope]
     public function filterByRegionIds(Builder $query, int|array $regions): Builder

--- a/src/Services/Assets/ResolveAssetRootLocations.php
+++ b/src/Services/Assets/ResolveAssetRootLocations.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Seatplus\Eveapi\Services\Assets;
+
+use Illuminate\Support\Collection;
+use Seatplus\Eveapi\Models\Assets\Asset;
+
+/**
+ * Resolves each asset's root_location_id — the top-level location it ultimately sits in —
+ * by walking up the self-referential container chain (a child's location_id is its parent's
+ * item_id) until a location_id that isn't a sibling item_id (i.e. a real Location) is reached.
+ *
+ * Kept in PHP (no raw SQL) for the per-character ingest path: the asset set is already in
+ * memory there, so this is an O(N × depth) walk plus a handful of grouped PK updates.
+ */
+class ResolveAssetRootLocations
+{
+    /**
+     * @param  Collection<int, array{item_id: int, location_id: int}>  $assets
+     * @return Collection<int, int> item_id => root_location_id
+     */
+    public function resolve(Collection $assets): Collection
+    {
+        $locationByItemId = $assets->pluck('location_id', 'item_id');
+
+        return $assets->mapWithKeys(function (array $asset) use ($locationByItemId): array {
+            $locationId = $asset['location_id'];
+            $seen = [];
+
+            // Walk up while the current location_id points at another of these assets; the
+            // $seen guard makes malformed cyclic data terminate instead of looping forever.
+            while ($locationByItemId->has($locationId) && ! isset($seen[$locationId])) {
+                $seen[$locationId] = true;
+                $locationId = $locationByItemId->get($locationId);
+            }
+
+            return [$asset['item_id'] => $locationId];
+        });
+    }
+
+    /**
+     * @param  Collection<int, int>  $rootByItemId  item_id => root_location_id
+     */
+    public function persist(Collection $rootByItemId): void
+    {
+        // One grouped update per distinct root location — a character's assets cluster in a
+        // handful of stations/structures, so this is a few PK-indexed updates.
+        $rootByItemId
+            // preserveKeys so each group keeps its item_id keys (groupBy drops them by default).
+            ->groupBy(fn (int $rootLocationId): int => $rootLocationId, preserveKeys: true)
+            ->each(fn (Collection $group, int $rootLocationId) => Asset::query()
+                ->whereIn('item_id', $group->keys()->all())
+                ->update(['root_location_id' => $rootLocationId]));
+    }
+}

--- a/tests/Jobs/Assets/CharacterAssetTest.php
+++ b/tests/Jobs/Assets/CharacterAssetTest.php
@@ -116,6 +116,32 @@ it('does not dispatch ResolveLocationJob if location is known', function () {
     Queue::assertNotPushed(ResolveLocationJob::class);
 });
 
+it('sets root_location_id for the whole 3-level nesting chain', function () {
+    $characterId = testCharacter()->character_id;
+    $location = Location::factory()->create();
+
+    // capital (in a real location) → freighter → container: each child's location_id is its
+    // parent's item_id. All three should resolve to the top-level location.
+    $make = fn (array $overrides): object => (object) Asset::factory()
+        ->make(array_merge(['assetable_id' => $characterId], $overrides))
+        ->toArray();
+
+    $data = [
+        $make(['item_id' => 100, 'location_id' => $location->location_id, 'location_flag' => 'Hangar']),
+        $make(['item_id' => 200, 'location_id' => 100]),
+        $make(['item_id' => 300, 'location_id' => 200]),
+    ];
+
+    $esi = Mockery::mock(EsiClient::class);
+    mockEsiTransport($esi, makeEsiResult($data));
+
+    (new CharacterAssetJob($characterId))->executeJob($esi);
+
+    expect(Asset::find(100)->root_location_id)->toBe($location->location_id)
+        ->and(Asset::find(200)->root_location_id)->toBe($location->location_id)
+        ->and(Asset::find(300)->root_location_id)->toBe($location->location_id);
+});
+
 // Helpers
 function buildAssetMockEsiData(MockInterface $esi): Collection
 {

--- a/tests/Unit/Models/AssetModelTest.php
+++ b/tests/Unit/Models/AssetModelTest.php
@@ -13,6 +13,23 @@ beforeEach(function () {
     Queue::fake();
 });
 
+it('resolves descendantAssets on a location flatly via root_location_id', function () {
+    $location = Location::factory()->create();
+
+    // three assets at different nesting depths, all rooted in $location
+    Asset::factory()->count(3)->create([
+        'assetable_id' => testCharacter()->character_id,
+        'root_location_id' => $location->location_id,
+    ]);
+    // an asset rooted elsewhere must not be included
+    Asset::factory()->create([
+        'assetable_id' => testCharacter()->character_id,
+        'root_location_id' => Location::factory()->create()->location_id,
+    ]);
+
+    expect($location->descendantAssets)->toHaveCount(3);
+});
+
 test('model has types', function () {
     $testAsset = Asset::factory()->withType()->create();
 

--- a/tests/Unit/Services/Assets/ResolveAssetRootLocationsTest.php
+++ b/tests/Unit/Services/Assets/ResolveAssetRootLocationsTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use Seatplus\Eveapi\Services\Assets\ResolveAssetRootLocations;
+
+it('resolves the root location by walking the container chain to any depth', function () {
+    // 100 sits in a real location; 200 is inside 100; 300 is inside 200 (depth 3); 400 is a
+    // second top-level item in the same location.
+    $assets = collect([
+        ['item_id' => 100, 'location_id' => 60003760],
+        ['item_id' => 200, 'location_id' => 100],
+        ['item_id' => 300, 'location_id' => 200],
+        ['item_id' => 400, 'location_id' => 60003760],
+    ]);
+
+    $roots = (new ResolveAssetRootLocations)->resolve($assets);
+
+    expect($roots->get(100))->toBe(60003760)
+        ->and($roots->get(200))->toBe(60003760)
+        ->and($roots->get(300))->toBe(60003760)
+        ->and($roots->get(400))->toBe(60003760);
+});
+
+it('terminates on cyclic data instead of looping forever', function () {
+    $assets = collect([
+        ['item_id' => 100, 'location_id' => 200],
+        ['item_id' => 200, 'location_id' => 100],
+    ]);
+
+    $roots = (new ResolveAssetRootLocations)->resolve($assets);
+
+    expect($roots)->toHaveCount(2);
+});


### PR DESCRIPTION
## Summary

Groundwork for the character-assets InfiniteScroll refactor — cuts the DB cost of the nested-asset queries.

Assets nest up to 3 levels (capital ship → freighter → container) via a self-referential `location_id == parent item_id`. Today, filtering "a location contains a matching asset at **any** depth" (type/group/category) is a 3-level `whereHas('assets.content.content')` + PHP tree recursion, and the list eager-loads the whole tree.

This adds **`root_location_id`** — the top-level location an asset ultimately sits in:
- **Ingest (`CharacterAssetJob`)** resolves it in **plain PHP** via the `ResolveAssetRootLocations` service, from the asset set already in memory — no raw SQL in the job (an O(N×depth) walk + a few grouped PK `->update()`s).
- **Migration** backfills existing rows once with a recursive CTE — the idiomatic place for a one-time whole-table backfill; raw SQL stays out of jobs.
- **`Location::descendantAssets`** (`hasMany` on `root_location_id`) flattens the tree, so the depth filter becomes a single indexed `whereHas`.

(`location_id` turned out to already be indexed — `assets_location_id_index` — so no index change was needed there.)

## Tests
- `ResolveAssetRootLocations::resolve` resolves the root at any depth and terminates on cyclic data (pure unit test).
- `root_location_id` is set for the whole 3-level chain after ingest (`CharacterAssetTest`).
- `Location::descendantAssets` returns only assets rooted in that location (`AssetModelTest`).
- 24 passed; Pint + PHPStan clean.

> **Pairs with the web assets PR** (InfiniteScroll + axios/Ziggy removal + modal/deep-link) which uses `root_location_id` / `descendantAssets` — they must land together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)