### PR TITLE
perf: index corporation_infos.alliance_id

### DIFF
--- a/database/migrations/2026_07_30_120000_add_index_to_corporation_infos_alliance_id.php
+++ b/database/migrations/2026_07_30_120000_add_index_to_corporation_infos_alliance_id.php
@@ -1,0 +1,17 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('corporation_infos', function (Blueprint $table) {
+            // seatplus/auth's AffiliationResolver joins corporation_infos on alliance_id to expand an
+            // alliance affiliation to its member corporations; the column was unindexed.
+            $table->index('alliance_id');
+        });
+    }
+};


### PR DESCRIPTION
## Context

seatplus/auth's new `AffiliationResolver` expands an alliance affiliation to its member corporations by joining `corporation_infos` on `alliance_id` (mirroring `AllianceInfo::corporations()` — `hasMany(CorporationInfo, 'alliance_id')`). That column was never indexed, so the join is a sequential scan on every affiliation resolution / permission check.

## Change

Additive migration adding a btree index on `corporation_infos.alliance_id`. No `down()` (per this package's migration convention).

## Verification

Pint, PHPStan (`[OK] No errors`), and 100% type-coverage pass; `migrate:fresh` applies the index cleanly (`CorporationInfoTest` green under `LazilyRefreshDatabase`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)