### PR TITLE
chore: remove dead esi-client connection config (#687)

### DIFF
--- a/config/eveapi.config.php
+++ b/config/eveapi.config.php
@@ -38,6 +38,9 @@ return [
         'sso_scheme' => env('EVE_SSO_SCHEME', 'https'),
         'sso_host' => env('EVE_SSO_HOST', 'login.eveonline.com'),
         'sso_port' => env('EVE_SSO_PORT', 443),
+        // Versioning — X-Compatibility-Date header (YYYY-MM-DD). Null keeps the
+        // esi-client's schema-matched default; set to pin a specific ESI spec date.
+        'compatibility_date' => env('EVE_ESI_COMPATIBILITY_DATE'),
         // Loging
         'logger_level' => Level::Info->value, // Monolog\Level case (Debug/Info/Warning/Error/…)
         'logfile_location' => storage_path('logs'),

--- a/config/eveapi.config.php
+++ b/config/eveapi.config.php
@@ -38,9 +38,8 @@ return [
         'sso_scheme' => env('EVE_SSO_SCHEME', 'https'),
         'sso_host' => env('EVE_SSO_HOST', 'login.eveonline.com'),
         'sso_port' => env('EVE_SSO_PORT', 443),
-        // Versioning — X-Compatibility-Date header (YYYY-MM-DD). Null keeps the
-        // esi-client's schema-matched default; set to pin a specific ESI spec date.
-        'compatibility_date' => env('EVE_ESI_COMPATIBILITY_DATE'),
+        // NB: compatibility_date is intentionally not configurable here — it is pinned to
+        // the installed esi-client/esi-schema version and set by esi-client's own default.
         // Loging
         'logger_level' => Level::Info->value, // Monolog\Level case (Debug/Info/Warning/Error/…)
         'logfile_location' => storage_path('logs'),

--- a/config/eveapi.config.php
+++ b/config/eveapi.config.php
@@ -29,18 +29,10 @@ use Monolog\Level;
 return [
 
     'esi-client' => [
-        // ESI
-        'datasource' => env('EVE_ESI_DATASOURCE', 'tranquility'),
-        'esi_scheme' => env('EVE_ESI_SCHEME', 'https'),
-        'esi_host' => env('EVE_ESI_HOST', 'esi.evetech.net'),
-        'esi_port' => env('EVE_ESI_PORT', 443),
-        // SSO
-        'sso_scheme' => env('EVE_SSO_SCHEME', 'https'),
-        'sso_host' => env('EVE_SSO_HOST', 'login.eveonline.com'),
-        'sso_port' => env('EVE_SSO_PORT', 443),
-        // NB: compatibility_date is intentionally not configurable here — it is pinned to
-        // the installed esi-client/esi-schema version and set by esi-client's own default.
-        // Loging
+        // Logging only. The ESI/SSO connection (datasource, scheme, host, port) and the
+        // X-Compatibility-Date header are esi-client's own concern — the base URL is
+        // esi.evetech.net and the compatibility date is pinned to the installed
+        // esi-client/esi-schema version, so neither is application-configurable.
         'logger_level' => Level::Info->value, // Monolog\Level case (Debug/Info/Warning/Error/…)
         'logfile_location' => storage_path('logs'),
     ],

--- a/src/EveapiServiceProvider.php
+++ b/src/EveapiServiceProvider.php
@@ -81,22 +81,6 @@ class EveapiServiceProvider extends ServiceProvider
         $esiConfiguration->logfile_location = config('eveapi.config.esi-client.logfile_location');
         $esiConfiguration->logger_level = config('eveapi.config.esi-client.logger_level');
 
-        // Wire the esi-client connection config so the EVE_ESI_*/EVE_SSO_* env vars are
-        // actually honoured. These keys were defined but never applied. The config
-        // defaults mirror EsiConfiguration's own, so behaviour is unchanged unless overridden.
-        $esiConfiguration->datasource = config('eveapi.config.esi-client.datasource');
-        $esiConfiguration->esi_scheme = config('eveapi.config.esi-client.esi_scheme');
-        $esiConfiguration->esi_host = config('eveapi.config.esi-client.esi_host');
-        $esiConfiguration->esi_port = (int) config('eveapi.config.esi-client.esi_port');
-        $esiConfiguration->sso_scheme = config('eveapi.config.esi-client.sso_scheme');
-        $esiConfiguration->sso_host = config('eveapi.config.esi-client.sso_host');
-        $esiConfiguration->sso_port = (int) config('eveapi.config.esi-client.sso_port');
-
-        // Deliberately NOT wired: compatibility_date (the X-Compatibility-Date header).
-        // It is welded to the generated esi-schema that the installed esi-client version
-        // ships, so it must track that package — not an operator env var, which could pin
-        // a date that mismatches the schema and break response deserialization.
-
         Model::preventLazyLoading(! app()->isProduction());
 
         // Add Migrations

--- a/src/EveapiServiceProvider.php
+++ b/src/EveapiServiceProvider.php
@@ -92,12 +92,10 @@ class EveapiServiceProvider extends ServiceProvider
         $esiConfiguration->sso_host = config('eveapi.config.esi-client.sso_host');
         $esiConfiguration->sso_port = (int) config('eveapi.config.esi-client.sso_port');
 
-        // Only override the X-Compatibility-Date header when explicitly configured;
-        // otherwise leave the esi-client's schema-matched default in place.
-        $compatibilityDate = config('eveapi.config.esi-client.compatibility_date');
-        if ($compatibilityDate !== null) {
-            $esiConfiguration->compatibility_date = $compatibilityDate;
-        }
+        // Deliberately NOT wired: compatibility_date (the X-Compatibility-Date header).
+        // It is welded to the generated esi-schema that the installed esi-client version
+        // ships, so it must track that package — not an operator env var, which could pin
+        // a date that mismatches the schema and break response deserialization.
 
         Model::preventLazyLoading(! app()->isProduction());
 

--- a/src/EveapiServiceProvider.php
+++ b/src/EveapiServiceProvider.php
@@ -81,6 +81,24 @@ class EveapiServiceProvider extends ServiceProvider
         $esiConfiguration->logfile_location = config('eveapi.config.esi-client.logfile_location');
         $esiConfiguration->logger_level = config('eveapi.config.esi-client.logger_level');
 
+        // Wire the esi-client connection config so the EVE_ESI_*/EVE_SSO_* env vars are
+        // actually honoured. These keys were defined but never applied. The config
+        // defaults mirror EsiConfiguration's own, so behaviour is unchanged unless overridden.
+        $esiConfiguration->datasource = config('eveapi.config.esi-client.datasource');
+        $esiConfiguration->esi_scheme = config('eveapi.config.esi-client.esi_scheme');
+        $esiConfiguration->esi_host = config('eveapi.config.esi-client.esi_host');
+        $esiConfiguration->esi_port = (int) config('eveapi.config.esi-client.esi_port');
+        $esiConfiguration->sso_scheme = config('eveapi.config.esi-client.sso_scheme');
+        $esiConfiguration->sso_host = config('eveapi.config.esi-client.sso_host');
+        $esiConfiguration->sso_port = (int) config('eveapi.config.esi-client.sso_port');
+
+        // Only override the X-Compatibility-Date header when explicitly configured;
+        // otherwise leave the esi-client's schema-matched default in place.
+        $compatibilityDate = config('eveapi.config.esi-client.compatibility_date');
+        if ($compatibilityDate !== null) {
+            $esiConfiguration->compatibility_date = $compatibilityDate;
+        }
+
         Model::preventLazyLoading(! app()->isProduction());
 
         // Add Migrations

--- a/tests/Unit/EveapiServiceProviderTest.php
+++ b/tests/Unit/EveapiServiceProviderTest.php
@@ -38,7 +38,6 @@ it('wires the esi-client connection config onto the EsiConfiguration singleton o
         'eveapi.config.esi-client.sso_scheme' => 'http',
         'eveapi.config.esi-client.sso_host' => 'login.example.test',
         'eveapi.config.esi-client.sso_port' => 9443,
-        'eveapi.config.esi-client.compatibility_date' => '2020-01-01',
     ]);
 
     $serviceProvider = new EveapiServiceProvider(app());
@@ -51,20 +50,19 @@ it('wires the esi-client connection config onto the EsiConfiguration singleton o
         ->esi_port->toBe(8443)
         ->sso_scheme->toBe('http')
         ->sso_host->toBe('login.example.test')
-        ->sso_port->toBe(9443)
-        ->compatibility_date->toBe('2020-01-01');
+        ->sso_port->toBe(9443);
 });
 
-it('keeps the esi-client default compatibility date when none is configured', function () {
+it('leaves the esi-client schema-matched compatibility date untouched', function () {
     EsiConfiguration::resetInstance();
-
-    config(['eveapi.config.esi-client.compatibility_date' => null]);
 
     $default = (new EsiConfiguration)->compatibility_date;
 
     $serviceProvider = new EveapiServiceProvider(app());
     $serviceProvider->boot();
 
+    // eveapi must not override compatibility_date — it is pinned to the installed
+    // esi-client/esi-schema version, not to application config.
     expect(EsiConfiguration::getInstance()->compatibility_date)->toBe($default);
 });
 

--- a/tests/Unit/EveapiServiceProviderTest.php
+++ b/tests/Unit/EveapiServiceProviderTest.php
@@ -27,6 +27,47 @@ it('sets EVE-compliant user agent on boot', function () {
         ->toContain('+https://github.com/seatplus/eveapi');
 });
 
+it('wires the esi-client connection config onto the EsiConfiguration singleton on boot', function () {
+    EsiConfiguration::resetInstance();
+
+    config([
+        'eveapi.config.esi-client.datasource' => 'singularity',
+        'eveapi.config.esi-client.esi_scheme' => 'http',
+        'eveapi.config.esi-client.esi_host' => 'esi.example.test',
+        'eveapi.config.esi-client.esi_port' => 8443,
+        'eveapi.config.esi-client.sso_scheme' => 'http',
+        'eveapi.config.esi-client.sso_host' => 'login.example.test',
+        'eveapi.config.esi-client.sso_port' => 9443,
+        'eveapi.config.esi-client.compatibility_date' => '2020-01-01',
+    ]);
+
+    $serviceProvider = new EveapiServiceProvider(app());
+    $serviceProvider->boot();
+
+    expect(EsiConfiguration::getInstance())
+        ->datasource->toBe('singularity')
+        ->esi_scheme->toBe('http')
+        ->esi_host->toBe('esi.example.test')
+        ->esi_port->toBe(8443)
+        ->sso_scheme->toBe('http')
+        ->sso_host->toBe('login.example.test')
+        ->sso_port->toBe(9443)
+        ->compatibility_date->toBe('2020-01-01');
+});
+
+it('keeps the esi-client default compatibility date when none is configured', function () {
+    EsiConfiguration::resetInstance();
+
+    config(['eveapi.config.esi-client.compatibility_date' => null]);
+
+    $default = (new EsiConfiguration)->compatibility_date;
+
+    $serviceProvider = new EveapiServiceProvider(app());
+    $serviceProvider->boot();
+
+    expect(EsiConfiguration::getInstance()->compatibility_date)->toBe($default);
+});
+
 it('tests horizon auth with user', function () {
 
     $serviceProvider = new EveapiServiceProvider(app());

--- a/tests/Unit/EveapiServiceProviderTest.php
+++ b/tests/Unit/EveapiServiceProviderTest.php
@@ -27,43 +27,22 @@ it('sets EVE-compliant user agent on boot', function () {
         ->toContain('+https://github.com/seatplus/eveapi');
 });
 
-it('wires the esi-client connection config onto the EsiConfiguration singleton on boot', function () {
+it('leaves the esi-client connection + compatibility date untouched', function () {
     EsiConfiguration::resetInstance();
 
-    config([
-        'eveapi.config.esi-client.datasource' => 'singularity',
-        'eveapi.config.esi-client.esi_scheme' => 'http',
-        'eveapi.config.esi-client.esi_host' => 'esi.example.test',
-        'eveapi.config.esi-client.esi_port' => 8443,
-        'eveapi.config.esi-client.sso_scheme' => 'http',
-        'eveapi.config.esi-client.sso_host' => 'login.example.test',
-        'eveapi.config.esi-client.sso_port' => 9443,
-    ]);
+    $defaults = new EsiConfiguration;
 
     $serviceProvider = new EveapiServiceProvider(app());
     $serviceProvider->boot();
 
+    // eveapi must not override esi-client's connection or versioning config — the base
+    // URL is fixed and the compatibility date is pinned to the installed esi-schema.
     expect(EsiConfiguration::getInstance())
-        ->datasource->toBe('singularity')
-        ->esi_scheme->toBe('http')
-        ->esi_host->toBe('esi.example.test')
-        ->esi_port->toBe(8443)
-        ->sso_scheme->toBe('http')
-        ->sso_host->toBe('login.example.test')
-        ->sso_port->toBe(9443);
-});
-
-it('leaves the esi-client schema-matched compatibility date untouched', function () {
-    EsiConfiguration::resetInstance();
-
-    $default = (new EsiConfiguration)->compatibility_date;
-
-    $serviceProvider = new EveapiServiceProvider(app());
-    $serviceProvider->boot();
-
-    // eveapi must not override compatibility_date — it is pinned to the installed
-    // esi-client/esi-schema version, not to application config.
-    expect(EsiConfiguration::getInstance()->compatibility_date)->toBe($default);
+        ->datasource->toBe($defaults->datasource)
+        ->esi_host->toBe($defaults->esi_host)
+        ->esi_scheme->toBe($defaults->esi_scheme)
+        ->esi_port->toBe($defaults->esi_port)
+        ->compatibility_date->toBe($defaults->compatibility_date);
 });
 
 it('tests horizon auth with user', function () {


### PR DESCRIPTION
Closes #687.

## What #687 reported
The `esi-client` config block in `config/eveapi.config.php` defined `datasource`, `esi_scheme`, `esi_host`, `esi_port`, `sso_scheme`, `sso_host`, `sso_port` (env-backed) but nothing ever applied them to `EsiConfiguration` — dead config.

## Resolution: delete, don't wire
After review, wiring these through was the wrong call:

- **`sso_scheme` / `sso_host` / `sso_port`** are read **nowhere** in esi-client. The SSO endpoints are hardcoded constants (`UpdateRefreshTokenService::TOKEN_URL`, `VerifyAccessToken::JWKS_URL`, …), so these keys are dead on both sides.
- **`datasource` / `esi_scheme` / `esi_host` / `esi_port`** are read by esi-client's legacy URL assembly (`EsiClient::buildDataUri`), but the current ESI is a single host (`esi.evetech.net`) versioned by the `X-Compatibility-Date` header — so operator-overriding scheme/host/port/datasource is moot, and `datasource=singularity` no longer exists.
- **`compatibility_date`** must never be operator config: it is pinned to the generated `esi-schema` that the installed esi-client version ships; a mismatched date would break response deserialization.

So the whole connection block is removed. esi-client keeps its own correct defaults, so **behaviour is unchanged** — this only deletes config that never did anything. Only the genuinely-applied logging keys (`logfile_location`, `logger_level`) remain.

## Changes
- `config/eveapi.config.php` — drop the dead ESI/SSO connection keys; keep logging.
- `tests/Unit/EveapiServiceProviderTest.php` — regression guard asserting eveapi leaves esi-client's connection + compatibility date at their defaults.
- `EveapiServiceProvider` — net unchanged (only logging was ever wired).

Static gate green: `pint --test` + `phpstan analyse`. DB feature tests deferred to CI (Postgres unreachable in the dev container).

🤖 Generated with [Claude Code](https://claude.com/claude-code)