### PR TITLE
chore: run CI on the 5.x branch line

### DIFF
--- a/.github/workflows/formats.yml
+++ b/.github/workflows/formats.yml
@@ -5,7 +5,7 @@ on:
     paths:
       - '**.php'
   pull_request:
-    branches: [ 4.x ]
+    branches: [ 4.x, 5.x ]
 
 jobs:
   ci:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   push:
-    branches: [ 3.x, 4.x ]
+    branches: [ 3.x, 4.x, 5.x ]
   pull_request:
-    branches: [ 3.x, 4.x ]
+    branches: [ 3.x, 4.x, 5.x ]
 
 jobs:
   ci:


### PR DESCRIPTION
Add 5.x to the push/pull_request triggers so the new major line gets CI (aligning eveapi with auth/web on 5.x).