### PR TITLE
feat!: adopt esi-client 5.0 / esi-schema 5.0 (ESI 2026-08-04)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
         "ext-redis": "*",
         "laravel/framework": "^13.0",
         "laravel/horizon": "^5.0",
-        "seatplus/esi-client": "^4.1"
+        "seatplus/esi-client": "^5.0",
+        "seatplus/esi-schema": "^5.0"
     },
     "require-dev": {
         "orchestra/testbench": "^11.0",

--- a/database/migrations/2026_08_18_120000_make_corporation_ceo_and_creator_nullable.php
+++ b/database/migrations/2026_08_18_120000_make_corporation_ceo_and_creator_nullable.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('corporation_infos', function (Blueprint $table) {
+            // ESI 2026-08-04 made ceo_id and creator_id optional on /corporations/{id}/ — a closed or
+            // npc_owned corporation reports neither. Until esi-schema 5.0 the DTO coerced them with
+            // `(int) ($data->ceo_id ?? 0)`, so a NOT NULL column could never be violated; they are now
+            // `?int` and pass NULL straight through.
+            //
+            // Left NOT NULL, the first such corporation aborts the INSERT with SQLSTATE 23502. That
+            // leaves the row absent, and CorporationInfoJob is only ever dispatched for corporations
+            // whose row is missing (CharacterAffiliationJob::followUp() gates on
+            // whereDoesntHave('corporation')), so it is re-dispatched on every affiliation pass and
+            // burns ESI quota indefinitely rather than failing once.
+            $table->bigInteger('ceo_id')->nullable()->change();
+            $table->bigInteger('creator_id')->nullable()->change();
+        });
+    }
+};

--- a/src/EveapiServiceProvider.php
+++ b/src/EveapiServiceProvider.php
@@ -73,13 +73,13 @@ class EveapiServiceProvider extends ServiceProvider
     {
         $version = InstalledVersions::getPrettyVersion('seatplus/eveapi') ?? 'dev';
         $esiConfiguration = EsiConfiguration::getInstance();
-        $esiConfiguration->http_user_agent .= " seatplus/eveapi/{$version} +https://github.com/seatplus/eveapi";
+        $esiConfiguration->httpUserAgent .= " seatplus/eveapi/{$version} +https://github.com/seatplus/eveapi";
 
         // Wire the esi-client logging config so its RotatingFileLogger writes alongside
         // the Laravel logs. Without this it falls back to its relative-path default
         // ('logs/'), which resolves to the process CWD (e.g. /workspace/logs) instead.
-        $esiConfiguration->logfile_location = config('eveapi.config.esi-client.logfile_location');
-        $esiConfiguration->logger_level = config('eveapi.config.esi-client.logger_level');
+        $esiConfiguration->logfileLocation = config('eveapi.config.esi-client.logfile_location');
+        $esiConfiguration->loggerLevel = config('eveapi.config.esi-client.logger_level');
 
         Model::preventLazyLoading(! app()->isProduction());
 

--- a/src/Jobs/Character/CharacterInfoJob.php
+++ b/src/Jobs/Character/CharacterInfoJob.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Seatplus\Eveapi\Jobs\Character;
 
 use Seatplus\EsiClient\EsiClient;
-use Seatplus\EsiSchema\Resources\Character\GetCharactersCharacterId;
+use Seatplus\EsiSchema\Resources\Character\GetCharactersDetail;
 use Seatplus\Eveapi\Jobs\EsiJob;
 use Seatplus\Eveapi\Models\Character\CharacterInfo;
 
 final class CharacterInfoJob extends EsiJob
 {
-    protected const string OPERATION_CLASS = GetCharactersCharacterId::class;
+    protected const string OPERATION_CLASS = GetCharactersDetail::class;
 
     public function __construct(public int $characterId) {}
 
@@ -38,7 +38,7 @@ final class CharacterInfoJob extends EsiJob
             'bloodline_id' => $response->bloodline_id,
             'security_status' => $response->security_status,
             'faction_id' => $response->faction_id,
-            'title' => $response->title,
+            'title' => $response->corporation_title,
         ]);
     }
 }

--- a/src/Jobs/Corporation/CorporationInfoJob.php
+++ b/src/Jobs/Corporation/CorporationInfoJob.php
@@ -35,11 +35,18 @@ final class CorporationInfoJob extends EsiJob
             'member_count' => $response->member_count,
             'ceo_id' => $response->ceo_id,
             'creator_id' => $response->creator_id,
-            'tax_rate' => $response->tax_rate,
+            // ESI replaced the scalar tax_rate with tax_rates{isk,loyalty_point} AND changed the
+            // unit: tax_rates.isk is documented "ISK tax rate (0.0% - 100.0%)" (example: 10), where
+            // the old tax_rate was a 0.0-1.0 fraction. Divide to keep this column's established
+            // meaning, so existing rows and new ones remain directly comparable.
+            'tax_rate' => $response->tax_rates->isk / 100,
             'alliance_id' => $response->alliance_id,
             'date_founded' => $response->date_founded !== null ? carbon($response->date_founded) : null,
             'description' => $response->description,
-            'faction_id' => $response->faction_id,
+            // faction_id was the faction that OWNED an NPC corporation; enlisted_faction_id is the
+            // faction a PLAYER corporation is enlisted with in factional warfare. Same column, a
+            // different concept — renaming it (and clearing the now-wrong values) is tracked separately.
+            'faction_id' => $response->enlisted_faction_id,
             'home_station_id' => $response->home_station_id,
             'shares' => $response->shares,
             'url' => $response->url,

--- a/src/Services/Esi/UpdateRefreshTokenService.php
+++ b/src/Services/Esi/UpdateRefreshTokenService.php
@@ -26,9 +26,9 @@ class UpdateRefreshTokenService
     public function update(RefreshToken $refreshToken): RefreshToken
     {
         $authentication = new EsiAuthentication(
-            access_token: $refreshToken->getRawOriginal('token'),
-            refresh_token: $refreshToken->refresh_token,
-            client_id: config('eveapi.config.esi.eve_client_id'),
+            accessToken: $refreshToken->getRawOriginal('token'),
+            refreshToken: $refreshToken->refresh_token,
+            clientId: config('eveapi.config.esi.eve_client_id'),
             secret: config('eveapi.config.esi.eve_client_secret'),
         );
 

--- a/tests/Jobs/Character/CharacterInfoTest.php
+++ b/tests/Jobs/Character/CharacterInfoTest.php
@@ -29,3 +29,26 @@ test('retrieve test', function () {
 
     expect(CharacterInfo::where('name', $mockData['name'])->exists())->toBeTrue();
 });
+
+test('it stores the corporation title, not the cosmetic title id', function () {
+    Bus::fake();
+
+    $esi = Mockery::mock(EsiClient::class);
+    mockEsiTransport($esi, makeEsiResult((object) [
+        'name' => 'Some Character',
+        'birthday' => '2015-03-24T11:37:00Z',
+        'gender' => 'male',
+        'race_id' => 1,
+        'bloodline_id' => 3,
+        'corporation_id' => 98000001,
+        'achievement_score' => 1234,
+        'corporation_title' => 'Chief Executive Officer',
+        'character_title_id' => '0199a1b2-c3d4-7890-abcd-ef0123456789',
+    ]));
+
+    $job = new CharacterInfoJob(90000001);
+    $job->executeJob($esi);
+
+    expect(CharacterInfo::find(90000001))
+        ->title->toBe('Chief Executive Officer');
+});

--- a/tests/Jobs/Corporation/CorporationInfoJobTest.php
+++ b/tests/Jobs/Corporation/CorporationInfoJobTest.php
@@ -36,3 +36,52 @@ test('returns early if cached', function () {
 
     expect(CorporationInfo::where('corporation_id', $this->corporation_id)->count())->toBe(0);
 });
+
+test('it converts the isk tax rate percentage to a fraction and stores the enlisted faction', function () {
+    Bus::fake();
+
+    $esi = Mockery::mock(EsiClient::class);
+    mockEsiTransport($esi, makeEsiResult((object) [
+        'name' => 'Some Corporation',
+        'ticker' => 'TICK',
+        'member_count' => 42,
+        'ceo_id' => 90000001,
+        'creator_id' => 90000002,
+        'home_station_id' => 60003760,
+        'shares' => 1000,
+        'tax_rates' => (object) ['isk' => 10.0, 'loyalty_point' => 5.6],
+        'enlisted_faction_id' => 500001,
+    ]));
+
+    $job = new CorporationInfoJob($this->corporation_id);
+    $job->executeJob($esi);
+
+    expect(CorporationInfo::find($this->corporation_id))
+        // ESI sends 10.0 meaning 10%; the column holds the historical 0.0-1.0 fraction.
+        ->tax_rate->toEqual(0.1)
+        ->faction_id->toEqual(500001);
+});
+
+test('it stores a corporation that has no ceo or creator', function () {
+    Bus::fake();
+
+    // ESI 2026-08-04 made ceo_id/creator_id optional — a closed or npc_owned corporation reports
+    // neither. Both columns were NOT NULL, so this payload used to abort with SQLSTATE 23502.
+    $esi = Mockery::mock(EsiClient::class);
+    mockEsiTransport($esi, makeEsiResult((object) [
+        'name' => 'Closed Corporation',
+        'ticker' => 'GONE',
+        'member_count' => 0,
+        'tax_rates' => (object) ['isk' => 0.0, 'loyalty_point' => 0.0],
+        'state' => 'closed',
+        'type' => 'npc_owned',
+    ]));
+
+    $job = new CorporationInfoJob($this->corporation_id);
+    $job->executeJob($esi);
+
+    expect(CorporationInfo::find($this->corporation_id))
+        ->ceo_id->toBeNull()
+        ->creator_id->toBeNull()
+        ->name->toBe('Closed Corporation');
+});

--- a/tests/Unit/EveapiServiceProviderTest.php
+++ b/tests/Unit/EveapiServiceProviderTest.php
@@ -20,7 +20,7 @@ it('sets EVE-compliant user agent on boot', function () {
     $serviceProvider = new EveapiServiceProvider(app());
     $serviceProvider->boot();
 
-    $userAgent = EsiConfiguration::getInstance()->http_user_agent;
+    $userAgent = EsiConfiguration::getInstance()->httpUserAgent;
 
     expect($userAgent)
         ->toContain('seatplus/eveapi/')
@@ -38,11 +38,10 @@ it('leaves the esi-client connection + compatibility date untouched', function (
     // eveapi must not override esi-client's connection or versioning config — the base
     // URL is fixed and the compatibility date is pinned to the installed esi-schema.
     expect(EsiConfiguration::getInstance())
-        ->datasource->toBe($defaults->datasource)
-        ->esi_host->toBe($defaults->esi_host)
-        ->esi_scheme->toBe($defaults->esi_scheme)
-        ->esi_port->toBe($defaults->esi_port)
-        ->compatibility_date->toBe($defaults->compatibility_date);
+        ->esiHost->toBe($defaults->esiHost)
+        ->esiScheme->toBe($defaults->esiScheme)
+        ->esiPort->toBe($defaults->esiPort)
+        ->compatibilityDate->toBe($defaults->compatibilityDate);
 });
 
 it('tests horizon auth with user', function () {

--- a/tests/Unit/Services/Esi/RecordingEsiClientTest.php
+++ b/tests/Unit/Services/Esi/RecordingEsiClientTest.php
@@ -12,9 +12,9 @@ beforeEach(function () {
 it('records rate limit remaining in redis after invoke', function () {
     $esiResponse = new EsiResponse(
         raw: json_encode([]),
-        raw_headers: ['X-Ratelimit-Remaining' => '100'],
+        rawHeaders: ['X-Ratelimit-Remaining' => '100'],
         expires: 'now',
-        response_code: 200,
+        responseCode: 200,
     );
 
     $fetcher = Mockery::mock(GuzzleFetcher::class);
@@ -31,9 +31,9 @@ it('records rate limit remaining in redis after invoke', function () {
 it('records rate limit with character context', function () {
     $esiResponse = new EsiResponse(
         raw: json_encode([]),
-        raw_headers: ['X-Ratelimit-Remaining' => '42'],
+        rawHeaders: ['X-Ratelimit-Remaining' => '42'],
         expires: 'now',
-        response_code: 200,
+        responseCode: 200,
     );
 
     $fetcher = Mockery::mock(GuzzleFetcher::class);
@@ -50,12 +50,12 @@ it('records rate limit with character context', function () {
 it('records error limit in redis after invoke', function () {
     $esiResponse = new EsiResponse(
         raw: json_encode([]),
-        raw_headers: [
+        rawHeaders: [
             'X-Esi-Error-Limit-Remain' => '50',
             'X-Esi-Error-Limit-Reset' => '30',
         ],
         expires: 'now',
-        response_code: 200,
+        responseCode: 200,
     );
 
     $fetcher = Mockery::mock(GuzzleFetcher::class);
@@ -71,9 +71,9 @@ it('records error limit in redis after invoke', function () {
 it('skips rate limit recording when rateLimitRemaining is null', function () {
     $esiResponse = new EsiResponse(
         raw: json_encode([]),
-        raw_headers: [],
+        rawHeaders: [],
         expires: 'now',
-        response_code: 200,
+        responseCode: 200,
     );
 
     $fetcher = Mockery::mock(GuzzleFetcher::class);
@@ -88,9 +88,9 @@ it('skips rate limit recording when rateLimitRemaining is null', function () {
 it('skips error limit recording when errorLimitRemaining is null', function () {
     $esiResponse = new EsiResponse(
         raw: json_encode([]),
-        raw_headers: ['X-Ratelimit-Remaining' => '80'],
+        rawHeaders: ['X-Ratelimit-Remaining' => '80'],
         expires: 'now',
-        response_code: 200,
+        responseCode: 200,
     );
 
     $fetcher = Mockery::mock(GuzzleFetcher::class);


### PR DESCRIPTION
Closes #714. Closes #721.

`esi-client 5.0.0` requires `esi-schema ^4.1 || ^5.0`, so this bump pulls **esi-schema 5.0.0 (ESI compatibility date 2026-08-04)** and crosses four CCP compatibility dates in one step.

## Blast radius is bounded, and verified

I diffed **all 218** old response DTOs and **all 37** operation classes this package references against the installed 5.0.0 set, ignoring generator docblocks. Only **`CharactersDetail`** and **`CorporationsDetail`** changed in a way that reaches eveapi. The three removed DTOs (`SovereigntyMapGetItem`, `SovereigntyStructuresGetItem`, `StatusGet`) are unreferenced, and the generated `'get'`/`'post'` → `'GET'`/`'POST'` literal change is a no-op because `GuzzleFetcher::httpRequest()` upper-cases the verb.

So a reviewer does not have to re-derive the surface: it is these two DTOs, nothing else.

## esi-schema changes (#714)

- `GetCharactersCharacterId` → `GetCharactersDetail`; signature unchanged.
- **`CharactersDetail::$title` removed.** The successor is `$corporation_title` — the spec calls it *"Character's corporation title"*. It is **not** `$character_title_id`, which the spec documents as the equipped **cosmetic** title and types as a UUID.
- **`CorporationsDetail::$tax_rate` → `$tax_rates{isk,loyalty_point}`, and the unit changed with it.** The spec documents `tax_rates.isk` as *"ISK tax rate (0.0% - 100.0%)"* with example `10`, where the old `tax_rate` was a 0.0–1.0 fraction (this repo's own factory used `randomFloat(2, 0, 1)`). The value is divided by 100 so the column keeps its established meaning and old and new rows stay directly comparable. Storing ESI's percentage verbatim would have been a silent 100× change to a column with no consumer to notice.
- **`CorporationsDetail::$faction_id` → `$enlisted_faction_id`** — a *redefinition*, not a rename. The old field identified an NPC corporation's owning faction; the new one is a player corporation's factional-warfare enlistment (*"Player-owned corporation only"*). The column name is kept here; renaming it and clearing the now-wrong values needs its own migration (see below).

## esi-client changes (#721)

- `EsiConfiguration` properties are camelCase (`httpUserAgent`, `logfileLocation`, `loggerLevel`). These writes **did not throw** under the old snake_case names — they created dynamic properties while the client read the real ones, so the ESI user-agent suffix and the log configuration were silently never applied. This was the more dangerous half of #721.
- `EsiAuthentication` and `EsiResponse` constructor arguments are camelCase.
- `EsiConfiguration::$datasource` was removed entirely. Contrary to #721's note that "eveapi does not touch the four properties esi-client removed", eveapi did: `EveapiServiceProviderTest` asserted on `$datasource`.
- `require.php` was already `^8.5`, so item 3 of #714 was a no-op.

## Two fixes beyond the two issues

**Declare `seatplus/esi-schema`.** 44 files under `src/` name esi-schema classes directly (every `OPERATION_CLASS`, plus `ScopeAccessDeniedException`), but the constraint was only inherited transitively through esi-client, which permits `^4.1 || ^5.0`. Declared explicitly so a resolution this package never sanctioned cannot happen — particularly relevant because `composer.lock` is gitignored and CI runs `composer update`.

**Make `corporation_infos.ceo_id` / `.creator_id` nullable.** ESI made both optional; a closed or `npc_owned` corporation reports neither. Until esi-schema 5.0 the DTO coerced them with `(int) ($data->ceo_id ?? 0)`, so the `NOT NULL` columns could never be violated — they are now `?int` and pass NULL straight through. Left as-is, the first such corporation aborts the INSERT with `SQLSTATE 23502`; and because `CorporationInfoJob` is dispatched from exactly one place, gated on `whereDoesntHave('corporation')`, the row stays absent and the job is re-dispatched on every affiliation pass indefinitely rather than failing once.

## On the tests

The existing `retrieve test` cases build their fake ESI payload from an **Eloquent factory** — i.e. from *database column names* rather than *ESI wire field names*. Combined with esi-schema's `?? default` hydration, that makes them structurally blind to exactly this class of change: after the rename, this suite stayed green while `CorporationInfoJob` wrote `tax_rate = 0.0` for every corporation, because the test only asserted that a row with the right `name` existed.

This PR adds wire-shaped tests that assert the *mapped values*, and I verified each one fails against the wrong mapping (`character_title_id` instead of `corporation_title`; `loyalty_point` instead of `isk`; the raw percentage instead of the fraction).

Closing that hole properly — a validating test seam that rejects a payload key which is not a real wire property — is deliberately **not** in this PR; it turns roughly 45 existing test cases red and needs to land incrementally behind a ratchet. Follow-up issues to be filed:

- a reflection-based wire-contract seam + wire-payload builder, replacing the factory-as-payload idiom
- rename `faction_id` → `enlisted_faction_id` and `title` → `corporation_title`; persist the new `achievement_score`, `character_title_id` and `loyalty_point` fields; add `type`/`state` so `enlisted_faction_id` is interpretable
- correct the documented retry model: `$maxExceptions` and `EsiJob::backoff()` are **inert**, because `ThrottlesExceptionsWithRedis` is registered with no `->when()` callback and therefore releases every escaping exception instead of rethrowing it. Retries are bounded solely by `retryUntil()` at a flat 300s. `README.md`, `ARCHITECTURE.md` Decision 4 and `EsiJob`'s own docblocks all describe something else
- route permanently-unrecoverable failures (missing OAuth scope, 4xx) to `fail()` instead of retrying for 30 minutes against the global 80/300s circuit breaker
- `CharacterAffiliationJob` bisects a failing batch on any `RequestFailedException`, including transient 5xx, exhausting the install's global ESI error budget; its `invalid_character_ids` cache write also has a TTL of 24 *minutes* where 24 hours was intended, a lost-update race, and no consumer
- `MailHeaderJob` stores `now()` for a mail with no timestamp (`carbon('')` is `now()`)
- delete `.github/workflows/update-changelog.yml`, which force-commits to the default branch on release and so moves `5.x` off the commit that was just tested and tagged; hand-write `CHANGELOG.md`, which is still headed *"All notable changes to `discord`"*
- `#713` is now stale — esi-client 5.0 contains Guzzle behind its own exception hierarchy, so the `@throws GuzzleException` docblock can go

## Verification

`composer test` is green: Pint, PHPStan (no errors), type coverage 100.0%, **611 passed** (1180 assertions). The nullable migration is confirmed applied against the live schema, and the new mapping tests were each mutation-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
