### PR TITLE
fix: CorporationDivisionFactory writes division_type, not division_typ

### DIFF
--- a/database/factories/CorporationDivisionFactory.php
+++ b/database/factories/CorporationDivisionFactory.php
@@ -42,7 +42,7 @@ class CorporationDivisionFactory extends Factory
         return [
             'corporation_id' => fake()->unique()->numberBetween(98000000, 99000000),
             'division_id' => fake()->unique()->randomDigitNotNull,
-            'division_typ' => fake()->randomElement(['hangar', 'wallet']),
+            'division_type' => fake()->randomElement(['hangar', 'wallet']),
         ];
     }
 }


### PR DESCRIPTION
The factory set a `division_typ` key, but the column (and model/query usage) is `division_type`, so CorporationDivision::factory()->create() inserted an unknown column and failed. Correct the key.