### PR TITLE
test: analyse tests/ with PHPStan (pest-plugin-phpstan rollout)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,8 @@
         "rector/rector": "^2.0",
         "driftingly/rector-laravel": "^2.0",
         "laravel/pint": "^1.9",
-        "dg/bypass-finals": "^1.9"
+        "dg/bypass-finals": "^1.9",
+        "phpstan/phpstan-mockery": "^2.0"
     },
     "extra": {
         "laravel": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,9 +1,9 @@
 includes:
     - vendor/larastan/larastan/extension.neon
-    # Pest-aware static analysis. `tests` is intentionally kept out of `paths`
-    # below for now — analysing the suite surfaces Mockery false-positives and
-    # redundant-expectation findings handled in a dedicated follow-up.
+    # Pest-aware static analysis (understands it()/expect()/$this).
     - vendor/pestphp/pest-plugin-phpstan/extension.neon
+    # Understands Mockery's dynamic API (shouldReceive(), etc.).
+    - vendor/phpstan/phpstan-mockery/extension.neon
 
 parameters:
     databaseMigrationsPath:
@@ -14,8 +14,55 @@ parameters:
         - src
         - config
         - database
+        - tests
     tmpDir: build/phpstan
     checkOctaneCompatibility: true
     checkModelProperties: true
     configDirectories:
         - config
+    ignoreErrors:
+        # pest.expectation.redundant flags assertions a strict return type / Larastan
+        # already guarantees; failOnRisky makes deleting sole-assertion cases unsafe.
+        # pest.expectation.impossible (real, unsatisfiable assertions) stays active.
+        -
+            identifier: pest.expectation.redundant
+        # filterBy*Ids are #[Scope]-attributed query scopes; Larastan does not yet
+        # resolve the #[Scope] attribute onto the Builder type (same gap as #[Table]).
+        -
+            message: '#Call to an undefined method Illuminate\\Database\\Eloquent\\Builder<.*>::filterBy(Type|Group|Category|Region|System)Ids\(\)#'
+        # Pest higher-order proxy: dynamic test-state props (test()->x / $this->x set
+        # in setUp) are not statically declared on the proxy type.
+        -
+            message: '#Access to an undefined property Pest\\(PendingCalls\\TestCall|Support\\HigherOrderTapProxy).*::\$#'
+        # Mockery's dynamic API: partial-mock method calls and property reads on a
+        # bare MockInterface (phpstan-mockery types shouldReceive(), not these).
+        -
+            message: '#(Call to an undefined method|Access to an undefined property) Mockery\\(Legacy)?MockInterface::#'
+        # Pest higher-order expectation chaining (expect()->first(), ->getRawOriginal(),
+        # TestCall::expectExceptionMessage()) — dynamic, not statically typed.
+        -
+            message: '#Call to an undefined method Pest\\(Expectation|Expectations\\HigherOrderExpectation|PendingCalls\\TestCall)#'
+        # Anonymous test-double classes declare return types the doubles never use.
+        -
+            identifier: return.unusedType
+        # Cross-package: eveapi tests reference auth''s User (auth depends on eveapi,
+        # not the reverse) — resolvable only in the assembled app.
+        -
+            message: '#Class Seatplus\\Auth\\Models\\User not found#'
+        # Intentional env() call: the setUp() dev-DB safety guard (see the comment there).
+        -
+            identifier: larastan.noEnvCallsOutsideOfConfig
+            path: tests/TestCase.php
+        # Larastan infers RefreshToken::$token as never (model-property inference gap).
+        -
+            message: '#Property Seatplus\\Eveapi\\Models\\RefreshToken::\$token#'
+        # Pre-existing orphaned PHPUnit-style function (never registered as a Pest test).
+        -
+            message: '#Undefined variable: \$this#'
+            path: tests/Unit/Models/CorporationMemberTrackingTest.php
+        # The queued job mutates its static $handled through serialize()/handle();
+        # PHPStan's flow analysis only sees the `= false` set just before, so it
+        # (wrongly) reports the later toBeTrue() as impossible. Runtime is correct.
+        -
+            identifier: pest.expectation.impossible
+            path: tests/Unit/EveapiServiceProviderTest.php

--- a/tests/Jobs/Contacts/ContactJobTest.php
+++ b/tests/Jobs/Contacts/ContactJobTest.php
@@ -98,6 +98,7 @@ test('ContactJob using ContactBaseJob and finds refresh_token', function (string
         'character_label' => new CharacterContactLabelJob($this->test_character->character_id),
         'corporation_label' => new CorporationContactLabelJob($this->test_character->corporation->corporation_id, testCharacter()->character_id),
         'alliance_label' => new AllianceContactLabelJob($this->test_character->corporation->alliance->alliance_id, testCharacter()->character_id),
+        default => throw new UnhandledMatchError,
     };
 
     expect($job->getRefreshToken())->character_id->toBe($this->test_character->character_id);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -60,11 +60,6 @@ abstract class TestCase extends OrchestraTestCase
         ];
     }
 
-    /**
-     * Define environment setup.
-     *
-     * @param  Application  $app
-     */
     #[\Override]
     protected function tearDown(): void
     {

--- a/tests/Unit/EveapiServiceProviderTest.php
+++ b/tests/Unit/EveapiServiceProviderTest.php
@@ -151,7 +151,7 @@ class RateLimitedTestJob
 {
     use InteractsWithQueue, Queueable;
 
-    public static $handled = false;
+    public static bool $handled = false;
 
     public function __construct(public $refreshToken) {}
 

--- a/tests/Unit/Models/AssetModelTest.php
+++ b/tests/Unit/Models/AssetModelTest.php
@@ -135,6 +135,7 @@ it('has in scope', function (string $scope) {
         'ofTypes' => $query->filterByTypeIds($type->type_id),
         'ofGroups' => $query->filterByGroupIds($type->group->group_id),
         'ofCategories' => $query->filterByCategoryIds($type->group->category->category_id),
+        default => throw new UnhandledMatchError,
     };
 
     expect($query->get())->toHaveCount(1);

--- a/tests/Unit/Models/ContactTest.php
+++ b/tests/Unit/Models/ContactTest.php
@@ -96,6 +96,7 @@ it('has has affiliation relationship', function (string $contactType) {
         'corporation' => $affiliation->corporation_id,
         'alliance' => $affiliation->alliance_id,
         'faction' => $affiliation->faction_id,
+        default => throw new UnhandledMatchError,
     };
 
     Contact::factory()->create([

--- a/tests/Unit/Models/ContractModelTest.php
+++ b/tests/Unit/Models/ContractModelTest.php
@@ -29,7 +29,8 @@ it('has inRegionScope', function (string $locationId) {
 
     $regionId = match ($locationId) {
         'start_location_id' => $testContract->startLocation->locatable->system->region->region_id,
-        'end_location_id' => $testContract->endLocation->locatable->system->region->region_id
+        'end_location_id' => $testContract->endLocation->locatable->system->region->region_id,
+        default => throw new UnhandledMatchError,
     };
 
     expect(Contract::query()->filterByRegionIds($regionId)->get())->toHaveCount(1)
@@ -53,7 +54,8 @@ it('has inSystemScope', function (string $locationId) {
 
     $systemId = match ($locationId) {
         'start_location_id' => $testContract->startLocation->locatable->system->system_id,
-        'end_location_id' => $testContract->endLocation->locatable->system->system_id
+        'end_location_id' => $testContract->endLocation->locatable->system->system_id,
+        default => throw new UnhandledMatchError,
     };
 
     expect(Contract::query()->filterBySystemIds($systemId)->get())->toHaveCount(1)


### PR DESCRIPTION
## What & why
`pest-plugin-phpstan` was wired but **`tests` was never in phpstan `paths`**, so the suite was never analysed. This finishes the rollout (#710) — following the esi-client pilot (seatplus/esi-client#39).

## Changes
- **`tests` added to phpstan `paths`** + **`phpstan/phpstan-mockery`** (dep + `includes`). Took the suite from **263 findings → 0**.
- **Genuine bugs fixed:** 5 non-exhaustive `match()` in tests → explicit `default` arms; test job's static `$handled` typed `bool`; a stray `@param $app` docblock removed.
- **Scoped, documented `ignoreErrors`** for systematic false-positives / environmental findings (Larastan already resolves the Eloquent model access — that's purely the Rector track's problem): `pest.expectation.redundant` (style rule; `impossible` stays active), `#[Scope]` `filterBy*Ids`, Pest higher-order proxy/expectation chaining, Mockery's dynamic API, anonymous test-double return types, the `setUp()` env() dev-DB guard, cross-package `auth\User`, a `RefreshToken::$token` inference gap, plus one static-mutated-through-queue `impossible()` and one pre-existing orphaned PHPUnit-style function.

## Result
`test:types` (src + tests) ✓ · `test:type-coverage` 100% ✓ · `test:lint` ✓ · edited test files pass.

Same CI note as the pilot: this repo's `formats` job (which runs `test:types`) is branch-filtered to `4.x`, so it doesn't run on a PR stacked on `chore/pest-5-upgrade` — validated locally; runs in CI once the stack targets `4.x`.

Closes #710

🤖 Generated with [Claude Code](https://claude.com/claude-code)