### PR TITLE
Fix cancelled-batch guard short-circuiting via batching() and modernize job tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 
 # macOS metadata
 .DS_Store
+.claude/

--- a/composer.json
+++ b/composer.json
@@ -44,8 +44,7 @@
         "larastan/larastan": "^3.0",
         "rector/rector": "^2.0",
         "driftingly/rector-laravel": "^2.0",
-        "laravel/pint": "^1.9",
-        "dg/bypass-finals": "^1.9"
+        "laravel/pint": "^1.9"
     },
     "extra": {
         "laravel": {

--- a/rector.php
+++ b/rector.php
@@ -27,11 +27,11 @@ return RectorConfig::configure()
         // Single-version PHP sets, deliberately NOT LevelSetList::UP_TO_PHP_85 — that one
         // is cumulative (php85 + up-to-php84 + … down to 7.x), so on a tree that had never
         // been Rector-clean it also applied long-pending 8.0/8.1/8.3 rewrites that have
-        // nothing to do with the PHP floor moving to 8.5. Two of them were not behaviour
-        // preserving here (constructor promotion under a partial mock that skips the
-        // constructor; arrow-function-to-first-class-callable where the closure is later
-        // rebound via Closure::call()). Scoping to 8.4 + 8.5 keeps this config to the
-        // version bump it is named for. Adopt older levels deliberately if ever wanted.
+        // nothing to do with the PHP floor moving to 8.5. At least one of them was not
+        // behaviour preserving here (arrow-function-to-first-class-callable where the
+        // closure is later rebound via Closure::call()). Scoping to 8.4 + 8.5 keeps this
+        // config to the version bump it is named for. Adopt older levels deliberately if
+        // ever wanted.
         SetList::PHP_84,
         SetList::PHP_85,
     ])

--- a/src/Jobs/Alliances/AllianceInfoJob.php
+++ b/src/Jobs/Alliances/AllianceInfoJob.php
@@ -24,7 +24,10 @@ final class AllianceInfoJob extends EsiJob
     #[\Override]
     public function executeJob(EsiClient $esi): void
     {
-        if ($this->batching() && $this->batch()->cancelled()) {
+        // batching() is already false for a cancelled batch (it is
+        // `$batch && ! finished() && ! cancelled()`), so it must not gate this check —
+        // `batching() && batch()->cancelled()` can never be true.
+        if ($this->batch()?->cancelled()) {
             return;
         }
 

--- a/src/Jobs/Assets/CharacterAssetsNameJob.php
+++ b/src/Jobs/Assets/CharacterAssetsNameJob.php
@@ -50,7 +50,10 @@ final class CharacterAssetsNameJob extends EsiJob
     #[\Override]
     public function executeJob(EsiClient $esi): void
     {
-        if ($this->batching() && $this->batch()->cancelled()) {
+        // batching() is already false for a cancelled batch (it is
+        // `$batch && ! finished() && ! cancelled()`), so it must not gate this check —
+        // `batching() && batch()->cancelled()` can never be true.
+        if ($this->batch()?->cancelled()) {
             return;
         }
 

--- a/src/Jobs/Contracts/ContractItemsBase.php
+++ b/src/Jobs/Contracts/ContractItemsBase.php
@@ -23,7 +23,10 @@ abstract class ContractItemsBase extends EsiJob implements ShouldBeUnique
     #[\Override]
     public function executeJob(EsiClient $esi): void
     {
-        if ($this->batching() && $this->batch()->cancelled()) {
+        // batching() is already false for a cancelled batch (it is
+        // `$batch && ! finished() && ! cancelled()`), so it must not gate this check —
+        // `batching() && batch()->cancelled()` can never be true.
+        if ($this->batch()?->cancelled()) {
             return;
         }
 

--- a/src/Jobs/Hydrate/Maintenance/EnrichAssetTypeGroupCategoryJob.php
+++ b/src/Jobs/Hydrate/Maintenance/EnrichAssetTypeGroupCategoryJob.php
@@ -11,17 +11,13 @@ use Seatplus\Eveapi\Models\Assets\Asset;
 
 class EnrichAssetTypeGroupCategoryJob extends HydrateMaintenanceBase
 {
-    // $characterId scopes the enrichment to a single character's assets — the per-character
-    // update chain only ever adds that character's rows. Left null (MaintenanceJob / observers)
-    // it enriches every unenriched asset globally. Scoping avoids re-scanning the whole assets
-    // table (all characters) on every character batch. Declared (not promoted) with a default so
-    // it stays initialised even when a test builds the job via a partial mock (no constructor call).
-    public ?int $characterId = null;
-
-    public function __construct(?int $characterId = null)
-    {
-        $this->characterId = $characterId;
-    }
+    /**
+     * $characterId scopes the enrichment to a single character's assets — the per-character
+     * update chain only ever adds that character's rows. Left null (MaintenanceJob / observers)
+     * it enriches every unenriched asset globally. Scoping avoids re-scanning the whole assets
+     * table (all characters) on every character batch.
+     */
+    public function __construct(public ?int $characterId = null) {}
 
     /**
      * Re-trigger enrichment when SDE data lands late, but only if at least one

--- a/tests/Integration/MailIntegrationTest.php
+++ b/tests/Integration/MailIntegrationTest.php
@@ -2,7 +2,6 @@
 
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Queue;
-use Mockery\MockInterface;
 use Seatplus\EsiClient\EsiClient;
 use Seatplus\Eveapi\Jobs\Mail\MailBodyJob;
 use Seatplus\Eveapi\Jobs\Mail\MailHeaderJob;
@@ -65,13 +64,15 @@ it('adds MailBodyJob to batch if batched', function () {
     // Create 5 mails in DB without body
     $mails = Event::fakeFor(fn () => Mail::factory()->count(5)->create(['body' => null]));
 
-    $job = mock(MailHeaderJob::class, function (MockInterface $mock) {
-        $mock->characterId = testCharacter()->character_id;
-        $mock->shouldReceive('batching')->andReturnTrue();
-        $mock->shouldReceive('batch->add')->times(5);
-    })->makePartial();
+    [$job, $batch] = new MailHeaderJob(testCharacter()->character_id)->withFakeBatch();
 
     // handleMailBody is public — call it directly with the mail collection mapped to expected shape
     $mailCollection = $mails->map(fn ($mail) => ['id' => $mail->id]);
     $job->handleMailBody(collect($mailCollection));
+
+    expect($batch->added)
+        ->toHaveCount(5)
+        ->each->toBeInstanceOf(MailBodyJob::class);
+
+    Queue::assertNothingPushed();
 });

--- a/tests/Jobs/Assets/EnrichAssetTypeGroupCategoryJobTest.php
+++ b/tests/Jobs/Assets/EnrichAssetTypeGroupCategoryJobTest.php
@@ -16,11 +16,7 @@ it('does not enrich asset if category is missing', function () {
         'type_id' => $type->type_id,
     ]));
 
-    $mock = Mockery::mock(EnrichAssetTypeGroupCategoryJob::class)->makePartial();
-
-    $mock->shouldReceive('batch->cancelled')->once()->andReturnFalse();
-
-    $mock->handle();
+    new EnrichAssetTypeGroupCategoryJob()->handle();
 
     // assert
     $assets = Asset::all();
@@ -69,11 +65,7 @@ it('enriches asset if category is present', function () {
     ]));
 
     // run the job
-    $mock = Mockery::mock(EnrichAssetTypeGroupCategoryJob::class)->makePartial();
-
-    $mock->shouldReceive('batch->cancelled')->once()->andReturnFalse();
-
-    $mock->handle();
+    new EnrichAssetTypeGroupCategoryJob()->handle();
 
     // assert
     $assets = Asset::all();
@@ -108,9 +100,7 @@ it('heals a partially enriched asset whose group_id is set but name columns are 
         'category_name_normalized' => null,
     ]));
 
-    $mock = Mockery::mock(EnrichAssetTypeGroupCategoryJob::class)->makePartial();
-    $mock->shouldReceive('batch->cancelled')->once()->andReturnFalse();
-    $mock->handle();
+    new EnrichAssetTypeGroupCategoryJob()->handle();
 
     expect(Asset::first())
         ->type_name_normalized->not()->toBeNull()

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -13,7 +13,6 @@
 
 /** @link https://pestphp.com/docs/underlying-test-case */
 
-use DG\BypassFinals;
 use Faker\Factory;
 use Firebase\JWT\JWT;
 use Mockery\MockInterface;
@@ -23,8 +22,6 @@ use Seatplus\Eveapi\Models\Character\CharacterInfo;
 use Seatplus\Eveapi\Models\RefreshToken;
 use Seatplus\Eveapi\Services\Esi\GetUpToDateRefreshTokenService;
 use Seatplus\Eveapi\Tests\TestCase;
-
-BypassFinals::enable();
 
 uses(TestCase::class)->in('Unit', 'Integration', 'Jobs');
 // uses(\Illuminate\Foundation\Testing\LazilyRefreshDatabase::class)->in('Unit', 'Integration', 'Jobs');

--- a/tests/Unit/Jobs/AllianceInfoJobTest.php
+++ b/tests/Unit/Jobs/AllianceInfoJobTest.php
@@ -5,14 +5,15 @@ use Seatplus\Eveapi\Jobs\Alliances\AllianceInfoJob;
 use Seatplus\Eveapi\Models\Alliance\AllianceInfo;
 
 it('returns early if batch is cancelled', function () {
+    // No expectations on the client: any ESI call means the guard did not return early.
     $esi = Mockery::mock(EsiClient::class);
 
-    $job = mock(AllianceInfoJob::class, function ($mock) {
-        $mock->shouldReceive('batching')->andReturn(true);
-        $mock->shouldReceive('batch->cancelled')->once()->andReturn(true);
-    })->shouldAllowMockingProtectedMethods()->makePartial();
+    [$job, $batch] = new AllianceInfoJob(12345)->withFakeBatch();
+    $batch->cancel();
 
     $job->executeJob($esi);
+
+    expect(AllianceInfo::where('alliance_id', 12345)->count())->toBe(0);
 });
 
 it('checks if the response is cached', function () {

--- a/tests/Unit/Jobs/CharacterAssetsNameJobTest.php
+++ b/tests/Unit/Jobs/CharacterAssetsNameJobTest.php
@@ -5,12 +5,11 @@ use Seatplus\Eveapi\Jobs\Assets\CharacterAssetsNameJob;
 use Seatplus\Eveapi\Models\Assets\Asset;
 
 it('returns early if batch is cancelled', function () {
+    // No expectations on the client: any ESI call means the guard did not return early.
     $esi = Mockery::mock(EsiClient::class);
 
-    $job = mock(CharacterAssetsNameJob::class)->shouldAllowMockingProtectedMethods()->makePartial();
-
-    $job->shouldReceive('batching')->once()->andReturn(true);
-    $job->shouldReceive('batch->cancelled')->once()->andReturn(true);
+    [$job, $batch] = new CharacterAssetsNameJob(testCharacter()->character_id)->withFakeBatch();
+    $batch->cancel();
 
     $job->executeJob($esi);
 

--- a/tests/Unit/Jobs/CharacterContractsJobTest.php
+++ b/tests/Unit/Jobs/CharacterContractsJobTest.php
@@ -2,6 +2,7 @@
 
 use Seatplus\EsiClient\EsiClient;
 use Seatplus\EsiSchema\Responses\CharactersCharacterIdContractsGetItem;
+use Seatplus\Eveapi\Jobs\Contracts\CharacterContractItemsJob;
 use Seatplus\Eveapi\Jobs\Contracts\CharacterContractsJob;
 use Seatplus\Eveapi\Models\Contracts\Contract;
 use Seatplus\Eveapi\Models\RefreshToken;
@@ -48,20 +49,33 @@ it('handles multiple pages and writes all contracts', function () {
 });
 
 it('adds follow up jobs to batch if batching', function () {
-
-    $contract = Contract::factory()->count(2)->make();
+    // Item-exchange contracts with a volume and no locations: each one needs a
+    // CharacterContractItemsJob, none needs a ResolveLocationJob.
+    $contract = fn (int $id) => CharactersCharacterIdContractsGetItem::from((object) [
+        'contract_id' => $id,
+        'acceptor_id' => 0,
+        'assignee_id' => 0,
+        'availability' => 'personal',
+        'date_expired' => now()->addDays(7)->toIso8601String(),
+        'date_issued' => now()->toIso8601String(),
+        'for_corporation' => false,
+        'issuer_corporation_id' => 1000001,
+        'issuer_id' => 123,
+        'status' => 'outstanding',
+        'type' => 'item_exchange',
+        'volume' => 100.0,
+    ]);
 
     $esi = Mockery::mock(EsiClient::class);
-    mockEsiTransport($esi, makeEsiResult(
-        array_map(fn ($c) => (object) $c, $contract->toArray())
-    ));
+    mockEsiTransport($esi, makeEsiResult([$contract(2001), $contract(2002)]));
 
-    $job = mock(CharacterContractsJob::class)->shouldAllowMockingProtectedMethods()->makePartial();
-    $job->characterId = 1;
-    $job->shouldReceive('batching')->once()->andReturnTrue();
-    $job->shouldReceive('batch->add')->once();
+    [$job, $batch] = new CharacterContractsJob(1)->withFakeBatch();
 
     $job->executeJob($esi);
+
+    expect($batch->added)
+        ->toHaveCount(2)
+        ->each->toBeInstanceOf(CharacterContractItemsJob::class);
 
     Queue::assertNothingPushed();
 });

--- a/tests/Unit/Jobs/ContractItemsJobTest.php
+++ b/tests/Unit/Jobs/ContractItemsJobTest.php
@@ -11,14 +11,15 @@ it('has tags', function () {
 });
 
 it('stops executing when batch is cancelled', function () {
+    // No expectations on the client: any ESI call means the guard did not return early.
     $esi = Mockery::mock(EsiClient::class);
 
-    $job = mock(CharacterContractItemsJob::class)->shouldAllowMockingProtectedMethods()->makePartial();
-    $job->contractId = 1;
-    $job->shouldReceive('batching')->once()->andReturn(true);
-    $job->shouldReceive('batch->cancelled')->once()->andReturn(true);
+    [$job, $batch] = new CharacterContractItemsJob(characterId: 1, contractId: 1)->withFakeBatch();
+    $batch->cancel();
 
     $job->executeJob($esi);
+
+    expect(ContractItem::count())->toBe(0);
 });
 
 it('does stop executing if response is cached', function () {

--- a/tests/Unit/Jobs/EnrichAssetTypeGroupCategoryJobTest.php
+++ b/tests/Unit/Jobs/EnrichAssetTypeGroupCategoryJobTest.php
@@ -1,14 +1,26 @@
 <?php
 
+use Illuminate\Support\Facades\Event;
 use Seatplus\Eveapi\Jobs\Hydrate\Maintenance\EnrichAssetTypeGroupCategoryJob;
 use Seatplus\Eveapi\Models\Assets\Asset;
+use Seatplus\Eveapi\Models\Universe\Category;
+use Seatplus\Eveapi\Models\Universe\Group;
+use Seatplus\Eveapi\Models\Universe\Type;
 
 it('returns early if batch is cancelled', function () {
-    $job = mock(EnrichAssetTypeGroupCategoryJob::class, function ($mock) {
-        $mock->shouldReceive('batch->cancelled')->andReturn(true);
-    })->makePartial();
+    // An asset that would otherwise be enriched: the whole type->group->category chain resolves.
+    $category = Event::fakeFor(fn () => Category::factory()->create());
+    $group = Event::fakeFor(fn () => Group::factory()->create(['category_id' => $category->category_id]));
+    $type = Event::fakeFor(fn () => Type::factory()->create(['group_id' => $group->group_id]));
+    $asset = Event::fakeFor(fn () => Asset::factory()->create(['type_id' => $type->type_id]));
+
+    [$job, $batch] = new EnrichAssetTypeGroupCategoryJob()->withFakeBatch();
+    $batch->cancel();
 
     $job->handle();
 
-    expect(Asset::count())->toBe(0);
+    expect($asset->refresh())
+        ->type_name_normalized->toBeNull()
+        ->group_id->toBeNull()
+        ->category_id->toBeNull();
 });

--- a/tests/Unit/Jobs/KillmailJobTest.php
+++ b/tests/Unit/Jobs/KillmailJobTest.php
@@ -3,6 +3,8 @@
 use Illuminate\Support\Facades\Event;
 use Seatplus\EsiClient\EsiClient;
 use Seatplus\Eveapi\Jobs\Killmails\KillmailJob;
+use Seatplus\Eveapi\Jobs\Universe\ResolveUniverseSystemBySystemIdJob;
+use Seatplus\Eveapi\Jobs\Universe\ResolveUniverseTypeByIdJob;
 use Seatplus\Eveapi\Models\Killmails\Killmail;
 use Seatplus\Eveapi\Models\Universe\System;
 
@@ -80,14 +82,15 @@ it('adds to batch', function () {
     $esi = Mockery::mock(EsiClient::class);
     mockEsiTransport($esi, $data);
 
-    $job = mock(KillmailJob::class)->shouldAllowMockingProtectedMethods()->makePartial();
-    $job->killmailId = $killmail->killmail_id;
-    $job->killmailHash = $killmail->killmail_hash;
-
-    $job->shouldReceive('batching')->twice()->andReturn(true);
-    $job->shouldReceive('batch->add')->twice();
+    [$job, $batch] = new KillmailJob($killmail->killmail_id, $killmail->killmail_hash)->withFakeBatch();
 
     $job->executeJob($esi);
+
+    // The unknown solar system and the unknown ship type are resolved through the batch,
+    // not dispatched on their own.
+    expect($batch->added)->toHaveCount(2)
+        ->and($batch->added[0])->toBeInstanceOf(ResolveUniverseSystemBySystemIdJob::class)
+        ->and($batch->added[1])->toBeInstanceOf(ResolveUniverseTypeByIdJob::class);
 
     Queue::assertNothingPushed();
 });

--- a/tests/Unit/Jobs/SdeImportJobTest.php
+++ b/tests/Unit/Jobs/SdeImportJobTest.php
@@ -1,13 +1,19 @@
 <?php
 
+use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Support\Facades\Artisan;
 use Seatplus\Eveapi\Jobs\Seatplus\SdeImportJob;
 
 it('calls seatplus:sde-import artisan command', function () {
-    Artisan::shouldReceive('call')
+    // Swap in a double of the Kernel *contract*: Artisan::shouldReceive() would build it
+    // from the resolved concrete kernel, which Testbench declares final.
+    $kernel = Mockery::mock(ConsoleKernel::class);
+    $kernel->shouldReceive('call')
         ->once()
         ->with('seatplus:sde-import');
+
+    Artisan::swap($kernel);
 
     (new SdeImportJob)->handle();
 });


### PR DESCRIPTION
## Summary
- Fixes #717: `batching() && batch()->cancelled()` could never be true, since `batching()` already returns `false` for a cancelled batch. Replaced with `$this->batch()?->cancelled()` in `AllianceInfoJob`, `CharacterAssetsNameJob`, and `ContractItemsBase`.
- Converts `EnrichAssetTypeGroupCategoryJob::$characterId` from a manually promoted property to constructor-promoted.
- Removes the `dg/bypass-finals` dependency and its `BypassFinals::enable()` call from `tests/Pest.php`, now that partial mocks of final classes are no longer relied on.
- Updates `rector.php` comment to reflect the remaining non-behaviour-preserving rule.
- Modernizes tests across batching/cancellation scenarios to use real fake batches (`withFakeBatch()`) instead of `Mockery::mock(...)->makePartial()` on final job classes, asserting on actual side effects (DB state, batch contents) rather than mock expectations.

## Testing
- Existing Pest suite updated in place; no new test scenarios beyond aligning coverage with the corrected guard logic.