### PR TITLE
perf(assets): chunk character asset upsert under the PostgreSQL placeholder cap

### DIFF
--- a/src/Jobs/Assets/CharacterAssetJob.php
+++ b/src/Jobs/Assets/CharacterAssetJob.php
@@ -19,6 +19,13 @@ final class CharacterAssetJob extends EsiJob
 {
     protected const string OPERATION_CLASS = GetCharactersCharacterIdAssets::class;
 
+    /**
+     * PostgreSQL rejects a statement with more than 65,535 bind parameters. The upsert payload
+     * carries 12 columns per row, so a single call tops out at 65,535 / 12 ≈ 5,461 rows. We chunk
+     * well below that ceiling to stay safe across drivers and future column additions.
+     */
+    private const int UPSERT_CHUNK_SIZE = 5000;
+
     private readonly Collection $assets;
 
     public function __construct(public int $characterId)
@@ -75,11 +82,11 @@ final class CharacterAssetJob extends EsiJob
             'root_item_id' => $roots->get($asset['item_id'])['root_item_id'],
         ]);
 
-        Asset::upsert($assetsWithRoots->toArray(), ['item_id'], [
+        $assetsWithRoots->chunk(self::UPSERT_CHUNK_SIZE)->each(fn (Collection $chunk): int => Asset::upsert($chunk->values()->toArray(), ['item_id'], [
             'assetable_id', 'assetable_type', 'is_blueprint_copy', 'is_singleton',
             'location_flag', 'location_id', 'location_type', 'quantity', 'type_id',
             'root_location_id', 'root_item_id',
-        ]);
+        ]));
 
         Asset::query()
             ->where('assetable_id', $this->characterId)


### PR DESCRIPTION
Fixes #639.

## Problem

PostgreSQL rejects any statement carrying more than **65,535 bind parameters**. `CharacterAssetJob` builds one big `Asset::upsert(...)` from every asset returned by ESI. The upsert payload has **12 columns** per row (`item_id`, `assetable_id`, `assetable_type`, `is_blueprint_copy`, `is_singleton`, `location_flag`, `location_id`, `location_type`, `quantity`, `type_id`, `root_location_id`, `root_item_id`), so a single call tops out at:

```
65,535 / 12 ≈ 5,461 rows
```

A character (or corp office) holding more assets than that throws and the sync fails.

## Fix

Chunk the payload before upserting:

```php
private const int UPSERT_CHUNK_SIZE = 5000;

$assetsWithRoots->chunk(self::UPSERT_CHUNK_SIZE)->each(fn (Collection $chunk): int => Asset::upsert(
    $chunk->values()->toArray(), ['item_id'], [/* same update columns */]
));
```

- **Chunk size 5,000** — comfortably below the 5,461 ceiling, leaving headroom for future column additions and non-PG drivers.
- The `uniqueBy` (`['item_id']`) and update-column list are unchanged, so behaviour is identical except it no longer explodes on large sets. The subsequent orphan-delete already keys off the full `$this->assets` collection, so it is unaffected.

## Jobs touched

- `src/Jobs/Assets/CharacterAssetJob.php` — the only asset upsert in the package. There is no `CorporationAssetJob`; corporation assets are not fetched via a large upsert, so nothing else needed changing.

## Gate results

```
vendor/bin/pint            → passed
vendor/bin/pint --test     → passed
phpstan analyse            → [OK] No errors
```

DB feature tests deferred to CI (Postgres unreachable in this environment; a math-only unit test on a private constant via reflection would be low value).

🤖 Generated with [Claude Code](https://claude.com/claude-code)